### PR TITLE
Activation conditions and child entry indices

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -72,10 +72,10 @@ http_archive(
 # Fontations
 http_archive(
     name = "fontations",
-    urls = ["https://github.com/googlefonts/fontations/archive/e01046e776d4539daf9e1856f3d8c9ea02984b1d.zip"],
-    strip_prefix = "fontations-e01046e776d4539daf9e1856f3d8c9ea02984b1d",
+    urls = ["https://github.com/googlefonts/fontations/archive/9063931e9cb9c4e0b40a54c83314486dd36115f8.zip"],
+    strip_prefix = "fontations-9063931e9cb9c4e0b40a54c83314486dd36115f8",
     build_file = "//third_party:fontations.BUILD",
-    integrity = "sha256-S9whGuFK3+vqEdl0Fx4lNpEf7fZ8EwPJirxkGzS6wdY=",
+    integrity = "sha256-aRxRkVF9A6aUE8Fu3y8StkH4tCLnM1iRFha6GcKbgFo=",
 )
 
 

--- a/common/hb_set_unique_ptr.cc
+++ b/common/hb_set_unique_ptr.cc
@@ -5,6 +5,8 @@
 
 #include "hb.h"
 
+using absl::flat_hash_set;
+
 namespace common {
 
 hb_set_unique_ptr make_hb_set() {
@@ -45,6 +47,15 @@ hb_set_unique_ptr make_hb_set_from_ranges(int number_of_ranges, ...) {
   }
   va_end(values);
   return result;
+}
+
+flat_hash_set<uint32_t> to_hash_set(const hb_set_unique_ptr& set) {
+  flat_hash_set<uint32_t> out;
+  hb_codepoint_t v = HB_SET_VALUE_INVALID;
+  while (hb_set_next(set.get(), &v)) {
+    out.insert(v);
+  }
+  return out;
 }
 
 }  // namespace common

--- a/common/hb_set_unique_ptr.h
+++ b/common/hb_set_unique_ptr.h
@@ -20,6 +20,8 @@ hb_set_unique_ptr make_hb_set_from_ranges(int number_of_ranges, ...);
 
 hb_set_unique_ptr make_hb_set(int length, ...);
 
+absl::flat_hash_set<uint32_t> to_hash_set(const hb_set_unique_ptr& set);
+
 }  // namespace common
 
 #endif  // COMMON_HB_SET_UNIQUE_PTR_H_

