### PR TITLE
Add an end to end testing shell script.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -11,6 +11,7 @@ bazel_dep(name = "protobuf", version = "29.3")
 bazel_dep(name = "rules_proto", version = "7.1.0")
 bazel_dep(name = "platforms", version = "0.0.11")
 bazel_dep(name = "rules_rust", version = "0.56.0")
+bazel_dep(name = "glib", version = "2.82.2.bcr.5")
 
 # Non Bazel Modules
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/third_party/harfbuzz.BUILD
+++ b/third_party/harfbuzz.BUILD
@@ -7,6 +7,28 @@ config_setting(
     ],
 )
 
+cc_binary(
+    name = "hb-shape",
+    srcs = [
+        "util/hb-shape.cc",
+        "util/batch.hh",
+        "util/options.hh",
+        "util/font-options.hh",
+        "util/face-options.hh",
+        "util/main-font-text.hh",
+        "util/shape-consumer.hh",
+        "util/shape-options.hh",
+        "util/shape-output.hh",
+        "util/shape-format.hh",
+        "util/text-options.hh",
+        "util/output-options.hh",
+    ],
+    deps = [
+        ":harfbuzz",
+        "@glib//glib",
+    ],
+)
+
 cc_library(
     name = "harfbuzz",
     srcs = glob(

--- a/third_party/harfbuzz/BUILD
+++ b/third_party/harfbuzz/BUILD
@@ -2,6 +2,7 @@ cc_library(
     name = "config",
     hdrs = [
         "config.h",
+        "hb-features.h",
     ],
     includes = [
         "./",

--- a/third_party/harfbuzz/hb-features.h
+++ b/third_party/harfbuzz/hb-features.h
@@ -1,0 +1,2 @@
+#define PACKAGE_NAME "HarfBuzz"
+#define PACKAGE_VERSION "11.0.0"

--- a/util/end-to-end.sh
+++ b/util/end-to-end.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# This script does an end to end test on an IFT font encoding.
+#
+# Given a font, an encoder config, and a text sample it produces the IFT encoded font.
+# Extends it with an IFT client for the text sample. Then finally compares the rendering
+# of that text sample by the extended font against the original input font.
+#
+# Comparison is made using a locally compiled version of hb-shape. Additional, if there 
+# is an installed copy of hb-view that's also used to compare actual rendering (ie. `which hb-view` returns something).
+#
+# Usage:
+# end-to-end.sh <path to font> <path to config> <text string>
+
+FONT=$(readlink -f $1)
+CONFIG=$(readlink -f $2)
+TEXT_SAMPLE=$3
+WORKING_DIR=$(mktemp -d)
+
+# TODO(garretrieger): take an optional design space position
+# TODO(garretrieger): take an optional list of feature tags
+
+# Locate hb-view if available
+HB_VIEW=$(which hb-view)
+
+# Create the IFT encoding
+bazel run //util:font2ift -- \
+  --input_font="$FONT" --config="$CONFIG" \
+  --output_path="$WORKING_DIR" --output_font="ift_font.ttf" 2> /dev/null 1> /dev/null
+
+# Run an extesion on it using the provided text
+bazel run @fontations//:ift_extend -- \
+  --font=$WORKING_DIR/ift_font.ttf --text="$TEXT_SAMPLE" -o $WORKING_DIR/extended.ttf 2> /dev/null 1> /dev/null
+
+# Compare shaping
+bazel run @harfbuzz//:hb-shape -- \
+  $FONT --text="$TEXT_SAMPLE" > $WORKING_DIR/original_shaping.txt 2> /dev/null
+bazel run @harfbuzz//:hb-shape -- \
+  $WORKING_DIR/extended.ttf --text="$TEXT_SAMPLE" > $WORKING_DIR/extended_shaping.txt 2> /dev/null
+
+diff -u $WORKING_DIR/original_shaping.txt $WORKING_DIR/extended_shaping.txt > $WORKING_DIR/diff.txt
+
+SHAPE_RETCODE=$?
+if [ $SHAPE_RETCODE -ne 0 ]; then
+  echo "Shaping Comparison: FAILED"
+  cat $WORKING_DIR/diff.txt
+  echo ""
+else
+  echo "Shaping Comparison: SUCCESS"
+fi
+
+VIEW_RETCODE=0
+if [[ -n "$HB_VIEW" ]]; then
+  $HB_VIEW $FONT --text="$TEXT_SAMPLE" -o $WORKING_DIR/original.svg -O svg
+  $HB_VIEW $WORKING_DIR/extended.ttf --text="$TEXT_SAMPLE" -o $WORKING_DIR/extended.svg -O svg
+  diff -u $WORKING_DIR/original.svg $WORKING_DIR/extended.svg > $WORKING_DIR/diff.txt
+  VIEW_RETCODE=$?
+  if [ $VIEW_RETCODE -ne 0 ]; then
+    echo "Rendering Comparison: FAILED"
+    cat $WORKING_DIR/diff.txt
+  else
+    echo "Rendering Comparison: SUCCESS"
+  fi
+  rm $WORKING_DIR/*.svg
+else
+  echo "Rendering Comparison: SKIPPED (hb-view not found)"
+fi
+
+rm $WORKING_DIR/*.ttf
+rm $WORKING_DIR/*.txt
+rm $WORKING_DIR/*.ift_tk
+rm $WORKING_DIR/*.ift_gk
+rmdir $WORKING_DIR
+
+if [ $SHAPE_RETCODE -ne 0 ] || [ $VIEW_RETCODE -ne 0 ]; then
+  exit -1
+fi
+exit 0


### PR DESCRIPTION
Generates an ift font from a config, extends it for a given text sample, and then compares the resutls of shaping/rendering the original and extended version.