### PR TITLE
In the glyph keyed segmenter implement merging of base patches

### DIFF
--- a/common/hb_set_unique_ptr.cc
+++ b/common/hb_set_unique_ptr.cc
@@ -49,10 +49,10 @@ hb_set_unique_ptr make_hb_set_from_ranges(int number_of_ranges, ...) {
   return result;
 }
 
-flat_hash_set<uint32_t> to_hash_set(const hb_set_unique_ptr& set) {
+flat_hash_set<uint32_t> to_hash_set(const hb_set_t* set) {
   flat_hash_set<uint32_t> out;
   hb_codepoint_t v = HB_SET_VALUE_INVALID;
-  while (hb_set_next(set.get(), &v)) {
+  while (hb_set_next(set, &v)) {
     out.insert(v);
   }
   return out;

--- a/common/hb_set_unique_ptr.h
+++ b/common/hb_set_unique_ptr.h
@@ -20,7 +20,7 @@ hb_set_unique_ptr make_hb_set_from_ranges(int number_of_ranges, ...);
 
 hb_set_unique_ptr make_hb_set(int length, ...);
 
-absl::flat_hash_set<uint32_t> to_hash_set(const hb_set_unique_ptr& set);
+absl::flat_hash_set<uint32_t> to_hash_set(const hb_set_t* set);
 
 }  // namespace common
 

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -12,8 +12,8 @@ cc_library(
     "@abseil-cpp//absl/container:flat_hash_map",
     "@abseil-cpp//absl/container:flat_hash_set",
     "@abseil-cpp//absl/container:btree",
-    "@abseil-cpp//absl/flags:flag",
-    "@abseil-cpp//absl/flags:parse",    
+    "@abseil-cpp//absl/log",
+    "@abseil-cpp//absl/log:initialize",
     "@harfbuzz",
   ],
   copts = [

--- a/ift/encoder/encoder.cc
+++ b/ift/encoder/encoder.cc
@@ -583,7 +583,7 @@ bool Encoder::Condition::operator<(const Condition& other) const {
 
   auto a = required_groups.begin();
   auto b = other.required_groups.begin();
-  while (a != required_groups.end() && b != required_groups.end()) {
+  while (a != required_groups.end() && b != other.required_groups.end()) {
     if (a->size() != b->size()) {
       return a->size() < b->size();
     }

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -28,7 +28,8 @@ class Encoder {
  public:
   typedef absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space_t;
 
-  // TODO(garretrieger): add api to configure brotli quality level (for glyph and table keyed).
+  // TODO(garretrieger): add api to configure brotli quality level (for glyph
+  // and table keyed).
   //                     Default to 11 but in tests run lower quality.
 
   // TODO XXXXXX be consistent with terminology used for patches/segments (ie.

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -94,6 +94,11 @@ class Encoder {
   absl::Status AddGlyphDataSegment(uint32_t segment_id,
                                    const absl::flat_hash_set<uint32_t>& gids);
 
+  // TODO(garretrieger): add a second type of activation condition which is
+  // SubsetDefinition -> segment_id. That will be used to set up the base
+  // activation conditions and then this method is only used for constructing
+  // composite conditions. Stop inferering the subset definition from the gids
+  // in a segment.
   absl::Status AddGlyphDataActivationCondition(Condition condition);
 
   /*

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -28,6 +28,9 @@ class Encoder {
  public:
   typedef absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space_t;
 
+  // TODO(garretrieger): add api to configure brotli quality level (for glyph and table keyed).
+  //                     Default to 11 but in tests run lower quality.
+
   // TODO XXXXXX be consistent with terminology used for patches/segments (ie.
   // standardize on one or the other throughout).
 

--- a/ift/encoder/encoder_test.cc
+++ b/ift/encoder/encoder_test.cc
@@ -80,7 +80,7 @@ class EncoderTest : public ::testing::Test {
     hb_set_add_sorted_array(excluded.get(), testdata::TEST_SEGMENT_4,
                             std::size(testdata::TEST_SEGMENT_4));
     hb_set_subtract(init.get(), excluded.get());
-    segment_0 = common::to_hash_set(init);
+    segment_0 = common::to_hash_set(init.get());
     segment_1 = TestSegment1();
     segment_2 = TestSegment2();
     segment_3 = TestSegment3();

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -43,7 +43,6 @@ namespace ift::encoder {
 //   - is the full analysis needed to get the or set?
 // - Add logging
 //   - timing info
-// - at the end output patch sizes by segment and patch index.
 // - Use merging and/or duplication to ensure minimum patch size.
 //   - composite patches (NOT STARTED)
 // - Multi segment combination testing with GSUB dep analysis to guide.

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -876,8 +876,6 @@ void output_set(const char* prefix, It begin, It end, std::stringstream& out) {
 }
 
 std::string GlyphSegmentation::ActivationCondition::ToString() const {
-  // TODO XXXX print condition in terms of segment numbers and not patch
-  // indices.
   std::stringstream out;
   out << "if (";
   bool first = true;

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -61,7 +61,8 @@ class GlyphSegmentation {
     }
 
     /*
-     * Populates out with the set of patch ids that are part of this condition (excluding the activated patch)
+     * Populates out with the set of patch ids that are part of this condition
+     * (excluding the activated patch)
      */
     void TriggeringPatches(hb_set_t* out) const {
       for (auto g : conditions_) {

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -162,7 +162,7 @@ class GlyphSegmentation {
   };
 
  private:
-  static void GroupsToSegmentation(
+  static absl::Status GroupsToSegmentation(
       const absl::btree_map<absl::btree_set<segment_index_t>,
                             absl::btree_set<glyph_id_t>>& and_glyph_groups,
       const absl::btree_map<absl::btree_set<segment_index_t>,

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -61,6 +61,22 @@ class GlyphSegmentation {
     }
 
     /*
+     * Populates out with the set of patch ids that are part of this condition (excluding the activated patch)
+     */
+    void TriggeringPatches(hb_set_t* out) const {
+      for (auto g : conditions_) {
+        for (auto patch_id : g) {
+          hb_set_add(out, patch_id);
+        }
+      }
+    }
+
+    /*
+     * Returns a human readable string representation of this condition.
+     */
+    std::string ToString() const;
+
+    /*
      * The patch to load when the condition is satisfied.
      */
     patch_id_t activated() const { return activated_; }
@@ -73,6 +89,12 @@ class GlyphSegmentation {
         }
       }
       return false;
+    }
+
+    bool operator<(const ActivationCondition& other) const;
+
+    bool operator==(const ActivationCondition& other) const {
+      return conditions_ == other.conditions_ && activated_ == other.activated_;
     }
 
    private:
@@ -107,7 +129,7 @@ class GlyphSegmentation {
    * The list of all conditions of how the various patches in this segmentation
    * are activated.
    */
-  const std::vector<ActivationCondition>& Conditions() const {
+  const absl::btree_set<ActivationCondition>& Conditions() const {
     return conditions_;
   }
 
@@ -153,7 +175,7 @@ class GlyphSegmentation {
   //                     built up from.
   absl::btree_set<glyph_id_t> init_font_glyphs_;
   absl::btree_set<glyph_id_t> unmapped_glyphs_;
-  std::vector<ActivationCondition> conditions_;
+  absl::btree_set<ActivationCondition> conditions_;
   absl::btree_map<patch_id_t, absl::btree_set<glyph_id_t>> patches_;
 };
 

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -1,6 +1,7 @@
 #ifndef IFT_ENCODER_GLYPH_SEGMENTATION_H_
 #define IFT_ENCODER_GLYPH_SEGMENTATION_H_
 
+#include <cstdint>
 #include <vector>
 
 #include "absl/container/btree_map.h"
@@ -82,7 +83,9 @@ class GlyphSegmentation {
   // TODO(garretrieger): also support optional feature segments.
   static absl::StatusOr<GlyphSegmentation> CodepointToGlyphSegments(
       hb_face_t* face, absl::flat_hash_set<hb_codepoint_t> initial_segment,
-      std::vector<absl::flat_hash_set<hb_codepoint_t>> codepoint_segments);
+      std::vector<absl::flat_hash_set<hb_codepoint_t>> codepoint_segments,
+      uint32_t patch_size_min_bytes = 0,
+      uint32_t patch_size_max_bytes = UINT32_MAX);
 
   /*
    * Returns a human readable string representation of this segmentation and

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -48,7 +48,8 @@ class GlyphSegmentation {
      * OR ... OR inersects(patch_n).
      */
     static ActivationCondition or_patches(
-        const absl::btree_set<patch_id_t>& ids, patch_id_t activated);
+        const absl::btree_set<patch_id_t>& ids, patch_id_t activated,
+        bool is_fallback = false);
 
     /*
      * This condition is activated if every set of patch ids intersects the
@@ -59,6 +60,8 @@ class GlyphSegmentation {
     const std::vector<absl::btree_set<patch_id_t>>& conditions() const {
       return conditions_;
     }
+
+    bool IsFallback() const { return is_fallback_; }
 
     /*
      * Populates out with the set of patch ids that are part of this condition
@@ -101,6 +104,7 @@ class GlyphSegmentation {
    private:
     ActivationCondition() : conditions_(), activated_(0) {}
 
+    bool is_fallback_ = false;
     std::vector<absl::btree_set<patch_id_t>> conditions_;
     patch_id_t activated_;
   };
@@ -167,6 +171,7 @@ class GlyphSegmentation {
                             absl::btree_set<glyph_id_t>>& and_glyph_groups,
       const absl::btree_map<absl::btree_set<segment_index_t>,
                             absl::btree_set<glyph_id_t>>& or_glyph_groups,
+      const absl::btree_set<segment_index_t>& fallback_group,
       std::vector<segment_index_t>& patch_id_to_segment_index,
       GlyphSegmentation& segmentation);
 

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -65,6 +65,16 @@ class GlyphSegmentation {
      */
     patch_id_t activated() const { return activated_; }
 
+    bool IsExclusive() const {
+      if (conditions_.size() == 1) {
+        const auto& ids = conditions_.at(0);
+        if (ids.size() == 1) {
+          return *ids.begin() == activated_;
+        }
+      }
+      return false;
+    }
+
    private:
     ActivationCondition() : conditions_(), activated_(0) {}
 
@@ -134,8 +144,13 @@ class GlyphSegmentation {
                             absl::btree_set<glyph_id_t>>& and_glyph_groups,
       const absl::btree_map<absl::btree_set<segment_index_t>,
                             absl::btree_set<glyph_id_t>>& or_glyph_groups,
+      std::vector<segment_index_t>& patch_id_to_segment_index,
       GlyphSegmentation& segmentation);
 
+  // TODO(garretrieger): the output conditions need to also capture the base
+  // codepoint segmentations since those
+  //                     form the base conditions which composite conditions are
+  //                     built up from.
   absl::btree_set<glyph_id_t> init_font_glyphs_;
   absl::btree_set<glyph_id_t> unmapped_glyphs_;
   std::vector<ActivationCondition> conditions_;

--- a/ift/encoder/glyph_segmentation_test.cc
+++ b/ift/encoder/glyph_segmentation_test.cc
@@ -123,4 +123,9 @@ if ((p2 OR p3)) then p6
 )");
 }
 
+// TODO XXXXXXXXX test where or_set glyphs are moved back to unmapped.
+// bazel run -c opt util:glyph_keyed_segments --
+// --input_font=$HOME/src/fonts/ofl/notonastaliqurdu/NotoNastaliqUrdu\[wght\].ttf
+// --number_of_segments=10 Triggers this case.
+
 }  // namespace ift::encoder

--- a/ift/glyph_keyed_diff.h
+++ b/ift/glyph_keyed_diff.h
@@ -13,8 +13,12 @@ namespace ift {
 class GlyphKeyedDiff {
  public:
   GlyphKeyedDiff(const common::FontData& font, common::CompatId base_compat_id,
-                 absl::flat_hash_set<hb_tag_t> included_tags, unsigned quality = 11)
-      : font_(font), base_compat_id_(base_compat_id), tags_(included_tags), brotli_diff_(quality) {}
+                 absl::flat_hash_set<hb_tag_t> included_tags,
+                 unsigned quality = 11)
+      : font_(font),
+        base_compat_id_(base_compat_id),
+        tags_(included_tags),
+        brotli_diff_(quality) {}
 
   absl::StatusOr<common::FontData> CreatePatch(
       const absl::btree_set<uint32_t>& gids) const;

--- a/ift/glyph_keyed_diff.h
+++ b/ift/glyph_keyed_diff.h
@@ -13,8 +13,8 @@ namespace ift {
 class GlyphKeyedDiff {
  public:
   GlyphKeyedDiff(const common::FontData& font, common::CompatId base_compat_id,
-                 absl::flat_hash_set<hb_tag_t> included_tags)
-      : font_(font), base_compat_id_(base_compat_id), tags_(included_tags) {}
+                 absl::flat_hash_set<hb_tag_t> included_tags, unsigned quality = 11)
+      : font_(font), base_compat_id_(base_compat_id), tags_(included_tags), brotli_diff_(quality) {}
 
   absl::StatusOr<common::FontData> CreatePatch(
       const absl::btree_set<uint32_t>& gids) const;

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -95,7 +95,7 @@ class IntegrationTest : public ::testing::Test {
     hb_set_add_sorted_array(excluded.get(), testdata::TEST_SEGMENT_4,
                             std::size(testdata::TEST_SEGMENT_4));
     hb_set_subtract(init.get(), excluded.get());
-    auto init_segment = common::to_hash_set(init);
+    auto init_segment = common::to_hash_set(init.get());
 
     encoder.SetFace(face.get());
 
@@ -124,7 +124,7 @@ class IntegrationTest : public ::testing::Test {
     hb_set_add_sorted_array(excluded.get(), testdata::TEST_VF_SEGMENT_4,
                             std::size(testdata::TEST_VF_SEGMENT_4));
     hb_set_subtract(init.get(), excluded.get());
-    auto init_segment = common::to_hash_set(init);
+    auto init_segment = common::to_hash_set(init.get());
 
     auto sc = encoder.AddGlyphDataSegment(0, init_segment);
     sc.Update(encoder.AddGlyphDataSegment(1, TestVfSegment1()));
@@ -154,7 +154,7 @@ class IntegrationTest : public ::testing::Test {
     hb_set_add_sorted_array(excluded.get(), testdata::TEST_FEATURE_SEGMENT_6,
                             std::size(testdata::TEST_FEATURE_SEGMENT_6));
     hb_set_subtract(init.get(), excluded.get());
-    auto init_segment = common::to_hash_set(init);
+    auto init_segment = common::to_hash_set(init.get());
 
     auto sc = encoder.AddGlyphDataSegment(0, init_segment);
     sc.Update(encoder.AddGlyphDataSegment(1, TestFeatureSegment1()));

--- a/util/BUILD
+++ b/util/BUILD
@@ -28,9 +28,9 @@ cc_binary(
 )
 
 cc_binary(
-    name = "glyph_keyed_segments",
+    name = "glyph_keyed_segmenter",
     srcs = [
-        "glyph_keyed_segments.cc",
+        "glyph_keyed_segmenter.cc",
     ],
     deps = [
         "//ift",

--- a/util/glyph_keyed_segments.cc
+++ b/util/glyph_keyed_segments.cc
@@ -36,7 +36,8 @@ ABSL_FLAG(uint32_t, number_of_segments, 2,
           "Number of segments to split the input codepoints into.");
 
 ABSL_FLAG(uint32_t, min_patch_size_bytes, 0,
-          "The segmenter will try to increase patch sizes to at least this amount via merging if needed.");
+          "The segmenter will try to increase patch sizes to at least this "
+          "amount via merging if needed.");
 
 using absl::btree_set;
 using absl::flat_hash_map;

--- a/util/glyph_keyed_segments.cc
+++ b/util/glyph_keyed_segments.cc
@@ -290,6 +290,10 @@ int main(int argc, char** argv) {
   std::cout << ">> Computed Segmentation" << std::endl;
   std::cout << result->ToString() << std::endl;
 
+  // TODO XXXXX add some QA checks on the segmentation:
+  // - Each glyph should be in at most one patch
+  // - All glyphs in the full closure should be in at least one patch.
+
   std::cout << ">> Analysis" << std::endl;
   auto cost = SegmentationSize(font->get(), *result);
   if (!cost.ok()) {

--- a/util/glyph_keyed_segments.cc
+++ b/util/glyph_keyed_segments.cc
@@ -11,6 +11,8 @@
 #include "absl/container/flat_hash_set.h"
 #include "absl/flags/flag.h"
 #include "absl/flags/parse.h"
+#include "absl/log/globals.h"
+#include "absl/log/initialize.h"
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "common/font_data.h"
@@ -25,6 +27,10 @@
  * segmentation and associated activation conditions that maintain the "closure
  * requirement".
  */
+
+// TODO XXXXX better name for this util
+// TODO XXXXX for ideal segmentation match the actual number of base segments
+// after merging.
 
 ABSL_FLAG(std::string, input_font, "in.ttf",
           "Name of the font to convert to IFT.");
@@ -266,7 +272,9 @@ std::vector<flat_hash_set<uint32_t>> GroupCodepoints(
 }
 
 int main(int argc, char** argv) {
+  absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
   auto args = absl::ParseCommandLine(argc, argv);
+  absl::InitializeLog();
 
   auto font = LoadFont(absl::GetFlag(FLAGS_input_font).c_str());
   if (!font.ok()) {

--- a/util/glyph_keyed_segments.cc
+++ b/util/glyph_keyed_segments.cc
@@ -1,5 +1,6 @@
 #include <google/protobuf/text_format.h>
 
+#include <cstdint>
 #include <cstdio>
 #include <fstream>
 #include <iostream>
@@ -38,6 +39,10 @@ ABSL_FLAG(uint32_t, number_of_segments, 2,
 ABSL_FLAG(uint32_t, min_patch_size_bytes, 0,
           "The segmenter will try to increase patch sizes to at least this "
           "amount via merging if needed.");
+
+ABSL_FLAG(uint32_t, max_patch_size_bytes, UINT32_MAX,
+          "The segmenter will avoid merges which result in patches larger than "
+          "this amount.");
 
 using absl::btree_set;
 using absl::flat_hash_map;
@@ -281,7 +286,8 @@ int main(int argc, char** argv) {
       GroupCodepoints(*codepoints, absl::GetFlag(FLAGS_number_of_segments));
 
   auto result = ift::encoder::GlyphSegmentation::CodepointToGlyphSegments(
-      font->get(), {}, groups, absl::GetFlag(FLAGS_min_patch_size_bytes));
+      font->get(), {}, groups, absl::GetFlag(FLAGS_min_patch_size_bytes),
+      absl::GetFlag(FLAGS_max_patch_size_bytes));
   if (!result.ok()) {
     std::cerr << result.status() << std::endl;
     return -1;

--- a/util/glyph_keyed_segments.cc
+++ b/util/glyph_keyed_segments.cc
@@ -35,6 +35,9 @@ ABSL_FLAG(
 ABSL_FLAG(uint32_t, number_of_segments, 2,
           "Number of segments to split the input codepoints into.");
 
+ABSL_FLAG(uint32_t, min_patch_size_bytes, 0,
+          "The segmenter will try to increase patch sizes to at least this amount via merging if needed.");
+
 using absl::btree_set;
 using absl::flat_hash_map;
 using absl::flat_hash_set;
@@ -277,7 +280,7 @@ int main(int argc, char** argv) {
       GroupCodepoints(*codepoints, absl::GetFlag(FLAGS_number_of_segments));
 
   auto result = ift::encoder::GlyphSegmentation::CodepointToGlyphSegments(
-      font->get(), {}, groups);
+      font->get(), {}, groups, absl::GetFlag(FLAGS_min_patch_size_bytes));
   if (!result.ok()) {
     std::cerr << result.status() << std::endl;
     return -1;


### PR DESCRIPTION
Base patches are those that contain glyphs exclusive to the codepoints that map to them. This PR adds support for automatically merging these together to meet a configured minimum patch size. The merger use dependency information from the conditional patches activation rules to find base patches that are likely to interact and uses those as candidates for merging. This reduces the overall number of conditional patches needed which ultimately reduces overhead.

Support for merging conditional patches together is not yet implemented.