### PR TITLE
Create a wrapper around hb_set_t, IntSet, that acts like a standard collection class.

### DIFF
--- a/common/BUILD
+++ b/common/BUILD
@@ -113,5 +113,6 @@ cc_test(
         ":mocks",
         "@googletest//:gtest_main",
         "@abseil-cpp//absl/container:btree",
+        "@abseil-cpp//absl/hash:hash_test",
     ],
 )

--- a/common/BUILD
+++ b/common/BUILD
@@ -35,6 +35,7 @@ cc_library(
         "hasher.h",
         "compat_id.h",
         "try.h",
+        "int_set.h",
     ],
     visibility = [
         "//visibility:public",
@@ -101,6 +102,7 @@ cc_test(
         "font_helper_test.cc",
         "sparse_bit_set_test.cc",
         "woff2_test.cc",
+        "int_set_test.cc",
     ],
     data = [
         "//common:testdata",

--- a/common/int_set.h
+++ b/common/int_set.h
@@ -140,10 +140,14 @@ class IntSet {
     return a == this->end();
   }
 
-  // TODO(garretrieger): add union, intersection etc.
+  template <typename H>
+  friend H AbslHashValue(H h, const IntSet& set) {
+    // Utilize the existing harfbuzz hashing function.
+    unsigned harfbuzz_hash = hb_set_hash(set.set_.get());
+    return H::combine(std::move(h), harfbuzz_hash);
+  }
 
-  // TODO(garretrieger): add absl hashing support so we can use these in
-  // hash_sets/maps
+  // TODO(garretrieger): add union, intersection etc.
 
   iterator begin() { return iterator(set_.get()); }
 

--- a/common/int_set.h
+++ b/common/int_set.h
@@ -78,8 +78,12 @@ class IntSet {
   }
 
   // TODO(garretrieger): construct from hb_set_t* or hb_set_unique_ptr.
+  // TODO(garretrieger): copy assignment operator
 
-  IntSet(const IntSet&) = delete;  // TODO(garretrieger): implement this.
+  IntSet(const IntSet& other) : set_(make_hb_set()) {
+    hb_set_union(set_.get(), other.set_.get());
+  }
+
   IntSet& operator=(const IntSet&) =
       delete;  // TODO(garretrieger): implement this.
 

--- a/common/int_set.h
+++ b/common/int_set.h
@@ -94,8 +94,36 @@ class IntSet {
     return *this;
   }
 
-  // TODO(garretrieger): add operator==
-  // TODO(garretrieger): add operator< so we can use thse in btree_sets/maps
+  bool operator==(const IntSet& other) const {
+    return hb_set_is_equal(this->set_.get(), other.set_.get());
+  }
+
+  bool operator!=(const IntSet& other) const { return !(*this == other); }
+
+  bool operator<(const IntSet& other) const {
+    auto a = this->begin();
+    auto b = other.begin();
+
+    while (a != this->end() && b != this->end()) {
+      if (*a < *b) {
+        return true;
+      } else if (*a > *b) {
+        return false;
+      }
+      // otherwise elements are equal, check the next
+      ++a;
+      ++b;
+    }
+
+    if (a == b) {
+      // sets are equal
+      return false;
+    }
+
+    // Otherwise only one of a or b is at the end, the shorter set comes first
+    return a == this->end();
+  }
+
   // TODO(garretrieger): add absl hashing support so we can use these in
   // hash_sets/maps
 

--- a/common/int_set_test.cc
+++ b/common/int_set_test.cc
@@ -2,6 +2,7 @@
 
 #include "common/hb_set_unique_ptr.h"
 #include "gtest/gtest.h"
+#include "absl/hash/hash_testing.h"
 
 namespace common {
 
@@ -200,6 +201,31 @@ TEST_F(IntSetTest, UseInBtreeSet) {
   ASSERT_EQ(*it, empty);
 }
 
-// TODO(garretrieger): test use in hash and btree, sets and maps.
+TEST_F(IntSetTest, UseInHashSet) {
+  absl::flat_hash_set<IntSet> sets{{7, 8, 11}, {7, 8}, {7, 8, 12}, {}};
+
+  IntSet empty{};
+  IntSet a{7, 8};
+  IntSet b{7, 8, 11};
+  IntSet c{7, 8, 12};
+  IntSet d{8, 11};
+
+  ASSERT_TRUE(sets.contains(empty));
+  ASSERT_TRUE(sets.contains(a));
+  ASSERT_TRUE(sets.contains(b));
+  ASSERT_TRUE(sets.contains(c));
+  ASSERT_FALSE(sets.contains(d));
+}
+
+TEST_F(IntSetTest, SupportsAbslHash) {
+  EXPECT_TRUE(absl::VerifyTypeImplementsAbslHashCorrectly({
+      IntSet {},
+      IntSet {7, 8},
+      IntSet {7, 8, 11},
+      IntSet {7, 8, 12},
+      IntSet {8, 11},
+      IntSet {7, 8, 12},
+  }));
+}
 
 }  // namespace common

--- a/common/int_set_test.cc
+++ b/common/int_set_test.cc
@@ -34,6 +34,46 @@ TEST_F(IntSetTest, BasicOperations) {
   ASSERT_FALSE(set.contains(7));
 }
 
+TEST_F(IntSetTest, Equality) {
+  IntSet a{1, 2, 1000};
+  IntSet b{1, 1000, 2};
+  IntSet c{1, 2, 1000, 1001};
+
+  ASSERT_TRUE(a == a);
+  ASSERT_FALSE(a != a);
+
+  ASSERT_TRUE(a == b);
+  ASSERT_FALSE(a != b);
+
+  ASSERT_FALSE(a == c);
+  ASSERT_TRUE(a != c);
+
+  ASSERT_FALSE(b == c);
+  ASSERT_TRUE(b != c);
+}
+
+TEST_F(IntSetTest, LessThan) {
+  // These are in the appropriate sorted order
+  IntSet empty;
+  IntSet a{7, 8};
+  IntSet b{7, 8, 11};
+  IntSet c{7, 8, 12};
+  IntSet d{8, 11};
+
+  // Self comparisons
+  ASSERT_FALSE(empty < empty);
+  ASSERT_FALSE(a < a);
+
+  // Ordering
+  ASSERT_TRUE(a < b);
+  ASSERT_TRUE(b < c);
+  ASSERT_TRUE(c < d);
+
+  ASSERT_FALSE(b < a);
+  ASSERT_FALSE(c < b);
+  ASSERT_FALSE(d < c);
+}
+
 TEST_F(IntSetTest, InitList) {
   IntSet set{10, 1000};
   ASSERT_TRUE(set.contains(10));

--- a/common/int_set_test.cc
+++ b/common/int_set_test.cc
@@ -103,6 +103,18 @@ TEST_F(IntSetTest, Move) {
   ASSERT_EQ(b.size(), 0);
 }
 
+TEST_F(IntSetTest, CopyConstructor) {
+  IntSet a{13, 47};
+  IntSet b(a);
+
+  ASSERT_EQ(a, b);
+  ASSERT_TRUE(a.contains(13));
+  ASSERT_TRUE(a.contains(47));
+
+  ASSERT_TRUE(b.contains(13));
+  ASSERT_TRUE(b.contains(47));
+}
+
 TEST_F(IntSetTest, EmptySetIteration) {
   IntSet empty;
   ASSERT_EQ(empty.begin(), empty.end());
@@ -130,6 +142,24 @@ TEST_F(IntSetTest, ForLoop) {
   for (auto v : set) {
     ASSERT_EQ(v, expected[index++]);
   }
+}
+
+TEST_F(IntSetTest, UseInBtreeSet) {
+  absl::btree_set<IntSet> sets{{7, 8, 11}, {7, 8}, {7, 8, 12}, {}};
+
+  IntSet empty{};
+  IntSet a{7, 8};
+  IntSet b{7, 8, 11};
+  IntSet c{7, 8, 12};
+  IntSet d{8, 11};
+
+  ASSERT_TRUE(sets.contains(a));
+  ASSERT_TRUE(sets.contains(b));
+  ASSERT_TRUE(sets.contains(c));
+  ASSERT_FALSE(sets.contains(d));
+
+  auto it = sets.begin();
+  ASSERT_EQ(*it, empty);
 }
 
 // TODO(garretrieger): test use in hash and btree, sets and maps.

--- a/common/int_set_test.cc
+++ b/common/int_set_test.cc
@@ -1,5 +1,6 @@
 #include "common/int_set.h"
 
+#include "common/hb_set_unique_ptr.h"
 #include "gtest/gtest.h"
 
 namespace common {
@@ -115,6 +116,43 @@ TEST_F(IntSetTest, CopyConstructor) {
   ASSERT_TRUE(b.contains(47));
 }
 
+TEST_F(IntSetTest, CopyHbSet) {
+  hb_set_unique_ptr hb_set = make_hb_set(2, 13, 47);
+
+  IntSet a(hb_set.get());
+  IntSet b(hb_set);
+
+  // Make sure chaing hb_set doesn't cause changes in the IntSet's
+  hb_set_add(hb_set.get(), 49);
+
+  IntSet expected {13, 47};
+
+  ASSERT_EQ(a, expected);
+  ASSERT_EQ(b, expected);
+
+  ASSERT_TRUE(a.contains(13));
+  ASSERT_TRUE(a.contains(47));
+  ASSERT_FALSE(a.contains(49));
+
+  ASSERT_TRUE(b.contains(13));
+  ASSERT_TRUE(b.contains(47));
+  ASSERT_FALSE(b.contains(49));
+}
+
+TEST_F(IntSetTest, Assignment) {
+  IntSet a{13, 47};
+  IntSet b{5, 9};
+
+  b = a;
+
+  ASSERT_EQ(a, b);
+  ASSERT_TRUE(a.contains(13));
+  ASSERT_TRUE(a.contains(47));
+
+  ASSERT_TRUE(b.contains(13));
+  ASSERT_TRUE(b.contains(47));
+}
+
 TEST_F(IntSetTest, EmptySetIteration) {
   IntSet empty;
   ASSERT_EQ(empty.begin(), empty.end());
@@ -163,6 +201,5 @@ TEST_F(IntSetTest, UseInBtreeSet) {
 }
 
 // TODO(garretrieger): test use in hash and btree, sets and maps.
-// TODO(garretrieger): test various operators (<, >, ==, !=)
 
 }  // namespace common

--- a/common/int_set_test.cc
+++ b/common/int_set_test.cc
@@ -1,0 +1,98 @@
+#include "common/int_set.h"
+
+#include "gtest/gtest.h"
+
+namespace common {
+
+class IntSetTest : public ::testing::Test {};
+
+TEST_F(IntSetTest, BasicOperations) {
+  IntSet set;
+  ASSERT_TRUE(set.empty());
+
+  set.add(5);
+  set.add(7);
+  set.add(7);
+  set.add(8);
+
+  ASSERT_FALSE(set.contains(4));
+  ASSERT_TRUE(set.contains(5));
+  ASSERT_FALSE(set.contains(6));
+  ASSERT_TRUE(set.contains(7));
+  ASSERT_TRUE(set.contains(8));
+
+  ASSERT_EQ(set.size(), 3);
+  ASSERT_FALSE(set.empty());
+
+  set.erase(4);
+  ASSERT_EQ(set.size(), 3);
+  ASSERT_FALSE(set.empty());
+
+  set.erase(7);
+  ASSERT_EQ(set.size(), 2);
+  ASSERT_FALSE(set.empty());
+  ASSERT_FALSE(set.contains(7));
+}
+
+TEST_F(IntSetTest, InitList) {
+  IntSet set{10, 1000};
+  ASSERT_TRUE(set.contains(10));
+  ASSERT_FALSE(set.contains(100));
+  ASSERT_TRUE(set.contains(1000));
+}
+
+TEST_F(IntSetTest, Move) {
+  IntSet a{10, 1000};
+
+  IntSet b(std::move(a));
+
+  ASSERT_TRUE(b.contains(10));
+  ASSERT_FALSE(b.contains(100));
+  ASSERT_TRUE(b.contains(1000));
+
+  // We gaurantee moved values remain valid after a move.
+  ASSERT_EQ(a.size(), 0);
+
+  a = std::move(b);
+
+  ASSERT_TRUE(a.contains(10));
+  ASSERT_FALSE(a.contains(100));
+  ASSERT_TRUE(a.contains(1000));
+
+  // We gaurantee moved values remain valid after a move.
+  ASSERT_EQ(b.size(), 0);
+}
+
+TEST_F(IntSetTest, EmptySetIteration) {
+  IntSet empty;
+  ASSERT_EQ(empty.begin(), empty.end());
+}
+
+TEST_F(IntSetTest, BasicIteration) {
+  IntSet set{7, 9, 10};
+  auto it = set.begin();
+
+  ASSERT_NE(it, set.end());
+  ASSERT_EQ(*it, 7);
+  ASSERT_EQ(*it++, 7);
+  ASSERT_EQ(*it, 9);
+  ASSERT_EQ(*(++it), 10);
+  ASSERT_EQ(*it, 10);
+  ++it;
+  ASSERT_EQ(it, set.end());
+}
+
+TEST_F(IntSetTest, ForLoop) {
+  IntSet set{7, 9, 10};
+  int expected[] = {7, 9, 10};
+
+  int index = 0;
+  for (auto v : set) {
+    ASSERT_EQ(v, expected[index++]);
+  }
+}
+
+// TODO(garretrieger): test use in hash and btree, sets and maps.
+// TODO(garretrieger): test various operators (<, >, ==, !=)
+
+}  // namespace common


### PR DESCRIPTION
Also supports being used as a key and value in absl collection classes (btree_set/map, flat_hash_set/map). This will allow more broad usage of hb set's throughout the encoder code and avoid having to change back and forth between absl collection types and hb_set's.