### PR TITLE
Some minor refactoring.

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -127,9 +127,9 @@ register_emscripten_toolchains()
 http_archive(
     name = "iftb",
     build_file = "//third_party:iftb.BUILD",
-    sha256 = "85e3be40a51db22c7a908db0f74a8a93451e1561d43695e9394d8719a50f0eaa",
-    strip_prefix = "binned-ift-reference-2235f63cd51598c8191487e5c196634910a514bf",
-    urls = ["https://github.com/garretrieger/binned-ift-reference/archive/2235f63cd51598c8191487e5c196634910a514bf.zip"],
+    sha256 = "a24060e6a0c9c7c7f601ec076564f4198ce3a38328f92cc9a32d9d1a7828b7b7",
+    strip_prefix = "binned-ift-reference-b2f144293ae0f8f3311c6a31bace15ac11ba39ea",
+    urls = ["https://github.com/garretrieger/binned-ift-reference/archive/b2f144293ae0f8f3311c6a31bace15ac11ba39ea.zip"],
 )
 
 http_archive(

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -47,14 +47,6 @@ class Encoder {
   const std::string& UrlTemplate() const { return url_template_; }
 
   /*
-   * Configures the whether or not the encoder will retain gids when in mixed
-   * mode. Defaults to true.
-   */
-  void SetMixedModeRetainGids(bool value) {
-    this->retain_gids_in_mixed_mode_ = value;
-  }
-
-  /*
    * Configures how many graph levels can be reached from each node in the
    * encoded graph. Defaults to 1.
    */
@@ -233,7 +225,6 @@ class Encoder {
   std::string url_template_ = "patch$5$4$3$2$1.br";
   uint32_t id_[4] = {0, 0, 0, 0};
   hb_face_t* face_ = nullptr;
-  bool retain_gids_in_mixed_mode_ = true;
   absl::btree_map<uint32_t, SubsetDefinition> existing_iftb_patches_;
   absl::flat_hash_map<uint32_t,
                       absl::flat_hash_map<hb_tag_t, absl::btree_set<uint32_t>>>

--- a/ift/iftb_binary_patch.cc
+++ b/ift/iftb_binary_patch.cc
@@ -124,11 +124,6 @@ Status IftbBinaryPatch::Patch(const FontData& font_base,
   ift_table->GetId(id);
   merger.setID(id);
 
-  if (!ift_table->GetGlyphMap().empty()) {
-    merger.addOldToNewGidMap(ift_table->GetGlyphMap().begin(),
-                             ift_table->GetGlyphMap().end());
-  }
-
   flat_hash_set<uint32_t> patch_indices;
   for (const FontData& patch : patches) {
     auto idx = get_chunk_index(patch);

--- a/ift/iftb_binary_patch_test.cc
+++ b/ift/iftb_binary_patch_test.cc
@@ -41,35 +41,19 @@ class IftbBinaryPatchTest : public ::testing::Test {
     return FontData(make_hb_blob(hb_blob_create_from_file(filename)));
   }
 
-  FontData Subset(const FontData& font, flat_hash_set<uint32_t> gids,
-                  bool retain_gids = true) {
+  FontData Subset(const FontData& font, flat_hash_set<uint32_t> gids) {
     hb_face_unique_ptr face = font.face();
     hb_subset_input_t* input = hb_subset_input_create_or_fail();
     for (uint32_t gid : gids) {
       hb_set_add(hb_subset_input_glyph_set(input), gid);
     }
-    hb_subset_input_set_flags(input, HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED |
-                                         HB_SUBSET_FLAGS_IFTB_REQUIREMENTS |
-                                         HB_SUBSET_FLAGS_NOTDEF_OUTLINE);
-
-    if (retain_gids) {
-      hb_subset_input_set_flags(input, hb_subset_input_get_flags(input) |
-                                           HB_SUBSET_FLAGS_RETAIN_GIDS);
-    }
+    hb_subset_input_set_flags(
+        input,
+        HB_SUBSET_FLAGS_RETAIN_GIDS | HB_SUBSET_FLAGS_PASSTHROUGH_UNRECOGNIZED |
+            HB_SUBSET_FLAGS_IFTB_REQUIREMENTS | HB_SUBSET_FLAGS_NOTDEF_OUTLINE);
 
     hb_subset_plan_t* plan = hb_subset_plan_create_or_fail(face.get(), input);
     hb_subset_input_destroy(input);
-
-    auto table = IFTTable::FromFont(font);
-    if (!retain_gids) {
-      // Insert a glyph map from the subsetter into the IFT table.
-      hb_map_t* gid_map = hb_subset_plan_old_to_new_glyph_mapping(plan);
-      int index = -1;
-      uint32_t old_gid = 0, new_gid = 0;
-      while (hb_map_next(gid_map, &index, &old_gid, &new_gid)) {
-        table->GetGlyphMap()[old_gid] = new_gid;
-      }
-    }
 
     hb_face_unique_ptr subset =
         make_hb_face(hb_subset_plan_execute_or_fail(plan));
@@ -79,14 +63,8 @@ class IftbBinaryPatchTest : public ::testing::Test {
     hb_blob_unique_ptr subset_data =
         make_hb_blob(hb_face_reference_blob(subset.get()));
 
-    if (retain_gids) {
-      FontData result(std::move(subset_data));
-      return result;
-    }
-
-    auto subset_face = make_hb_face(hb_face_create(subset_data.get(), 0));
-    auto result_with_table = table->AddToFont(subset_face.get());
-    return std::move(*result_with_table);
+    FontData result(std::move(subset_data));
+    return result;
   }
 
   FontData font;
@@ -195,43 +173,6 @@ TEST_F(IftbBinaryPatchTest, SinglePatchOnSubset) {
   ASSERT_TRUE(gids.ok()) << gids.status();
 
   FontData subset = Subset(font, *gids);
-  ASSERT_GT(subset.size(), 500);
-
-  FontData result;
-  auto s = patcher.Patch(subset, chunk2, &result);
-  ASSERT_TRUE(s.ok()) << s;
-  ASSERT_GT(result.size(), subset.size());
-  auto sc = glyph_size(result, 0xa5);
-  ASSERT_TRUE(sc.ok()) << sc.status();
-
-  auto ift_table = IFTTable::FromFont(result);
-  ASSERT_TRUE(ift_table.ok()) << ift_table.status();
-
-  for (const auto& e : ift_table->GetPatchMap().GetEntries()) {
-    uint32_t patch_index = e.patch_index;
-    for (uint32_t codepoint : e.coverage.codepoints) {
-      ASSERT_NE(patch_index, 2);
-      // spot check a couple of codepoints that should be removed.
-      ASSERT_NE(codepoint, 0xa5);
-      ASSERT_NE(codepoint, 0x30d4);
-    }
-  }
-
-  sc = glyph_size(result, 0xab);
-  ASSERT_TRUE(absl::IsNotFound(sc.status())) << sc.status();
-  sc = glyph_size(result, 0x2e8d);
-  ASSERT_TRUE(absl::IsNotFound(sc.status())) << sc.status();
-
-  ASSERT_EQ(*glyph_size(result, 0xa5), *glyph_size(original, 0xa5));
-  ASSERT_EQ(*glyph_size(result, 0x30d4), *glyph_size(original, 0x30d4));
-}
-
-TEST_F(IftbBinaryPatchTest, SinglePatchOnSubset_DontRetainGids) {
-  auto gids = IftbBinaryPatch::GidsInPatch(chunk2);
-  gids->insert(0);
-  ASSERT_TRUE(gids.ok()) << gids.status();
-
-  FontData subset = Subset(font, *gids, false);
   ASSERT_GT(subset.size(), 500);
 
   FontData result;

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -474,8 +474,7 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
   static constexpr uint32_t chunk5_gid = 989;
   static constexpr uint32_t chunk6_gid = 932;
   ASSERT_FALSE(FontHelper::GlyfData(face.get(), chunk2_gid)->empty());
-  ASSERT_TRUE(
-      absl::IsNotFound(FontHelper::GlyfData(face.get(), chunk5_gid).status()));
+  ASSERT_TRUE(FontHelper::GlyfData(face.get(), chunk5_gid)->empty());
 
   sc = client->AddDesiredFeatures({kVrt3});
   sc.Update(AddPatchesIftb(*client, encoder, feature_test_patches_));
@@ -576,10 +575,11 @@ TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
 
   // ### Checks ###
 
-  // Loca len chaning is supported so we should see gid count
-  // increase or remain the same at each step.
-  ASSERT_LE(gid_count_1, gid_count_2);
-  ASSERT_LE(gid_count_2, gid_count_3);
+  // To avoid loca len change the encoder ensures that a full len
+  // loca exists in the base font. So gid count should be consistent
+  // at each point
+  ASSERT_EQ(gid_count_1, gid_count_2);
+  ASSERT_EQ(gid_count_2, gid_count_3);
 
   codepoints = ToCodepointsSet(client->GetFontData());
   ASSERT_TRUE(codepoints.contains(chunk0_cp));

--- a/ift/proto/IFT.proto
+++ b/ift/proto/IFT.proto
@@ -28,9 +28,7 @@ message IFT {
 
   repeated SubsetMapping subset_mapping = 4;
   
-  GlyphMapping glyph_map = 5;
-
-  // next = 6
+  // next = 5
 }
 
 // Maps from a subset description to a patch
@@ -59,12 +57,6 @@ message SubsetMapping {
   PatchEncoding patch_encoding = 4;
 
   // next = 6
-}
-
-message GlyphMapping {
-  map<uint32, uint32> old_to_new = 1;
-
-  // next = 2
 }
 
 // Format for a table-wise shared brotli patch.

--- a/ift/proto/ift_table.h
+++ b/ift/proto/ift_table.h
@@ -51,11 +51,6 @@ class IFTTable {
   PatchMap& GetPatchMap() { return patch_map_; }
   bool HasExtensionEntries() const;
 
-  const absl::flat_hash_map<uint32_t, uint32_t>& GetGlyphMap() const {
-    return glyph_map_;
-  }
-  absl::flat_hash_map<uint32_t, uint32_t>& GetGlyphMap() { return glyph_map_; }
-
   const std::string& GetUrlTemplate() const { return url_template_; }
   void SetUrlTemplate(absl::string_view value) { url_template_ = value; }
   absl::Status SetId(absl::Span<const uint32_t> id) {
@@ -94,7 +89,6 @@ class IFTTable {
   std::string url_template_;
   uint32_t id_[4];
   PatchMap patch_map_;
-  absl::flat_hash_map<uint32_t, uint32_t> glyph_map_;
 };
 
 }  // namespace ift::proto

--- a/ift/proto/ift_table_test.cc
+++ b/ift/proto/ift_table_test.cc
@@ -203,50 +203,6 @@ TEST_F(IFTTableTest, RoundTrip_WithExtension) {
   ASSERT_EQ(expected, table_from_font->GetPatchMap());
 }
 
-TEST_F(IFTTableTest, CreateWithGlyphMap) {
-  IFTTable table;
-  table.GetGlyphMap()[123] = 456;
-
-  IFT main = table.CreateMainTable();
-  IFT ext = table.CreateExtensionTable();
-
-  ASSERT_EQ(main.glyph_map().old_to_new().at(123), 456);
-  ASSERT_TRUE(ext.glyph_map().old_to_new().empty());
-
-  table.GetPatchMap().AddEntry({30}, 3, SHARED_BROTLI_ENCODING, true);
-
-  main = table.CreateMainTable();
-  ext = table.CreateExtensionTable();
-
-  ASSERT_TRUE(main.glyph_map().old_to_new().empty());
-  ASSERT_EQ(ext.glyph_map().old_to_new().at(123), 456);
-}
-
-TEST_F(IFTTableTest, RoundTrip_WithExtension_AndGlyphMap) {
-  IFTTable table;
-  table.GetPatchMap().AddEntry({10}, 1, SHARED_BROTLI_ENCODING);
-  table.GetPatchMap().AddEntry({20}, 2, SHARED_BROTLI_ENCODING);
-  table.GetPatchMap().AddEntry({30}, 3, SHARED_BROTLI_ENCODING, true);
-  table.GetPatchMap().AddEntry({40}, 4, SHARED_BROTLI_ENCODING, true);
-  table.GetGlyphMap()[123] = 456;
-
-  auto font = table.AddToFont(roboto_ab.get());
-  ASSERT_TRUE(font.ok()) << font.status();
-
-  auto table_from_font = IFTTable::FromFont(*font);
-  ASSERT_TRUE(table_from_font.ok()) << table_from_font.status();
-
-  PatchMap expected = {
-      {{10}, 1, SHARED_BROTLI_ENCODING},
-      {{20}, 2, SHARED_BROTLI_ENCODING},
-      {{30}, 3, SHARED_BROTLI_ENCODING, true},
-      {{40}, 4, SHARED_BROTLI_ENCODING, true},
-  };
-  ASSERT_EQ(expected, table_from_font->GetPatchMap());
-  ASSERT_EQ(table_from_font->GetGlyphMap().size(), 1);
-  ASSERT_EQ(table_from_font->GetGlyphMap().at(123), 456);
-}
-
 TEST_F(IFTTableTest, HasExtensionEntries) {
   IFTTable table;
   table.GetPatchMap().AddEntry({10}, 1, SHARED_BROTLI_ENCODING);


### PR DESCRIPTION
Notably updates IFTTable to have a member AddToFont() method so that when constructing a family with an IFT table you don't have to work with the IFT protos.