--- a/fontations/Cargo.lock
+++ b/fontations/Cargo.lock
@@ -542,10 +542,9 @@ dependencies = [
 
 [[package]]
 name = "font-test-data"
-version = "0.2.1"
+version = "0.3.0"
 dependencies = [
- "read-fonts",
- "write-fonts",
+ "font-types",
 ]
 
 [[package]]
@@ -1186,7 +1185,7 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.25.3"
+version = "0.26.0"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -1394,7 +1393,7 @@ checksum = "1de1d4f81173b03af4c0cbed3c898f6bff5b870e4a7f5d6f4057d62a7a4b686e"
 
 [[package]]
 name = "skrifa"
-version = "0.26.5"
+version = "0.27.0"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -1862,7 +1861,7 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.33.1"
+version = "0.34.0"
 dependencies = [
  "ansi_term",
  "bincode",

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -794,8 +794,7 @@ Status Encoder::PopulateGlyphKeyedPatchMap(PatchMap& patch_map) const {
       }
 
       PatchMap::Coverage coverage;
-      coverage.copy_mode_append =
-          false;  // union the group members together (OR).
+      coverage.conjunctive = false;  // ... OR ...
 
       for (uint32_t patch_id : group) {
         auto entry_index = patch_id_to_entry_index.find(patch_id);
@@ -803,7 +802,7 @@ Status Encoder::PopulateGlyphKeyedPatchMap(PatchMap& patch_map) const {
           return absl::InternalError(StrCat("entry for patch_id = ", patch_id,
                                             " was not previously created."));
         }
-        coverage.copy_indices.insert(entry_index->second);
+        coverage.child_indices.insert(entry_index->second);
       }
 
       if (condition->required_groups.size() == 1 &&
@@ -831,15 +830,15 @@ Status Encoder::PopulateGlyphKeyedPatchMap(PatchMap& patch_map) const {
   for (auto condition = remaining_conditions.begin();
        condition != remaining_conditions.end(); condition++) {
     PatchMap::Coverage coverage;
-    coverage.copy_mode_append = true;  // append the groups (AND)
+    coverage.conjunctive = true;  // ... AND ...
 
     for (const auto& group : condition->required_groups) {
       if (group.size() == 1) {
-        coverage.copy_indices.insert(patch_id_to_entry_index[*group.begin()]);
+        coverage.child_indices.insert(patch_id_to_entry_index[*group.begin()]);
         continue;
       }
 
-      coverage.copy_indices.insert(patch_group_to_entry_index[group]);
+      coverage.child_indices.insert(patch_group_to_entry_index[group]);
     }
 
     // TODO(garretrieger): required_features implies f1 AND f2 ..., but

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -16,6 +16,7 @@
 #include "common/font_data.h"
 #include "common/font_helper.h"
 #include "common/hb_set_unique_ptr.h"
+#include "common/try.h"
 #include "common/woff2.h"
 #include "hb-subset.h"
 #include "ift/glyph_keyed_diff.h"
@@ -626,7 +627,7 @@ Status Encoder::PopulateGlyphKeyedPatchMap(
     auto it = glyph_data_segment_feature_dependencies_.find(id);
     if (it == glyph_data_segment_feature_dependencies_.end()) {
       // Just a regular entry mapped by codepoints only.
-      patch_map.AddEntry(e.second.codepoints, e.first, GLYPH_KEYED);
+      TRYV(patch_map.AddEntry(e.second.codepoints, e.first, GLYPH_KEYED));
       continue;
     }
 
@@ -651,7 +652,7 @@ Status Encoder::PopulateGlyphKeyedPatchMap(
             std::inserter(coverage.codepoints, coverage.codepoints.begin()));
       }
 
-      patch_map.AddEntry(coverage, id, GLYPH_KEYED);
+      TRYV(patch_map.AddEntry(coverage, id, GLYPH_KEYED));
     }
   }
   return absl::OkStatus();
@@ -718,7 +719,7 @@ StatusOr<FontData> Encoder::Encode(ProcessingContext& context,
     ids.push_back(id);
 
     PatchMap::Coverage coverage = s.ToCoverage();
-    table_keyed_patch_map.AddEntry(coverage, id, encoding);
+    TRYV(table_keyed_patch_map.AddEntry(coverage, id, encoding));
   }
 
   auto face = base->face();

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -28,12 +28,15 @@ class Encoder {
  public:
   typedef absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space_t;
 
-  // TODO XXXXXX be consistent with terminology used for patches/segments (ie. standardize on one or the other throughout).
-  // TODO XXXXXX have all conditions be provided even for the initial segment, and then expand the base subset
-  //             based on what segments are requested. Add a test for this expansion.
+  // TODO XXXXXX be consistent with terminology used for patches/segments (ie.
+  // standardize on one or the other throughout).
+  // TODO XXXXXX have all conditions be provided even for the initial segment,
+  // and then expand the base subset
+  //             based on what segments are requested. Add a test for this
+  //             expansion.
 
   /*
-   *  This conditions is satisfied if the input subset definition matches at
+   * This conditions is satisfied if the input subset definition matches at
    * least one segment in each required group and every feature in
    * required_features.
    */
@@ -42,14 +45,11 @@ class Encoder {
     absl::btree_set<hb_tag_t> required_features;
     uint32_t activated_segment_id;
 
-    Condition() :
-      required_groups(),
-      activated_segment_id(0) {}
+    Condition() : required_groups(), activated_segment_id(0) {}
 
     // Construct a condition that maps a segment to itself.
-    Condition(uint32_t segment_id) :
-      required_groups({{segment_id}}),
-      activated_segment_id(segment_id) {}
+    Condition(uint32_t segment_id)
+        : required_groups({{segment_id}}), activated_segment_id(segment_id) {}
 
     // Returns true if this condition is activated by exactly one segment and no
     // features.

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -30,10 +30,6 @@ class Encoder {
 
   // TODO XXXXXX be consistent with terminology used for patches/segments (ie.
   // standardize on one or the other throughout).
-  // TODO XXXXXX have all conditions be provided even for the initial segment,
-  // and then expand the base subset
-  //             based on what segments are requested. Add a test for this
-  //             expansion.
 
   /*
    * This conditions is satisfied if the input subset definition matches at
@@ -264,9 +260,6 @@ class Encoder {
                               uint32_t number,
                               std::vector<SubsetDefinition>& out);
 
-  SubsetDefinition AddFeatureSpecificChunksIfNeeded(
-      const SubsetDefinition& def) const;
-
   SubsetDefinition Combine(const SubsetDefinition& s1,
                            const SubsetDefinition& s2) const;
 
@@ -316,9 +309,6 @@ class Encoder {
   absl::StatusOr<common::FontData> Instance(
       const ProcessingContext& context, hb_face_t* font,
       const design_space_t& design_space) const;
-
-  template <typename T>
-  void RemoveSegments(T ids);
 
   absl::StatusOr<std::unique_ptr<const common::BinaryDiff>> GetDifferFor(
       const common::FontData& font_data, common::CompatId compat_id,

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -29,6 +29,8 @@ class Encoder {
   typedef absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space_t;
 
   // TODO XXXXXX be consistent with terminology used for patches/segments (ie. standardize on one or the other throughout).
+  // TODO XXXXXX have all conditions be provided even for the initial segment, and then expand the base subset
+  //             based on what segments are requested. Add a test for this expansion.
 
   /*
    *  This conditions is satisfied if the input subset definition matches at
@@ -39,6 +41,15 @@ class Encoder {
     std::vector<absl::btree_set<uint32_t>> required_groups;
     absl::btree_set<hb_tag_t> required_features;
     uint32_t activated_segment_id;
+
+    Condition() :
+      required_groups(),
+      activated_segment_id(0) {}
+
+    // Construct a condition that maps a segment to itself.
+    Condition(uint32_t segment_id) :
+      required_groups({{segment_id}}),
+      activated_segment_id(segment_id) {}
 
     // Returns true if this condition is activated by exactly one segment and no
     // features.

--- a/ift/encoder/encoder_test.cc
+++ b/ift/encoder/encoder_test.cc
@@ -58,6 +58,8 @@ typedef btree_map<std::string, btree_set<std::string>> graph;
 constexpr hb_tag_t kWght = HB_TAG('w', 'g', 'h', 't');
 constexpr hb_tag_t kWdth = HB_TAG('w', 'd', 't', 'h');
 
+// TODO XXXX add a test that checks the constructed glyph map for a case with complicated conditions.
+
 class EncoderTest : public ::testing::Test {
  protected:
   EncoderTest() {

--- a/ift/encoder/encoder_test.cc
+++ b/ift/encoder/encoder_test.cc
@@ -700,6 +700,10 @@ void ClearCompatIdFromFormat2(uint8_t* data) {
   }
 }
 
+// TODO(garretrieger): XXXXXXX test with activation conditions that ensures they
+// are expanded appropriately in the
+//                     initial font.
+
 TEST_F(EncoderTest, Encode_ComplicatedActivationConditions) {
   Encoder encoder;
   hb_face_t* face = font.reference_face();

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -29,7 +29,6 @@ namespace ift::encoder {
 // - Multi segment combination testing with GSUB dep analysis to guide.
 // - Use merging and/or duplication to ensure minimum patch size.
 
-
 btree_set<uint32_t> to_btree_set(const hb_set_t* set) {
   btree_set<uint32_t> out;
   uint32_t v = HB_SET_VALUE_INVALID;

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -31,6 +31,8 @@ typedef uint32_t glyph_id_t;
  */
 class GlyphSegmentation {
  public:
+  // TODO(garretrieger): merge this with Encoder::Condition they are basically
+  // identical.
   class ActivationCondition {
    public:
     /*

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -87,7 +87,8 @@ class IntegrationTest : public ::testing::Test {
     auto sc = encoder.AddGlyphDataSegment(1, TestSegment1());
     sc.Update(encoder.AddGlyphDataSegment(2, TestSegment2()));
     sc.Update(encoder.AddGlyphDataSegment(3, TestSegment3()));
-    sc.Update(encoder.AddGlyphDataSegment(4, TestSegment4()));
+    sc.Update(encoder.AddGlyphDataSegment(4, TestSegment4()));    
+
     return sc;
   }
 
@@ -467,6 +468,11 @@ TEST_F(IntegrationTest, MixedMode) {
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3, 4}));
   ASSERT_TRUE(sc.ok()) << sc;
 
+  // Setup activations for 2 through 4 (1 is init)
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
+
   auto encoding = encoder.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
@@ -519,9 +525,16 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({2}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({4}));
+
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(1)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
+
   sc.Update(encoder.AddFeatureDependency(1, 5, kVrt3));
   sc.Update(encoder.AddFeatureDependency(2, 5, kVrt3));
   sc.Update(encoder.AddFeatureDependency(4, 6, kVrt3));
+
   encoder.AddFeatureGroupSegment({kVrt3});
   ASSERT_TRUE(sc.ok()) << sc;
 
@@ -588,6 +601,10 @@ TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({2}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({4}));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(1)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
   ASSERT_TRUE(sc.ok()) << sc;
 
   auto encoding = encoder.Encode();
@@ -650,6 +667,11 @@ TEST_F(IntegrationTest, MixedMode_Complex) {
   sc = encoder.SetBaseSubsetFromSegments({});
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({1, 2}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3, 4}));
+
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(1)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
   ASSERT_TRUE(sc.ok()) << sc;
 
   auto encoding = encoder.Encode();
@@ -692,6 +714,10 @@ TEST_F(IntegrationTest, MixedMode_SequentialDependentPatches) {
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({2}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({4}));
+
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
   ASSERT_TRUE(sc.ok()) << sc;
 
   auto encoding = encoder.Encode();
@@ -720,6 +746,10 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation) {
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({2}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3, 4}));
   encoder.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
+
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
   ASSERT_TRUE(sc.ok()) << sc;
 
   auto encoding = encoder.Encode();
@@ -762,6 +792,10 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_DropsUnusedPatches) {
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({2}));
   sc.Update(encoder.AddNonGlyphSegmentFromGlyphSegments({3, 4}));
   encoder.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
+
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(2)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(3)));
+  sc.Update(encoder.AddGlyphDataActivationCondition(Encoder::Condition(4)));
 
   ASSERT_TRUE(sc.ok()) << sc;
 

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -87,7 +87,7 @@ class IntegrationTest : public ::testing::Test {
     auto sc = encoder.AddGlyphDataSegment(1, TestSegment1());
     sc.Update(encoder.AddGlyphDataSegment(2, TestSegment2()));
     sc.Update(encoder.AddGlyphDataSegment(3, TestSegment3()));
-    sc.Update(encoder.AddGlyphDataSegment(4, TestSegment4()));    
+    sc.Update(encoder.AddGlyphDataSegment(4, TestSegment4()));
 
     return sc;
   }
@@ -212,6 +212,8 @@ bool GvarDataMatches(hb_face_t* a, hb_face_t* b, uint32_t codepoint,
 
 // TODO(garretrieger): full expansion test.
 // TODO(garretrieger): test of a woff2 encoded IFT font.
+// TODO XXXXX a test which checks for proper expansion of the base subset based
+// on specified conditions.
 
 TEST_F(IntegrationTest, TableKeyedOnly) {
   Encoder encoder;

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -592,6 +592,8 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
   ASSERT_FALSE(FontHelper::GlyfData(extended_face.get(), chunk6_gid)->empty());
 }
 
+// TODO XXXX test using complex composite activation conditions
+
 TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
   Encoder encoder;
   auto sc = InitEncoderForMixedMode(encoder);

--- a/ift/proto/format_2_patch_map.cc
+++ b/ift/proto/format_2_patch_map.cc
@@ -263,7 +263,12 @@ Status EncodeEntry(const PatchMap::Entry& entry, uint32_t last_entry_index,
       (has_patch_encoding ? encoding_bit_mask : 0) |  // bit 3
       (has_codepoints ? codepoint_bit_mask & BiasFormat(bias_bytes)
                       : 0);  // bit 4 and 5
-  // not set, ignore (bit 6)
+
+  // set ignore bit if needed
+  if (entry.ignored) {
+    format = format | ignore_bit_mask;
+  }
+
   FontHelper::WriteUInt8(format, out);
 
   if (has_features_or_design_space) {

--- a/ift/proto/format_2_patch_map_test.cc
+++ b/ift/proto/format_2_patch_map_test.cc
@@ -51,6 +51,27 @@ TEST_F(Format2PatchMapTest, Simple) {
   ASSERT_EQ(*encoded, absl::StrCat(HeaderSimple(), entry_0));
 }
 
+TEST_F(Format2PatchMapTest, IgnoreBit) {
+  IFTTable table;
+  PatchMap& map = table.GetPatchMap();
+  PatchMap::Coverage coverage{1, 2, 3};
+  auto sc = map.AddEntry(coverage, 1, TABLE_KEYED_FULL, true);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  table.SetUrlTemplate("foo/$1");
+  table.SetId({1, 2, 3, 4});
+
+  auto encoded = Format2PatchMap::Serialize(table);
+  ASSERT_TRUE(encoded.ok()) << encoded.status();
+
+  std::string entry_0 = {
+      // entry 0
+      0b01010000,             // format = Ignored + Codepoints
+      0b00000101, 0b00001110  // codepoints (BF4, depth 1)= {1, 2, 3}
+  };
+  ASSERT_EQ(*encoded, absl::StrCat(HeaderSimple(), entry_0));
+}
+
 TEST_F(Format2PatchMapTest, TwoByteBias) {
   IFTTable table;
   PatchMap& map = table.GetPatchMap();

--- a/ift/proto/format_2_patch_map_test.cc
+++ b/ift/proto/format_2_patch_map_test.cc
@@ -90,14 +90,14 @@ TEST_F(Format2PatchMapTest, CopyIndices) {
   ASSERT_TRUE(sc.ok()) << sc;
 
   PatchMap::Coverage union_cov;
-  union_cov.copy_indices.insert(1);
-  union_cov.copy_indices.insert(0);
+  union_cov.child_indices.insert(1);
+  union_cov.child_indices.insert(0);
   sc = map.AddEntry(union_cov, 3, TABLE_KEYED_FULL);
   ASSERT_TRUE(sc.ok()) << sc;
 
   PatchMap::Coverage append_cov;
-  append_cov.copy_indices.insert(2);
-  append_cov.copy_mode_append = true;
+  append_cov.child_indices.insert(2);
+  append_cov.conjunctive = true;
   sc = map.AddEntry(append_cov, 4, TABLE_KEYED_FULL);
   ASSERT_TRUE(sc.ok()) << sc;
 

--- a/ift/proto/format_2_patch_map_test.cc
+++ b/ift/proto/format_2_patch_map_test.cc
@@ -15,12 +15,6 @@ class Format2PatchMapTest : public ::testing::Test {
   Format2PatchMapTest() {}
 };
 
-constexpr int min_header_size = 34;
-constexpr int min_entry_size = 1;
-constexpr int min_codepoints_size = 1;
-constexpr int min_feature_design_space_size = 3;
-constexpr int segment_size = 12;
-
 static std::string HeaderSimple() {
   return {
       0x02,                    // format
@@ -40,7 +34,8 @@ TEST_F(Format2PatchMapTest, Simple) {
   IFTTable table;
   PatchMap& map = table.GetPatchMap();
   PatchMap::Coverage coverage{1, 2, 3};
-  map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  auto sc = map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   table.SetUrlTemplate("foo/$1");
   table.SetId({1, 2, 3, 4});
@@ -60,7 +55,8 @@ TEST_F(Format2PatchMapTest, TwoByteBias) {
   IFTTable table;
   PatchMap& map = table.GetPatchMap();
   PatchMap::Coverage coverage{10251, 10252, 10253};
-  map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  auto sc = map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   table.SetUrlTemplate("foo/$1");
   table.SetId({1, 2, 3, 4});
@@ -82,7 +78,8 @@ TEST_F(Format2PatchMapTest, ThreeByteBias) {
   IFTTable table;
   PatchMap& map = table.GetPatchMap();
   PatchMap::Coverage coverage{100251, 100252, 100253};
-  map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  auto sc = map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   table.SetUrlTemplate("foo/$1");
   table.SetId({1, 2, 3, 4});
@@ -104,7 +101,8 @@ TEST_F(Format2PatchMapTest, ComplexSet) {
   IFTTable table;
   PatchMap& map = table.GetPatchMap();
   PatchMap::Coverage coverage{123, 155, 179, 180, 181, 182, 1013};
-  map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  auto sc = map.AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   std::string uri_template = "foo/$1";
   table.SetUrlTemplate(uri_template);
@@ -128,7 +126,8 @@ TEST_F(Format2PatchMapTest, Features) {
   PatchMap::Coverage coverage{1, 2, 3};
   coverage.features.insert(HB_TAG('w', 'g', 'h', 't'));
   coverage.features.insert(HB_TAG('w', 'd', 't', 'h'));
-  table.GetPatchMap().AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  auto sc = table.GetPatchMap().AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   std::string uri_template = "foo/$1";
   table.SetUrlTemplate(uri_template);
@@ -157,7 +156,8 @@ TEST_F(Format2PatchMapTest, DesignSpace) {
       *common::AxisRange::Range(100.0f, 200.0f);
   coverage.design_space[HB_TAG('w', 'd', 't', 'h')] =
       common::AxisRange::Point(0.75f);
-  table.GetPatchMap().AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  auto sc = table.GetPatchMap().AddEntry(coverage, 1, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   std::string uri_template = "foo/$1";
   table.SetUrlTemplate(uri_template);
@@ -186,13 +186,16 @@ TEST_F(Format2PatchMapTest, NonDefaultPatchFormat) {
   IFTTable table;
 
   PatchMap::Coverage coverage1{1, 2, 3};
-  table.GetPatchMap().AddEntry(coverage1, 1, TABLE_KEYED_PARTIAL);
+  auto sc = table.GetPatchMap().AddEntry(coverage1, 1, TABLE_KEYED_PARTIAL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   PatchMap::Coverage coverage2{15, 16, 17};
-  table.GetPatchMap().AddEntry(coverage2, 2, TABLE_KEYED_PARTIAL);
+  sc = table.GetPatchMap().AddEntry(coverage2, 2, TABLE_KEYED_PARTIAL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   PatchMap::Coverage coverage3{25, 26, 27};
-  table.GetPatchMap().AddEntry(coverage3, 3, GLYPH_KEYED);
+  sc = table.GetPatchMap().AddEntry(coverage3, 3, GLYPH_KEYED);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   std::string uri_template = "foo/$1";
   table.SetUrlTemplate(uri_template);
@@ -239,13 +242,16 @@ TEST_F(Format2PatchMapTest, NonDefaultPatchFormat) {
 TEST_F(Format2PatchMapTest, IndexDeltas) {
   IFTTable table;
   PatchMap::Coverage coverage1{1, 2, 3};
-  table.GetPatchMap().AddEntry(coverage1, 7, TABLE_KEYED_FULL);
+  auto sc = table.GetPatchMap().AddEntry(coverage1, 7, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   PatchMap::Coverage coverage2{15, 16, 17};
-  table.GetPatchMap().AddEntry(coverage2, 4, TABLE_KEYED_FULL);
+  sc = table.GetPatchMap().AddEntry(coverage2, 4, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   PatchMap::Coverage coverage3{25, 26, 27};
-  table.GetPatchMap().AddEntry(coverage3, 10, TABLE_KEYED_FULL);
+  sc = table.GetPatchMap().AddEntry(coverage3, 10, TABLE_KEYED_FULL);
+  ASSERT_TRUE(sc.ok()) << sc;
 
   std::string uri_template = "foo/$1";
   table.SetUrlTemplate(uri_template);

--- a/ift/proto/ift_table_test.cc
+++ b/ift/proto/ift_table_test.cc
@@ -39,23 +39,26 @@ class IFTTableTest : public ::testing::Test {
   IFTTableTest() : roboto_ab(make_hb_face(nullptr)) {
     sample.SetUrlTemplate("fonts/go/here");
     sample.SetId({1, 2, 3, 4});
-    sample.GetPatchMap().AddEntry({30, 32}, 1, TABLE_KEYED_PARTIAL);
-    sample.GetPatchMap().AddEntry({55, 56, 57}, 2, GLYPH_KEYED);
+    auto sc = sample.GetPatchMap().AddEntry({30, 32}, 1, TABLE_KEYED_PARTIAL);
+    sc.Update(sample.GetPatchMap().AddEntry({55, 56, 57}, 2, GLYPH_KEYED));
+    assert(sc.ok());
 
     sample_with_extensions = sample;
-    sample_with_extensions.GetPatchMap().AddEntry(
+    sc = sample_with_extensions.GetPatchMap().AddEntry(
         {77, 78}, 3,
         TABLE_KEYED_PARTIAL);  // TODO XXXXX we don't track extensions here
                                // anymore.
 
     overlap_sample = sample;
-    overlap_sample.GetPatchMap().AddEntry({55}, 3, TABLE_KEYED_PARTIAL);
+    sc.Update(
+        overlap_sample.GetPatchMap().AddEntry({55}, 3, TABLE_KEYED_PARTIAL));
 
     complex_ids.SetUrlTemplate("fonts/go/here");
-    complex_ids.GetPatchMap().AddEntry({0}, 0, TABLE_KEYED_PARTIAL);
-    complex_ids.GetPatchMap().AddEntry({5}, 5, TABLE_KEYED_PARTIAL);
-    complex_ids.GetPatchMap().AddEntry({2}, 2, TABLE_KEYED_PARTIAL);
-    complex_ids.GetPatchMap().AddEntry({4}, 4, TABLE_KEYED_PARTIAL);
+    sc.Update(complex_ids.GetPatchMap().AddEntry({0}, 0, TABLE_KEYED_PARTIAL));
+    sc.Update(complex_ids.GetPatchMap().AddEntry({5}, 5, TABLE_KEYED_PARTIAL));
+    sc.Update(complex_ids.GetPatchMap().AddEntry({2}, 2, TABLE_KEYED_PARTIAL));
+    sc.Update(complex_ids.GetPatchMap().AddEntry({4}, 4, TABLE_KEYED_PARTIAL));
+    assert(sc.ok());
 
     hb_blob_unique_ptr blob = make_hb_blob(
         hb_blob_create_from_file("common/testdata/Roboto-Regular.ab.ttf"));

--- a/ift/proto/patch_map.cc
+++ b/ift/proto/patch_map.cc
@@ -113,10 +113,10 @@ Span<const PatchMap::Entry> PatchMap::GetEntries() const { return entries_; }
 Status PatchMap::AddEntry(const PatchMap::Coverage& coverage,
                           uint32_t patch_index, PatchEncoding encoding,
                           bool ignored) {
-  // If copy indices are present ensure they refer only to entries prior to this
-  // one.
-  if (!coverage.copy_indices.empty()) {
-    for (uint32_t index : coverage.copy_indices) {
+  // If child indices are present ensure they refer only to entries prior to
+  // this one.
+  if (!coverage.child_indices.empty()) {
+    for (uint32_t index : coverage.child_indices) {
       if (index >= entries_.size()) {
         return absl::InvalidArgumentError(
             absl::StrCat("Invalid copy index. ", index, " is out of bounds."));

--- a/ift/proto/patch_map.h
+++ b/ift/proto/patch_map.h
@@ -56,14 +56,12 @@ class PatchMap {
     absl::btree_set<hb_tag_t> features;
     absl::btree_map<hb_tag_t, common::AxisRange> design_space;
 
-    // If true copy mode
-    // (https://w3c.github.io/IFT/Overview.html#mapping-entry-copymodeandcount)
-    // is "append", other it's "union".
-    bool copy_mode_append = false;
-    // Set of copy indices
-    // (https://w3c.github.io/IFT/Overview.html#mapping-entry-copyindices)
+    // https://w3c.github.io/IFT/Overview.html#mapping-entry-childentrymatchmodeandcount)
+    bool conjunctive = false;
+    // Set of child entry indices
+    // (https://w3c.github.io/IFT/Overview.html#mapping-entry-childentrymatchmodeandcount)
     // values are the indices of previous entries.
-    absl::btree_set<uint32_t> copy_indices;
+    absl::btree_set<uint32_t> child_indices;
   };
 
   struct Entry {

--- a/ift/proto/patch_map_test.cc
+++ b/ift/proto/patch_map_test.cc
@@ -136,7 +136,7 @@ TEST_F(PatchMapTest, AddEntry_WithCopyIndices) {
   };
 
   PatchMap::Coverage cov;
-  cov.copy_indices = {0, 1};
+  cov.child_indices = {0, 1};
 
   auto sc = map.AddEntry(cov, 5, TABLE_KEYED_FULL);
   ASSERT_TRUE(sc.ok()) << sc;
@@ -151,7 +151,7 @@ TEST_F(PatchMapTest, AddEntry_InvalidCopyIndices) {
   };
 
   PatchMap::Coverage cov;
-  cov.copy_indices = {0, 2};
+  cov.child_indices = {0, 2};
 
   auto sc = map.AddEntry(cov, 5, TABLE_KEYED_FULL);
   ASSERT_EQ(sc, absl::InvalidArgumentError(

--- a/util/convert_iftb.cc
+++ b/util/convert_iftb.cc
@@ -68,7 +68,7 @@ StatusOr<EncoderConfig> create_config(
     const btree_set<uint32_t>& loaded_chunks) {
   EncoderConfig config;
   // Populate segments in the config. chunks are directly analagous to segments.
-  auto segments = config.mutable_glyph_segments();
+  auto segments = config.mutable_glyph_patches();
   for (const auto [gid, chunk] : gid_map) {
     Glyphs glyphs;
     auto [it, added] = segments->insert(std::pair(chunk, glyphs));

--- a/util/convert_iftb_test.cc
+++ b/util/convert_iftb_test.cc
@@ -41,14 +41,14 @@ TEST_F(ConvertIftbTest, BasicConversion) {
   ASSERT_TRUE(config.ok()) << config.status();
 
   std::string expected_config =
-      "glyph_segments {\n"
+      "glyph_patches {\n"
       "  key: 0\n"
       "  value {\n"
       "    values: 0\n"
       "    values: 5\n"
       "  }\n"
       "}\n"
-      "glyph_segments {\n"
+      "glyph_patches {\n"
       "  key: 1\n"
       "  value {\n"
       "    values: 1\n"
@@ -56,7 +56,7 @@ TEST_F(ConvertIftbTest, BasicConversion) {
       "    values: 3\n"
       "  }\n"
       "}\n"
-      "glyph_segments {\n"
+      "glyph_patches {\n"
       "  key: 2\n"
       "  value {\n"
       "    values: 4\n"

--- a/util/encoder_config.proto
+++ b/util/encoder_config.proto
@@ -154,7 +154,7 @@ message EncoderConfig {
 message ActivationCondition {
   repeated GlyphPatches required_patch_groups = 1;
   Features required_features = 2;
-  uint32_t activated_patch = 3;
+  uint32 activated_patch = 3;
 }
 
 // A list of glyph patch ids

--- a/util/encoder_config.proto
+++ b/util/encoder_config.proto
@@ -13,13 +13,11 @@ edition = "2023";
 // contain one glyph keyed patch per specified glyph segment and unique configuration of the design space
 // reachable via the non glyph table keyed patches.
 //
-// By default each glyph segment will be reachable by matching any code points that map to any glyph in that
-// segment. However, this default mapping can be overriden use the glyph_patch_dependecies map to specify a
-// set of glyph segments and features that when matched will trigger that glyph segment. For example if there
-// were three input segments (1, 2, 3) where segment 1 contained the f glyph, segment 2 contained the i glyph
-// and segment 3 contains the fi ligature glyph then segment 3 should be configured to be dependent on
-// segments 1 and 2 which would result in segment 3 to only be selected by the client if segments 1 and 2
-// were also selected.
+// glyph_patches is used to configure a segmentation of the glyphs in the font. These are the building blocks
+// used to construct other parts of the encoding plan. glyph_patches can be moved into the initial font via 
+// initial_glyph_patches or they can be configured to be loaded via patches by specifying a loading condition
+// via glyph_patch_conditions. Note that glyph_patches which do not have an activation condition will not 
+// have patches generated for them.
 //
 // The second section of the configuration is the "Non Glyph Extension Configuration" which describes how to
 // segment the data in all non-glyph tables (everything but glyf, gvar, CFF, and CFF2). These tables will be

--- a/util/encoder_config.proto
+++ b/util/encoder_config.proto
@@ -63,15 +63,16 @@ message EncoderConfig {
   //
   // The key of the mapping is an integer id which other parts of the configuration can use to reference
   // the segment.
-  map<uint32, Glyphs> glyph_segments = 1;
+  map<uint32, Glyphs> glyph_patches = 1;
 
-  // Encodes a depencies between other glyph patches and layout features.
+  // Lists the conditions under which the patches specified in glyph_patches will be loaded. Every patch
+  // should be given at least one condition here other wise it won't be accessible in the produced mapping.
   //
   // An entry in this map implies that the patch mapping entry for the glyph patch identified by the key
-  // will be set up such that it will only be matched for loading iff:
-  // - All of GlyphPatchDependency.required_patches are matched, AND
+  // will be set up such that it will only be activated for loading iff:
+  // - At least one patch in each ActivationCondition.required_patch_groups is matched, AND
   // - All of GlyphPatchDependency.required_features are matched.
-  map<uint32, GlyphPatchDependency> glyph_patch_dependencies = 2;
+  map<uint32, ActivationCondition> glyph_patch_conditions = 2;
 
   // ### Non Glyph Extension Configuration ###
 
@@ -142,8 +143,13 @@ message EncoderConfig {
   bool add_everything_else_segments = 14;
 }
 
-message GlyphPatchDependency {
-  GlyphPatches required_patches = 1;
+// Activated when at least one of every patch group is matched and all required_features match.
+// More formally, if p_i_j is patch j in group i, and f_i is feature i:
+//
+// (p_1_1 OR p_1_2 OR ...) AND (p_2_1 OR ...) AND
+// f_1 AND f_2 AND ...
+message ActivationCondition {
+  repeated GlyphPatches required_patch_groups = 1;
   Features required_features = 2;
 }
 

--- a/util/encoder_config.proto
+++ b/util/encoder_config.proto
@@ -68,11 +68,14 @@ message EncoderConfig {
   // Lists the conditions under which the patches specified in glyph_patches will be loaded. Every patch
   // should be given at least one condition here other wise it won't be accessible in the produced mapping.
   //
-  // An entry in this map implies that the patch mapping entry for the glyph patch identified by the key
-  // will be set up such that it will only be activated for loading iff:
+  // An entry in this map implies that the patch mapping entry for the glyph patch identified by
+  // ActivationCondition.activated_patch will be set up such that it will only be activated for loading iff:
   // - At least one patch in each ActivationCondition.required_patch_groups is matched, AND
   // - All of GlyphPatchDependency.required_features are matched.
-  map<uint32, ActivationCondition> glyph_patch_conditions = 2;
+  //
+  // More then one condition can exist for the same patch. That patch will be activated when at least one
+  // condition is satisfied.
+  repeated ActivationCondition glyph_patch_conditions = 2;
 
   // ### Non Glyph Extension Configuration ###
 
@@ -151,6 +154,7 @@ message EncoderConfig {
 message ActivationCondition {
   repeated GlyphPatches required_patch_groups = 1;
   Features required_features = 2;
+  uint32_t activated_patch = 3;
 }
 
 // A list of glyph patch ids

--- a/util/font2ift.cc
+++ b/util/font2ift.cc
@@ -154,7 +154,8 @@ Status ConfigureEncoder(EncoderConfig config, Encoder& encoder) {
           "Deps with more than one feature or segment aren't supported yet.");
     }
 
-    uint32_t required_segment_id = dep.required_patch_groups().at(0).values().at(0);
+    uint32_t required_segment_id =
+        dep.required_patch_groups().at(0).values().at(0);
     hb_tag_t tag = FontHelper::ToTag(dep.required_features().values().at(0));
     TRYV(encoder.AddFeatureDependency(required_segment_id, id, tag));
   }

--- a/util/font2ift.cc
+++ b/util/font2ift.cc
@@ -142,18 +142,19 @@ StatusOr<Encoder::design_space_t> to_design_space(const DesignSpace& proto) {
 
 Status ConfigureEncoder(EncoderConfig config, Encoder& encoder) {
   // First configure the glyph keyed segments, including features deps
-  for (const auto& [id, gids] : config.glyph_segments()) {
+  for (const auto& [id, gids] : config.glyph_patches()) {
     TRYV(encoder.AddGlyphDataSegment(id, values(gids)));
   }
 
-  for (const auto& [id, dep] : config.glyph_patch_dependencies()) {
-    if (dep.required_patches().values_size() != 1 ||
+  for (const auto& [id, dep] : config.glyph_patch_conditions()) {
+    if (dep.required_patch_groups_size() != 1 ||
+        dep.required_patch_groups().at(0).values_size() != 1 ||
         dep.required_features().values_size() != 1) {
       return absl::UnimplementedError(
           "Deps with more than one feature or segment aren't supported yet.");
     }
 
-    uint32_t required_segment_id = dep.required_patches().values().at(0);
+    uint32_t required_segment_id = dep.required_patch_groups().at(0).values().at(0);
     hb_tag_t tag = FontHelper::ToTag(dep.required_features().values().at(0));
     TRYV(encoder.AddFeatureDependency(required_segment_id, id, tag));
   }

--- a/util/glyph_keyed_segments.cc
+++ b/util/glyph_keyed_segments.cc
@@ -37,6 +37,7 @@ using common::hb_blob_unique_ptr;
 using common::hb_face_unique_ptr;
 using common::make_hb_blob;
 using ift::encoder::Encoder;
+using ift::encoder::GlyphSegmentation;
 
 StatusOr<FontData> load_file(const char* path) {
   hb_blob_unique_ptr blob =
@@ -49,6 +50,106 @@ StatusOr<FontData> load_file(const char* path) {
 
 StatusOr<hb_face_unique_ptr> load_font(const char* filename) {
   return TRY(load_file(filename)).face();
+}
+
+constexpr uint32_t NETWORK_REQUEST_BYTE_OVERHEAD = 75;
+
+StatusOr<int> EncodingSize(const Encoder::Encoding& encoding) {
+  auto init_font = encoding.init_font.face();
+  
+  uint32_t total_size = 0;
+  for (const auto& [url, data] : encoding.patches) {
+    if (url.substr(url.size() - 2) == "gk") {
+      total_size += data.size() + NETWORK_REQUEST_BYTE_OVERHEAD;
+      printf("  patch %s adds %u bytes, %u bytes overhead\n", url.c_str(), data.size(), NETWORK_REQUEST_BYTE_OVERHEAD);
+    }
+  }
+
+  auto iftx = FontHelper::TableData(init_font.get(), HB_TAG('I', 'F', 'T', 'X'));
+  total_size += iftx.size();
+  printf("  mapping table %u bytes\n", iftx.size());
+
+  return total_size;
+}
+
+StatusOr<int> IdealSegmentationSize(hb_face_t* font, const GlyphSegmentation& segmentation, uint32_t number_input_segments) {
+  // There are three parts to the cost of a segmentation:
+  // - Size of the glyph keyed mapping table.
+  // - Total size of all glyph keyed patches
+  // - Network overhead (fixed cost per patch).
+
+  printf("IdealSegmentationSize():\n");
+  btree_set<uint32_t> glyphs;
+  for (const auto& [id, glyph_set] : segmentation.GidSegments()) {
+    glyphs.insert(glyph_set.begin(), glyph_set.end());
+  }
+
+  uint32_t glyphs_per_patch = glyphs.size() / number_input_segments;
+  uint32_t remainder_glyphs = glyphs.size() % number_input_segments;
+
+
+  Encoder encoder;
+  encoder.SetFace(font);
+
+  flat_hash_set<uint32_t> all_segments;
+
+  TRYV(encoder.SetBaseSubset({}));
+
+  auto glyphs_it = glyphs.begin();  
+  for (uint32_t i = 0; i < number_input_segments; i++) {
+    auto begin = glyphs_it;
+    glyphs_it  = std::next(glyphs_it, glyphs_per_patch);
+    if (remainder_glyphs > 0) {
+      glyphs_it++;
+      remainder_glyphs--;
+    }
+
+    flat_hash_set<uint32_t> gids;
+    gids.insert(begin, glyphs_it);
+    TRYV(encoder.AddGlyphDataSegment(i, gids));
+    all_segments.insert(i);
+    TRYV(encoder.AddGlyphDataActivationCondition(Encoder::Condition(i)));
+  }
+
+  TRYV(encoder.AddNonGlyphSegmentFromGlyphSegments(all_segments));
+
+  auto encoding = TRY(encoder.Encode());
+  return EncodingSize(encoding);
+}
+
+StatusOr<int> SegmentationSize(hb_face_t* font, const GlyphSegmentation& segmentation) {
+  // There are three parts to the cost of a segmentation:
+  // - Size of the glyph keyed mapping table.
+  // - Total size of all glyph keyed patches
+  // - Network overhead (fixed cost per patch).
+  printf("SegmentationSize():\n");
+  Encoder encoder;
+  encoder.SetFace(font);
+
+  flat_hash_set<uint32_t> all_segments;
+
+  TRYV(encoder.SetBaseSubset({}));
+
+  for (const auto& [id, glyph_set] : segmentation.GidSegments()) {
+    flat_hash_set<uint32_t> s;
+    s.insert(glyph_set.begin(), glyph_set.end());
+    TRYV(encoder.AddGlyphDataSegment(id, s));
+    all_segments.insert(id);
+  }
+
+  TRYV(encoder.AddNonGlyphSegmentFromGlyphSegments(all_segments));
+
+  for (const auto& c : segmentation.Conditions()) {
+    Encoder::Condition condition;
+    for (const auto& g : c.conditions()) {
+      condition.required_groups.push_back(g);
+    }
+    condition.activated_segment_id = c.activated();
+    TRYV(encoder.AddGlyphDataActivationCondition(condition));
+  }
+
+  auto encoding = TRY(encoder.Encode());
+  return EncodingSize(encoding);
 }
 
 int main(int argc, char** argv) {
@@ -67,11 +168,27 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  std::cout << result->ToString();
+  std::cout << ">> Computed Segmentation" << std::endl;
+  std::cout << result->ToString() << std::endl;
+
+  std::cout << ">> Analysis" << std::endl;  
+  auto cost = SegmentationSize(font->get(), *result);
+  if (!cost.ok()) {
+    std::cerr << "Failed to compute segmentation cost: " << cost.status() << std::endl;
+  }
+  auto ideal_cost = IdealSegmentationSize(font->get(), *result, 2);
+  if (!ideal_cost.ok()) {
+    std::cerr << "Failed to compute segmentation cost: " << cost.status() << std::endl;
+  }
 
   std::cout << std::endl;
-  std::cout << "Number of glyphs placed in fallback patch: "
+  std::cout << "glyphs_in_fallback = "
             << result->UnmappedGlyphs().size() << std::endl;
+  std::cout << "ideal_cost_bytes = " << *ideal_cost << std::endl;
+  std::cout << "total_cost_bytes = " << *cost << std::endl;  
+
+  double overhead_percent = (((double) *cost) / ((double) *ideal_cost) * 100.0) - 100.0;
+  std::cout << "%_overhead = " << overhead_percent << std::endl;
 
   return 0;
 }


### PR DESCRIPTION
This PR adds support for configuring the encoder with generic activation conditions for glyph keyed patches. Conditions can be of the form if (p1 or ... or ...) and (...) and ... then load pn. The previously available functionality for optional features has been reworked to use the new general framework.

Additionally serialization support has been added for writing a patch map using activation conditions via the child entry indices mechanism (see: https://github.com/w3c/IFT/pull/252).

Lastly, this PR also updates the glyph segmentation util to make use of the new condition functionality in the test encodings it produces.