### PR TITLE
[closure segmenter] remove conditions that become empty.

### DIFF
--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -350,6 +350,15 @@ Status GroupGlyphs(SegmentationContext& context) {
     }
   }
 
+  // Remove any or_glyph_groups which are now empty.
+  for (auto it = context.or_glyph_groups.cbegin(); it != context.or_glyph_groups.cend();) {
+    if (it->second.empty()) {
+      it = context.or_glyph_groups.erase(it);
+    } else {
+      it++;
+    }
+  }
+
   for (uint32_t gid : context.unmapped_glyphs) {
     // this glyph is not activated anywhere but is needed in the full closure
     // so add it to an activation condition of any segment.

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -351,7 +351,8 @@ Status GroupGlyphs(SegmentationContext& context) {
   }
 
   // Remove any or_glyph_groups which are now empty.
-  for (auto it = context.or_glyph_groups.cbegin(); it != context.or_glyph_groups.cend();) {
+  for (auto it = context.or_glyph_groups.cbegin();
+       it != context.or_glyph_groups.cend();) {
     if (it->second.empty()) {
       it = context.or_glyph_groups.erase(it);
     } else {

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -237,6 +237,14 @@ bool GlyphSegmentation::ActivationCondition::operator<(
     return activated_ < other.activated_;
   }
 
+  if (is_exclusive_ != other.is_exclusive_) {
+    return is_exclusive_;
+  }
+
+  if (is_fallback_ != other.is_fallback_) {
+    return !is_fallback_;
+  }
+
   // These two are equal
   return false;
 }

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -115,7 +115,14 @@ class GlyphSegmentation {
     bool operator<(const ActivationCondition& other) const;
 
     bool operator==(const ActivationCondition& other) const {
-      return conditions_ == other.conditions_ && activated_ == other.activated_;
+      return conditions_ == other.conditions_ &&
+             activated_ == other.activated_ &&
+             is_fallback_ == other.is_fallback_ &&
+             is_exclusive_ == other.is_exclusive_;
+    }
+
+    bool operator!=(const ActivationCondition& other) const {
+      return !(*this == other);
     }
 
    private:

--- a/ift/encoder/glyph_segmentation_test.cc
+++ b/ift/encoder/glyph_segmentation_test.cc
@@ -15,6 +15,7 @@ using common::FontData;
 using common::hb_face_unique_ptr;
 using common::IntSet;
 using common::make_hb_face;
+using common::SegmentSet;
 using google::protobuf::TextFormat;
 
 namespace ift::encoder {
@@ -373,6 +374,51 @@ glyph_patch_conditions {
 initial_codepoints {
 }
 )");
+}
+
+TEST_F(GlyphSegmentationTest, ActivationConditionOrdering) {
+  auto a = GlyphSegmentation::ActivationCondition::exclusive_segment(4, 8);
+  auto b =
+      GlyphSegmentation::ActivationCondition::and_segments(SegmentSet{4}, 8);
+  auto c =
+      GlyphSegmentation::ActivationCondition::and_segments(SegmentSet{4}, 9);
+
+  auto d =
+      GlyphSegmentation::ActivationCondition::or_segments(SegmentSet{4, 5}, 9);
+  auto e =
+      GlyphSegmentation::ActivationCondition::or_segments(SegmentSet{4, 6}, 9);
+
+  auto f =
+      GlyphSegmentation::ActivationCondition::and_segments(SegmentSet{4, 5}, 9);
+  auto g =
+      GlyphSegmentation::ActivationCondition::and_segments(SegmentSet{4, 6}, 9);
+
+  ASSERT_EQ(a, a);
+  ASSERT_EQ(b, b);
+  ASSERT_EQ(c, c);
+  ASSERT_EQ(d, d);
+  ASSERT_EQ(e, e);
+  ASSERT_EQ(f, f);
+  ASSERT_EQ(g, g);
+
+  ASSERT_NE(a, b);
+  ASSERT_NE(b, c);
+  ASSERT_NE(d, e);
+  ASSERT_NE(f, g);
+
+  ASSERT_LT(a, b);
+  ASSERT_LT(b, c);
+  ASSERT_LT(c, d);
+  ASSERT_LT(d, e);
+  ASSERT_LT(e, f);
+  ASSERT_LT(f, g);
+
+  ASSERT_FALSE(b < a);
+  ASSERT_FALSE(c < b);
+  ASSERT_FALSE(d < c);
+  ASSERT_FALSE(e < d);
+  ASSERT_FALSE(f < e);
+  ASSERT_FALSE(g < f);
 }
 
 // TODO(garretrieger): add test where or_set glyphs are moved back to unmapped


### PR DESCRIPTION
Glyphs can be removed from a condition if additional conditions are detected. If all glyphs are removed from a condition then the condition should be removed.