### PR TITLE
Add CFF/CFF2 charstring offsets to encoded fonts.

### DIFF
--- a/common/font_helper.h
+++ b/common/font_helper.h
@@ -148,6 +148,12 @@ class FontHelper {
                                          FontData& non_charstrings,
                                          FontData& charstrings);
 
+  static absl::StatusOr<std::optional<uint32_t>> CffCharStringsOffset(
+      hb_face_t* face);
+
+  static absl::StatusOr<std::optional<uint32_t>> Cff2CharStringsOffset(
+      hb_face_t* face);
+
   static absl::StatusOr<uint32_t> GvarSharedTupleCount(const hb_face_t* face);
 
   static absl::StatusOr<absl::string_view> Loca(const hb_face_t* face) {

--- a/common/font_helper_test.cc
+++ b/common/font_helper_test.cc
@@ -1,6 +1,7 @@
 #include "common/font_helper.h"
 
 #include <cstdint>
+#include <optional>
 
 #include "absl/container/flat_hash_map.h"
 #include "common/font_data.h"
@@ -404,7 +405,26 @@ TEST_F(FontHelperTest, Cff2Data) {
   ASSERT_EQ(data.size(), 0);
 }
 
+TEST_F(FontHelperTest, CffGetCharstrings) {
+  auto offset = FontHelper::CffCharStringsOffset(noto_sans_jp_otf.get());
+  ASSERT_TRUE(offset.ok()) << offset.status();
+  ASSERT_EQ(**offset, 0xa7ed);
+}
+
 TEST_F(FontHelperTest, Cff2GetCharstrings) {
+  auto offset = FontHelper::Cff2CharStringsOffset(noto_sans_vf_jp_otf.get());
+  ASSERT_TRUE(offset.ok()) << offset.status();
+  ASSERT_EQ(**offset, 0x8f);
+}
+
+TEST_F(FontHelperTest, Cff2GetCharstrings_NoTable) {
+  auto offset = FontHelper::Cff2CharStringsOffset(
+      noto_sans_jp_otf.get());  // does not have CFF2
+  ASSERT_TRUE(offset.ok()) << offset.status();
+  ASSERT_EQ(*offset, std::nullopt);
+}
+
+TEST_F(FontHelperTest, Cff2GetCharstringsOffset) {
   FontData noncharstrings;
   FontData charstrings;
   auto status = FontHelper::Cff2GetCharstrings(noto_sans_vf_jp_otf.get(),

--- a/ift/proto/format_2_patch_map.h
+++ b/ift/proto/format_2_patch_map.h
@@ -1,6 +1,8 @@
 #ifndef IFT_PROTO_FORMAT_2_PATCH_MAP_H_
 #define IFT_PROTO_FORMAT_2_PATCH_MAP_H_
 
+#include <optional>
+
 #include "absl/status/statusor.h"
 #include "ift/proto/ift_table.h"
 
@@ -8,7 +10,9 @@ namespace ift::proto {
 
 class Format2PatchMap {
  public:
-  static absl::StatusOr<std::string> Serialize(const IFTTable& ift_table);
+  static absl::StatusOr<std::string> Serialize(
+      const IFTTable& ift_table, std::optional<uint32_t> cff_charstrings_offset,
+      std::optional<uint32_t> cff2_charstrings_offset);
 };
 
 }  // namespace ift::proto

--- a/ift/proto/format_2_patch_map_test.cc
+++ b/ift/proto/format_2_patch_map_test.cc
@@ -18,30 +18,29 @@ class Format2PatchMapTest : public ::testing::Test {
   Format2PatchMapTest() {}
 };
 
-static std::string HeaderSimple(uint8_t entry_count = 1, uint8_t offset_delta = 0) {
-  std::string part1 {
-    0x02,  // format
-    0x00, 0x00, 0x00,
-    0x00,  // reserved
-    0x00, 0x00, 0x00,
-    0x01, 0x00, 0x00,
-    0x00, 0x02, 0x00,
-    0x00, 0x00, 0x03,
-    0x00, 0x00, 0x00,
-    0x04,                           // compat id
-    0x01,                           // default format = Table Keyed Full
-    0x00, 0x00, (char)entry_count,  // entry count
-    0x00, 0x00, 0x00};
+static std::string HeaderSimple(uint8_t entry_count = 1,
+                                uint8_t offset_delta = 0) {
+  std::string part1{0x02,  // format
+                    0x00, 0x00, 0x00,
+                    0x00,  // reserved
+                    0x00, 0x00, 0x00,
+                    0x01, 0x00, 0x00,
+                    0x00, 0x02, 0x00,
+                    0x00, 0x00, 0x03,
+                    0x00, 0x00, 0x00,
+                    0x04,  // compat id
+                    0x01,  // default format = Table Keyed Full
+                    0x00, 0x00, (char)entry_count,  // entry count
+                    0x00, 0x00, 0x00};
 
-  std::string part2 {
-    0x00, 0x00, 0x00,
-    0x00,        // entry id string data offset
-    0x00, 0x06,  // uri template length
-    0x66, 0x6f, 0x6f,
-    0x2f, 0x24, 0x31,
+  std::string part2{
+      0x00, 0x00, 0x00,
+      0x00,        // entry id string data offset
+      0x00, 0x06,  // uri template length
+      0x66, 0x6f, 0x6f, 0x2f, 0x24, 0x31,
   };
 
-  part1 += (char) ((uint8_t) 0x29 + offset_delta);
+  part1 += (char)((uint8_t)0x29 + offset_delta);
   part1 += part2;
   return part1;
 }
@@ -80,9 +79,7 @@ TEST_F(Format2PatchMapTest, Simple_WithCffOffset) {
   auto encoded = Format2PatchMap::Serialize(table, 0x7856, std::nullopt);
   ASSERT_TRUE(encoded.ok()) << encoded.status();
 
-  std::string cff_offset = {
-      0x00, 0x00, 0x78, 0x56
-  };
+  std::string cff_offset = {0x00, 0x00, 0x78, 0x56};
 
   std::string entry_0 = {
       // entry 0
@@ -105,9 +102,7 @@ TEST_F(Format2PatchMapTest, Simple_WithCff2Offset) {
   auto encoded = Format2PatchMap::Serialize(table, std::nullopt, 0x127856);
   ASSERT_TRUE(encoded.ok()) << encoded.status();
 
-  std::string cff2_offset = {
-      0x00, 0x12, 0x78, 0x56
-  };
+  std::string cff2_offset = {0x00, 0x12, 0x78, 0x56};
 
   std::string entry_0 = {
       // entry 0
@@ -131,8 +126,7 @@ TEST_F(Format2PatchMapTest, Simple_WithCffAndCff2Offset) {
   ASSERT_TRUE(encoded.ok()) << encoded.status();
 
   std::string offsets = {
-    0x00, 0x00, 0x01, 0x23,
-    0x00, 0x00, 0x04, 0x56,
+      0x00, 0x00, 0x01, 0x23, 0x00, 0x00, 0x04, 0x56,
   };
 
   std::string entry_0 = {

--- a/ift/proto/ift_table.cc
+++ b/ift/proto/ift_table.cc
@@ -2,6 +2,7 @@
 
 #include <algorithm>
 #include <cstdint>
+#include <optional>
 #include <string>
 
 #include "absl/container/flat_hash_map.h"
@@ -99,7 +100,10 @@ StatusOr<FontData> IFTTable::AddToFont(
 absl::StatusOr<common::FontData> IFTTable::AddToFont(
     hb_face_t* face, const IFTTable& main,
     std::optional<const IFTTable*> extension) {
-  auto main_bytes = Format2PatchMap::Serialize(main);
+  // TODO XXXXX check for CFF/CFF2 and set offset as needed. Only set on the
+  // main table.
+  auto main_bytes =
+      Format2PatchMap::Serialize(main, std::nullopt, std::nullopt);
   if (!main_bytes.ok()) {
     return main_bytes.status();
   }
@@ -107,7 +111,8 @@ absl::StatusOr<common::FontData> IFTTable::AddToFont(
   StatusOr<std::string> ext_bytes;
   std::optional<absl::string_view> ext_view;
   if (extension) {
-    ext_bytes = Format2PatchMap::Serialize(**extension);
+    ext_bytes =
+        Format2PatchMap::Serialize(**extension, std::nullopt, std::nullopt);
     if (!ext_bytes.ok()) {
       return ext_bytes.status();
     }

--- a/ift/proto/ift_table_test.cc
+++ b/ift/proto/ift_table_test.cc
@@ -83,7 +83,8 @@ TEST_F(IFTTableTest, AddToFont) {
 
   FontData data(blob.get());
 
-  std::string expected = *Format2PatchMap::Serialize(sample);
+  std::string expected =
+      *Format2PatchMap::Serialize(sample, std::nullopt, std::nullopt);
   FontData expected_data(expected);
 
   ASSERT_EQ(data, expected_data);
@@ -110,8 +111,10 @@ TEST_F(IFTTableTest, AddToFont_WithExtension) {
   FontData iftx_table =
       FontHelper::TableData(face.get(), HB_TAG('I', 'F', 'T', 'X'));
 
-  FontData expected_ift(*Format2PatchMap::Serialize(sample));
-  FontData expected_iftx(*Format2PatchMap::Serialize(sample_with_extensions));
+  FontData expected_ift(
+      *Format2PatchMap::Serialize(sample, std::nullopt, std::nullopt));
+  FontData expected_iftx(*Format2PatchMap::Serialize(
+      sample_with_extensions, std::nullopt, std::nullopt));
   ASSERT_EQ(ift_table, expected_ift);
   ASSERT_EQ(iftx_table, expected_iftx);
 


### PR DESCRIPTION
Matches the spec changes in https://github.com/w3c/IFT/pull/265, https://github.com/w3c/IFT/issues/260