### PR TITLE
Add a utility that can convert from an IFTB info dump into an encoder config

### DIFF
--- a/util/BUILD
+++ b/util/BUILD
@@ -26,3 +26,51 @@ cc_binary(
         "@harfbuzz",
     ],
 )
+
+cc_library(
+    name = "convert_iftb",
+    srcs = [
+        "convert_iftb.cc",
+        "convert_iftb.h",
+    ],
+    deps = [
+        "//common",
+        ":encoder_config_cc_proto",
+        "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/flags:parse",
+    ],
+)
+
+cc_test(
+    name = "convert_iftb_test",
+    size = "small",
+    srcs = [
+        "convert_iftb_test.cc",
+    ],
+    data = [
+        "testdata/convert-iftb-sample.txt",
+    ],
+    deps = [
+        ":convert_iftb",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_binary(
+    name = "iftb2config",
+    srcs = [
+        "iftb2config.cc",
+    ],
+    deps = [
+        ":convert_iftb",
+        ":encoder_config_cc_proto",
+        "@abseil-cpp//absl/container:flat_hash_set",
+        "@abseil-cpp//absl/flags:flag",
+        "@abseil-cpp//absl/flags:parse",
+        "@abseil-cpp//absl/status:statusor",
+        "@abseil-cpp//absl/strings",
+    ],
+)

--- a/util/convert_iftb.cc
+++ b/util/convert_iftb.cc
@@ -1,0 +1,129 @@
+#include "util/convert_iftb.h"
+
+#include <cstdint>
+#include <cstdlib>
+#include <string>
+
+#include "absl/container/btree_map.h"
+#include "absl/container/btree_set.h"
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "util/encoder_config.pb.h"
+
+using absl::btree_map;
+using absl::btree_set;
+using absl::StatusOr;
+using absl::string_view;
+
+namespace util {
+
+string_view next_token(string_view line, string_view delim, std::string& out) {
+  if (line.empty()) {
+    out = "";
+    return line;
+  }
+
+  size_t index = line.find(delim);
+  if (index == std::string::npos) {
+    out = line;
+    return string_view();
+  }
+
+  out = line.substr(0, index);
+  return line.substr(index + delim.size());
+}
+
+btree_set<std::uint32_t> load_chunk_set(string_view line) {
+  btree_set<std::uint32_t> result;
+
+  std::string next;
+  while (!line.empty()) {
+    line = next_token(line, ", ", next);
+    result.insert(std::stoi(next));
+  }
+
+  return result;
+}
+
+btree_map<std::uint32_t, uint32_t> load_gid_map(string_view line) {
+  btree_map<std::uint32_t, uint32_t> result;
+
+  std::string next;
+  while (!line.empty()) {
+    line = next_token(line, ", ", next);
+
+    std::string gid;
+    std::string chunk;
+    next = next_token(next, ":", gid);
+    next = next_token(next, ":", chunk);
+
+    result[std::stoi(gid)] = std::stoi(chunk);
+  }
+
+  return result;
+}
+
+StatusOr<EncoderConfig> create_config(
+    const btree_map<std::uint32_t, uint32_t>& gid_map,
+    const btree_set<uint32_t>& loaded_chunks) {
+  EncoderConfig config;
+  // Populate segments in the config. chunks are directly analagous to segments.
+  auto segments = config.mutable_glyph_segments();
+  for (const auto [gid, chunk] : gid_map) {
+    Glyphs glyphs;
+    auto [it, added] = segments->insert(std::pair(chunk, glyphs));
+    it->second.add_values(gid);
+  }
+
+  // Set up the initial subset, which is specified by loaded_chunks
+  for (auto chunk : loaded_chunks) {
+    config.mutable_initial_glyph_patches()->add_values(chunk);
+  }
+
+  // Add all non-initial segments to a single non-glyph segment
+  // TODO(garretrieger): flag to configure having more than one table keyed
+  //                     segment.
+  btree_set<uint32_t> non_initial_segments;
+  for (const auto [gid, chunk] : gid_map) {
+    if (loaded_chunks.contains(chunk)) {
+      continue;
+    }
+    non_initial_segments.insert(chunk);
+  }
+
+  GlyphPatches* patches = config.add_glyph_patch_groupings();
+  for (auto chunk : non_initial_segments) {
+    patches->add_values(chunk);
+  }
+
+  return config;
+}
+
+StatusOr<EncoderConfig> convert_iftb(string_view iftb_dump) {
+  btree_map<std::uint32_t, uint32_t> gid_map;
+  btree_set<uint32_t> loaded_chunks;
+
+  while (!iftb_dump.empty()) {
+    std::string line;
+    iftb_dump = next_token(iftb_dump, "\n", line);
+
+    std::string field;
+    line = next_token(line, ": ", field);
+
+    fprintf(stderr, ">> %s\n", field.c_str());
+
+    if (field == "gidMap") {
+      gid_map = load_gid_map(line);
+      continue;
+    }
+
+    if (field == "chunkSet indexes") {
+      loaded_chunks = load_chunk_set(line);
+      continue;
+    }
+  }
+
+  return create_config(gid_map, loaded_chunks);
+}
+
+}  // namespace util

--- a/util/convert_iftb.h
+++ b/util/convert_iftb.h
@@ -1,0 +1,14 @@
+#ifndef UTIL_CONVERT_IFTB_H_
+#define UTIL_CONVERT_IFTB_H_
+
+#include "absl/status/statusor.h"
+#include "absl/strings/string_view.h"
+#include "util/encoder_config.pb.h"
+
+namespace util {
+
+absl::StatusOr<EncoderConfig> convert_iftb(absl::string_view iftb_dump);
+
+}
+
+#endif  // UTIL_CONVERT_IFTB_H_

--- a/util/convert_iftb_test.cc
+++ b/util/convert_iftb_test.cc
@@ -1,0 +1,79 @@
+#include "util/convert_iftb.h"
+
+#include <google/protobuf/text_format.h>
+
+#include <string>
+
+#include "absl/container/flat_hash_set.h"
+#include "common/font_data.h"
+#include "common/sparse_bit_set.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+
+using testing::Eq;
+
+using absl::flat_hash_set;
+using common::FontData;
+using common::hb_blob_unique_ptr;
+using common::make_hb_blob;
+using ::common::SparseBitSet;
+using google::protobuf::TextFormat;
+
+namespace util {
+
+class ConvertIftbTest : public ::testing::Test {
+ protected:
+  ConvertIftbTest() {
+    hb_blob_unique_ptr blob =
+        common::make_hb_blob(hb_blob_create_from_file_or_fail(
+            "util/testdata/convert-iftb-sample.txt"));
+    assert(blob.get());
+
+    FontData blob_data(blob.get());
+    sample_input = blob_data.string();
+  }
+
+  std::string sample_input;
+};
+
+TEST_F(ConvertIftbTest, BasicConversion) {
+  auto config = convert_iftb(sample_input);
+  ASSERT_TRUE(config.ok()) << config.status();
+
+  std::string expected_config =
+      "glyph_segments {\n"
+      "  key: 0\n"
+      "  value {\n"
+      "    values: 0\n"
+      "    values: 5\n"
+      "  }\n"
+      "}\n"
+      "glyph_segments {\n"
+      "  key: 1\n"
+      "  value {\n"
+      "    values: 1\n"
+      "    values: 2\n"
+      "    values: 3\n"
+      "  }\n"
+      "}\n"
+      "glyph_segments {\n"
+      "  key: 2\n"
+      "  value {\n"
+      "    values: 4\n"
+      "    values: 6\n"
+      "  }\n"
+      "}\n"
+      "initial_glyph_patches {\n"
+      "  values: 0\n"
+      "}\n"
+      "glyph_patch_groupings {\n"
+      "  values: 1\n"
+      "  values: 2\n"
+      "}\n";
+  std::string config_string;
+  TextFormat::PrintToString(*config, &config_string);
+
+  ASSERT_EQ(config_string, expected_config);
+}
+
+}  // namespace util

--- a/util/font2ift.cc
+++ b/util/font2ift.cc
@@ -144,7 +144,8 @@ btree_set<hb_tag_t> tag_values(const T& proto_set) {
 StatusOr<Encoder::design_space_t> to_design_space(const DesignSpace& proto) {
   Encoder::design_space_t result;
   for (const auto& [tag_str, range_proto] : proto.ranges()) {
-    auto range = TRY(common::AxisRange::Range(range_proto.start(), range_proto.end()));
+    auto range =
+        TRY(common::AxisRange::Range(range_proto.start(), range_proto.end()));
     result[FontHelper::ToTag(tag_str)] = range;
   }
   return result;
@@ -181,11 +182,11 @@ Status ConfigureEncoder(EncoderConfig config, Encoder& encoder) {
     base_subset.feature_tags = init_features;
     base_subset.design_space = init_design_space;
     TRYV(encoder.SetBaseSubsetFromDef(base_subset));
-  } else if (init_codepoints.empty() && init_features.empty() && init_design_space.empty() &&
-             !init_segments.empty()) {
+  } else if (init_codepoints.empty() && init_features.empty() &&
+             init_design_space.empty() && !init_segments.empty()) {
     TRYV(encoder.SetBaseSubsetFromSegments(init_segments));
-  } else if (init_codepoints.empty() && init_features.empty() && !init_design_space.empty() &&
-             !init_segments.empty()) {
+  } else if (init_codepoints.empty() && init_features.empty() &&
+             !init_design_space.empty() && !init_segments.empty()) {
     TRYV(encoder.SetBaseSubsetFromSegments(init_segments, init_design_space));
   } else {
     return absl::UnimplementedError(
@@ -202,7 +203,8 @@ Status ConfigureEncoder(EncoderConfig config, Encoder& encoder) {
     encoder.AddFeatureGroupSegment(tag_values(features));
   }
 
-  for (const auto& design_space_proto : config.non_glyph_design_space_segmentation()) {
+  for (const auto& design_space_proto :
+       config.non_glyph_design_space_segmentation()) {
     auto design_space = TRY(to_design_space(design_space_proto));
     encoder.AddDesignSpaceSegment(design_space);
   }

--- a/util/iftb2config.cc
+++ b/util/iftb2config.cc
@@ -1,0 +1,35 @@
+/*
+ * This utility converts an iftb info dump into the corresponding
+ * encoding_config.proto config file.
+ *
+ * Takes the info dump on stdin and outputs the config on stdout.
+ */
+
+#include <google/protobuf/text_format.h>
+
+#include <iostream>
+#include <sstream>
+
+#include "absl/flags/parse.h"
+#include "util/convert_iftb.h"
+
+int main(int argc, char** argv) {
+  auto args = absl::ParseCommandLine(argc, argv);
+
+  std::stringstream ss;
+  ss << std::cin.rdbuf();
+  std::string input = ss.str();
+
+  auto config = util::convert_iftb(input);
+  if (!config.ok()) {
+    std::cerr << "Failure parsing iftb info dump: " << config.status()
+              << std::endl;
+    return -1;
+  }
+
+  std::string out;
+  google::protobuf::TextFormat::PrintToString(*config, &out);
+
+  std::cout << out << std::endl;
+  return 0;
+}

--- a/util/testdata/convert-iftb-sample.txt
+++ b/util/testdata/convert-iftb-sample.txt
@@ -1,0 +1,9 @@
+majorVersion: 0
+minorVersion: 1
+ID: bbf038d5 582c7194 b721ed1d e13c8483
+chunkCount: 3
+glyphCount: 7
+chunkSet indexes: 0
+gidMap: 0:0, 1:1, 2:1, 3:1, 4:2, 5:0, 6:2
+filesURI: ./Roboto-Regular_iftb/$3/chunk$3$2$1.br
+


### PR DESCRIPTION
This will allow the iftb segmenter to be used to generate segmentation plans until we have a new segmenter implemented.