### PR TITLE
Allow encoder to use short loca when possible.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,10 +72,10 @@ http_archive(
 # Fontations
 http_archive(
     name = "fontations",
-    urls = ["https://github.com/googlefonts/fontations/archive/b3514837812c462d94707bd0afc41b11e8cc4e6d.zip"],
-    strip_prefix = "fontations-b3514837812c462d94707bd0afc41b11e8cc4e6d",
+    urls = ["https://github.com/googlefonts/fontations/archive/e01046e776d4539daf9e1856f3d8c9ea02984b1d.zip"],
+    strip_prefix = "fontations-e01046e776d4539daf9e1856f3d8c9ea02984b1d",
     build_file = "//third_party:fontations.BUILD",
-    integrity = "sha256-HDDXjyJGNYemgLVp7XNFaFawWTyv8lgPEWfrgfzdFE8=",
+    integrity = "sha256-S9whGuFK3+vqEdl0Fx4lNpEf7fZ8EwPJirxkGzS6wdY=",
 )
 
 

--- a/common/font_helper.cc
+++ b/common/font_helper.cc
@@ -22,6 +22,29 @@ using common::FontData;
 
 namespace common {
 
+bool FontHelper::HasLongLoca(const hb_face_t* face) {
+  FontData head = TableData(face, kHead);
+  if (head.size() < 52) {
+    return false;
+  }
+
+  return (bool)head.str()[51];
+}
+
+bool FontHelper::HasWideGvar(const hb_face_t* face) {
+  auto gvar = TableData(face, kGvar);
+  if (gvar.empty()) {
+    return false;
+  }
+
+  constexpr uint32_t gvar_flags_offset = 15;
+  if (gvar.size() < gvar_flags_offset + 1) {
+    return false;
+  }
+
+  return (((uint8_t)gvar.str()[gvar_flags_offset]) & 0x01);
+}
+
 absl::StatusOr<string_view> FontHelper::GlyfData(const hb_face_t* face,
                                                  uint32_t gid) {
   auto loca = Loca(face);

--- a/common/font_helper.h
+++ b/common/font_helper.h
@@ -131,6 +131,9 @@ class FontHelper {
     return ReadInt<8, uint8_t>(value);
   }
 
+  static bool HasLongLoca(const hb_face_t* face);
+  static bool HasWideGvar(const hb_face_t* face);
+
   static absl::StatusOr<absl::string_view> GlyfData(const hb_face_t* face,
                                                     uint32_t gid);
 

--- a/fontations/Cargo.lock
+++ b/fontations/Cargo.lock
@@ -1394,7 +1394,7 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "skrifa"
-version = "0.26.4"
+version = "0.26.5"
 dependencies = [
  "bytemuck",
  "core_maths",

--- a/ift/client/fontations_client.h
+++ b/ift/client/fontations_client.h
@@ -21,8 +21,8 @@ typedef absl::btree_map<std::string, absl::btree_set<std::string>> graph;
  * Runs 'ift_graph' on the IFT font created by encoder and writes a
  * representation of the graph into 'out'.
  */
-absl::Status ToGraph(const ift::encoder::Encoder& encoder,
-                     const common::FontData& base, graph& out);
+absl::Status ToGraph(const ift::encoder::Encoder::Encoding& encoding,
+                     graph& out);
 
 /**
  * Runs 'ift_extend' on the IFT font created by encoder and returns the
@@ -32,15 +32,15 @@ absl::Status ToGraph(const ift::encoder::Encoder& encoder,
  * the client ended up fetching and applying.
  */
 absl::StatusOr<common::FontData> ExtendWithDesignSpace(
-    const ift::encoder::Encoder& encoder, const common::FontData& ift_font,
+    const ift::encoder::Encoder::Encoding& encoding,
     absl::btree_set<uint32_t> codepoints,
     absl::btree_set<hb_tag_t> feature_tags,
     absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space,
     absl::btree_set<std::string>* applied_uris = nullptr);
 
-absl::StatusOr<common::FontData> Extend(const ift::encoder::Encoder& encoder,
-                                        const common::FontData& ift_font,
-                                        absl::btree_set<uint32_t> codepoints);
+absl::StatusOr<common::FontData> Extend(
+    const ift::encoder::Encoder::Encoding& encoding,
+    absl::btree_set<uint32_t> codepoints);
 
 }  // namespace ift::client
 

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -214,6 +214,10 @@ class Encoder {
   static void AddCombinations(const std::vector<const SubsetDefinition*>& in,
                               uint32_t number,
                               std::vector<SubsetDefinition>& out);
+
+  SubsetDefinition AddFeatureSpecificChunksIfNeeded(
+      const SubsetDefinition& def) const;
+
   SubsetDefinition Combine(const SubsetDefinition& s1,
                            const SubsetDefinition& s2) const;
 

--- a/util/font2ift.cc
+++ b/util/font2ift.cc
@@ -104,19 +104,20 @@ void write_patch(const std::string& url, const FontData& patch) {
   }
 }
 
-int write_output(const Encoder& encoder, const FontData& base_font) {
+int write_output(const Encoder::Encoding& encoding) {
   std::string output_path = absl::GetFlag(FLAGS_output_path);
   std::string output_font = absl::GetFlag(FLAGS_output_font);
 
   std::cerr << "  Writing init font: " << StrCat(output_path, "/", output_font)
             << std::endl;
-  auto sc = write_file(StrCat(output_path, "/", output_font), base_font);
+  auto sc =
+      write_file(StrCat(output_path, "/", output_font), encoding.init_font);
   if (!sc.ok()) {
     std::cerr << sc.message() << std::endl;
     return -1;
   }
 
-  for (const auto& p : encoder.Patches()) {
+  for (const auto& p : encoding.patches) {
     write_patch(p.first, p.second);
   }
 
@@ -270,12 +271,12 @@ int main(int argc, char** argv) {
   }
 
   std::cout << ">> encoding:" << std::endl;
-  auto encoded = encoder.Encode();
-  if (!encoded.ok()) {
-    std::cerr << "Encoding failed: " << encoded.status() << std::endl;
+  auto encoding = encoder.Encode();
+  if (!encoding.ok()) {
+    std::cerr << "Encoding failed: " << encoding.status() << std::endl;
     return -1;
   }
 
   std::cout << ">> generating output patches:" << std::endl;
-  return write_output(encoder, *encoded);
+  return write_output(*encoding);
 }


### PR DESCRIPTION
Previously we always forced long loca to avoid dealing with potential loca type change. Now if the fully expanded font will fit into a short loca the encoder will use it.