### PR TITLE
[closure segmenter] Add incremental glyph grouping to the closure segmenter merging loop.

### DIFF
--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -17,6 +17,7 @@ cc_library(
     "//ift",
     "//util:encoder_config_cc_proto",
     "@abseil-cpp//absl/container:flat_hash_map",
+    "@abseil-cpp//absl/container:node_hash_map",
     "@abseil-cpp//absl/container:flat_hash_set",
     "@abseil-cpp//absl/container:btree",
     "@abseil-cpp//absl/log",

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -433,8 +433,8 @@ Status GroupGlyphs(SegmentationContext& context, const GlyphSet& glyphs) {
     context.or_glyph_groups[context.fallback_segments].insert(gid);
   }
 
-  auto condition = GlyphSegmentation::ActivationCondition::or_segments(context.fallback_segments, 0, true);
-  context.AddConditionAndGlyphs(condition, context.or_glyph_groups[context.fallback_segments]);
+  // Note: we don't need to include the fallback segment/condition in context.conditions_and_glyphs since
+  //       all downstream processing which utilizes that map ignores the fallback segment.
 
   return absl::OkStatus();
 }

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -34,6 +34,7 @@ using common::CompatId;
 using common::FontData;
 using common::FontHelper;
 using common::GlyphSet;
+using common::hb_face_unique_ptr;
 using common::hb_set_unique_ptr;
 using common::IntSet;
 using common::make_hb_face;
@@ -54,6 +55,179 @@ namespace ift::encoder {
 // - Use merging and/or duplication to ensure minimum patch size.
 //   - composite patches (NOT STARTED)
 // - Multi segment combination testing with GSUB dep analysis to guide.
+
+class RequestedSegmentationInformation;
+class GlyphClosureCache;
+
+Status AnalyzeSegment(const RequestedSegmentationInformation& segmentation_info,
+                      GlyphClosureCache& closure_cache,
+                      const CodepointSet& codepoints, GlyphSet& and_gids,
+                      GlyphSet& or_gids, GlyphSet& exclusive_gids);
+
+/*
+ * A cache of the results of glyph closure on a specific font face.
+ */
+class GlyphClosureCache {
+ public:
+  GlyphClosureCache(hb_face_t* face)
+      : preprocessed_face_(make_hb_face(hb_subset_preprocess(face))),
+        original_face_(make_hb_face(hb_face_reference(face))) {}
+
+  StatusOr<GlyphSet> GlyphClosure(const CodepointSet& codepoints) {
+    auto it = glyph_closure_cache_.find(codepoints);
+    if (it != glyph_closure_cache_.end()) {
+      glyph_closure_cache_hit_++;
+      return it->second;
+    }
+
+    glyph_closure_cache_miss_++;
+    closure_count_cumulative_++;
+    closure_count_delta_++;
+
+    hb_subset_input_t* input = hb_subset_input_create_or_fail();
+    if (!input) {
+      return absl::InternalError("Closure subset configuration failed.");
+    }
+
+    codepoints.union_into(hb_subset_input_unicode_set(input));
+    // TODO(garretrieger): configure features (and other settings) appropriately
+    // based on the IFT default feature list.
+
+    hb_subset_plan_t* plan =
+        hb_subset_plan_create_or_fail(preprocessed_face_.get(), input);
+    hb_subset_input_destroy(input);
+    if (!plan) {
+      return absl::InternalError("Closure calculation failed.");
+    }
+
+    hb_map_t* new_to_old = hb_subset_plan_new_to_old_glyph_mapping(plan);
+    hb_set_unique_ptr gids = make_hb_set();
+    hb_map_values(new_to_old, gids.get());
+    hb_subset_plan_destroy(plan);
+
+    glyph_closure_cache_.insert(std::pair(codepoints, GlyphSet(gids)));
+
+    return GlyphSet(gids);
+  }
+
+  StatusOr<const GlyphSet*> CodepointsToOrGids(
+      const RequestedSegmentationInformation& segmentation_info,
+      const CodepointSet& codepoints) {
+    auto it = code_point_set_to_or_gids_cache_.find(codepoints);
+    if (it != code_point_set_to_or_gids_cache_.end()) {
+      code_point_set_to_or_gids_cache_hit_++;
+      return &it->second;
+    }
+
+    code_point_set_to_or_gids_cache_miss_++;
+    GlyphSet and_gids;
+    GlyphSet or_gids;
+    GlyphSet exclusive_gids;
+    TRYV(AnalyzeSegment(segmentation_info, *this, codepoints, and_gids, or_gids,
+                        exclusive_gids));
+
+    auto [new_value, inserted] =
+        code_point_set_to_or_gids_cache_.insert(std::pair(codepoints, or_gids));
+    return &new_value->second;
+  }
+
+  void LogCacheStats() const {
+    double hit_rate = 100.0 * ((double)code_point_set_to_or_gids_cache_hit_) /
+                      ((double)(code_point_set_to_or_gids_cache_hit_ +
+                                code_point_set_to_or_gids_cache_miss_));
+    VLOG(0) << "Codepoints to or_gids cache hit rate: " << hit_rate << "% ("
+            << code_point_set_to_or_gids_cache_hit_ << " hits, "
+            << code_point_set_to_or_gids_cache_miss_ << " misses)";
+
+    double closure_hit_rate =
+        100.0 * ((double)glyph_closure_cache_hit_) /
+        ((double)(glyph_closure_cache_hit_ + glyph_closure_cache_miss_));
+    VLOG(0) << "Glyph closure cache hit rate: " << closure_hit_rate << "% ("
+            << glyph_closure_cache_hit_ << " hits, "
+            << glyph_closure_cache_miss_ << " misses)";
+  }
+
+  void LogClosureCount(absl::string_view operation) {
+    VLOG(0) << operation << ": cumulative number of glyph closures "
+            << closure_count_cumulative_ << " (+" << closure_count_delta_
+            << ")";
+    closure_count_delta_ = 0;
+  }
+
+ private:
+  hb_face_unique_ptr preprocessed_face_;
+  hb_face_unique_ptr original_face_;
+  flat_hash_map<CodepointSet, GlyphSet> glyph_closure_cache_;
+  uint32_t glyph_closure_cache_hit_ = 0;
+  uint32_t glyph_closure_cache_miss_ = 0;
+  uint32_t closure_count_cumulative_ = 0;
+  uint32_t closure_count_delta_ = 0;
+
+  // for this cache we return pointers to the sets so need node_hash_map for
+  // pointer stability.
+  node_hash_map<CodepointSet, GlyphSet> code_point_set_to_or_gids_cache_;
+  uint32_t code_point_set_to_or_gids_cache_hit_ = 0;
+  uint32_t code_point_set_to_or_gids_cache_miss_ = 0;
+};
+
+/*
+ * Stores basic information about the configuration of a requested segmentation
+ */
+class RequestedSegmentationInformation {
+ public:
+  RequestedSegmentationInformation(std::vector<CodepointSet> segments,
+                                   CodepointSet init_font_codepoints,
+                                   GlyphClosureCache& closure_cache)
+      : segments_(std::move(segments)),
+        init_font_codepoints_(std::move(init_font_codepoints)) {
+    all_codepoints_.union_set(init_font_codepoints_);
+    for (const auto& s : segments_) {
+      all_codepoints_.union_set(s);
+    }
+
+    {
+      auto closure = closure_cache.GlyphClosure(init_font_codepoints_);
+      if (closure.ok()) {
+        init_font_glyphs_ = std::move(*closure);
+      }
+    }
+
+    auto closure = closure_cache.GlyphClosure(all_codepoints_);
+    if (closure.ok()) {
+      full_closure_ = std::move(*closure);
+    }
+  }
+
+  uint32_t MergeSegments(segment_index_t base, const SegmentSet& to_merge,
+                         const CodepointSet& merged_codepoints) {
+    segments_[base].union_set(merged_codepoints);
+    for (segment_index_t s : to_merge) {
+      // To avoid changing the indices of other segments set the ones we're
+      // removing to empty sets. That effectively disables them.
+      segments_[s].clear();
+    }
+    return segments_[base].size();
+  }
+
+  const CodepointSet& InitFontCodepoints() const {
+    return init_font_codepoints_;
+  }
+
+  const GlyphSet& InitFontGlyphs() const { return init_font_glyphs_; }
+
+  const GlyphSet& FullClosure() const { return full_closure_; }
+
+  const CodepointSet& AllCodepoints() const { return all_codepoints_; }
+
+  const std::vector<CodepointSet>& Segments() const { return segments_; }
+
+ private:
+  std::vector<CodepointSet> segments_;
+  CodepointSet init_font_codepoints_;
+  GlyphSet init_font_glyphs_;
+  CodepointSet all_codepoints_;
+  GlyphSet full_closure_;
+};
 
 /*
  * A set of conditions which activate a specific single glyph.
@@ -80,9 +254,7 @@ class GlyphConditions {
  */
 class GlyphConditionSet {
  public:
-  GlyphConditionSet(uint32_t num_glyphs) {
-    gid_conditions_.resize(num_glyphs);
-  }
+  GlyphConditionSet(uint32_t num_glyphs) { gid_conditions_.resize(num_glyphs); }
 
   const GlyphConditions& ConditionsFor(glyph_id_t gid) const {
     return gid_conditions_[gid];
@@ -108,8 +280,10 @@ class GlyphConditionSet {
     return it->second;
   }
 
-  // Clears out any stored information for glyphs and segments in this condition set.
-  void InvalidateGlyphInformation(const GlyphSet& glyphs, const SegmentSet& segments) {
+  // Clears out any stored information for glyphs and segments in this condition
+  // set.
+  void InvalidateGlyphInformation(const GlyphSet& glyphs,
+                                  const SegmentSet& segments) {
     // Remove all segments we touched here from gid_conditions so they can be
     // recalculated.
     for (uint32_t gid : glyphs) {
@@ -123,7 +297,7 @@ class GlyphConditionSet {
 
   bool operator==(const GlyphConditionSet& other) const {
     return other.gid_conditions_ == gid_conditions_ &&
-      other.segment_to_gid_conditions_ == other.segment_to_gid_conditions_;
+           other.segment_to_gid_conditions_ == other.segment_to_gid_conditions_;
   }
 
   bool operator!=(const GlyphConditionSet& other) const {
@@ -131,54 +305,250 @@ class GlyphConditionSet {
   }
 
  private:
-  // Index in this vector is the glyph id associated with the condition at that index.
+  // Index in this vector is the glyph id associated with the condition at that
+  // index.
   std::vector<GlyphConditions> gid_conditions_;
 
-  // Index that tracks for each segment id which set of glyphs include that segment in it's conditions.
+  // Index that tracks for each segment id which set of glyphs include that
+  // segment in it's conditions.
   flat_hash_map<uint32_t, GlyphSet> segment_to_gid_conditions_;
-  
+};
+
+/*
+ * Grouping of the glyphs into a font by the associated activation conditions.
+ */
+class GlyphGroupings {
+ public:
+  GlyphGroupings(const std::vector<CodepointSet>& segments) {
+    uint32_t index = 0;
+    for (const auto& s : segments) {
+      if (!s.empty()) {
+        fallback_segments_.insert(index);
+      }
+      index++;
+    }
+  }
+
+  const btree_map<GlyphSegmentation::ActivationCondition, GlyphSet>&
+  ConditionsAndGlyphs() const {
+    return conditions_and_glyphs_;
+  }
+
+  const btree_map<SegmentSet, GlyphSet>& AndGlyphGroups() const {
+    return and_glyph_groups_;
+  }
+
+  const btree_map<SegmentSet, GlyphSet>& OrGlyphGroups() const {
+    return or_glyph_groups_;
+  }
+
+  // Index from segment index to the conditions that reference it.
+  const btree_set<GlyphSegmentation::ActivationCondition>&
+  TriggeringSegmentToConditions(segment_index_t segment) const {
+    static btree_set<GlyphSegmentation::ActivationCondition> empty;
+    auto it = triggering_segment_to_conditions_.find(segment);
+    if (it != triggering_segment_to_conditions_.end()) {
+      return it->second;
+    }
+    return empty;
+  }
+
+  // Removes all stored grouping information related to glyph with the specified
+  // condition.
+  void InvalidateGlyphInformation(const GlyphConditions& condition,
+                                  uint32_t gid) {
+    auto it = and_glyph_groups_.find(condition.and_segments);
+    if (it != and_glyph_groups_.end()) {
+      it->second.erase(gid);
+      if (it->second.empty()) {
+        and_glyph_groups_.erase(it);
+        GlyphSegmentation::ActivationCondition activation_condition =
+            GlyphSegmentation::ActivationCondition::and_segments(
+                condition.and_segments, 0);
+        if (condition.and_segments.size() == 1) {
+          activation_condition =
+              GlyphSegmentation::ActivationCondition::exclusive_segment(
+                  *condition.and_segments.begin(), 0);
+        }
+        RemoveConditionAndGlyphs(activation_condition);
+      }
+    }
+
+    it = or_glyph_groups_.find(condition.or_segments);
+    if (it != or_glyph_groups_.end()) {
+      it->second.erase(gid);
+      if (it->second.empty()) {
+        or_glyph_groups_.erase(it);
+        GlyphSegmentation::ActivationCondition activation_condition =
+            GlyphSegmentation::ActivationCondition::or_segments(
+                condition.or_segments, 0);
+        RemoveConditionAndGlyphs(activation_condition);
+      }
+    }
+
+    unmapped_glyphs_.erase(gid);
+  }
+
+  void RemoveFallbackSegments(const SegmentSet& removed_segments) {
+    // Invalidate the existing fallback segment 'or group', it will be fully
+    // recomputed by GroupGlyphs
+    or_glyph_groups_.erase(fallback_segments_);
+    for (segment_index_t segment_index : removed_segments) {
+      fallback_segments_.erase(segment_index);
+    }
+  }
+
+  Status GroupGlyphs(const RequestedSegmentationInformation& segmentation_info,
+                     const GlyphConditionSet& glyph_condition_set,
+                     GlyphClosureCache& closure_cache, const GlyphSet& glyphs) {
+    const auto& initial_closure = segmentation_info.InitFontGlyphs();
+
+    btree_set<SegmentSet> modified_and_groups;
+    btree_set<SegmentSet> modified_or_groups;
+
+    for (glyph_id_t gid : glyphs) {
+      const auto& condition = glyph_condition_set.ConditionsFor(gid);
+      if (!condition.and_segments.empty()) {
+        and_glyph_groups_[condition.and_segments].insert(gid);
+        modified_and_groups.insert(condition.and_segments);
+      }
+      if (!condition.or_segments.empty()) {
+        or_glyph_groups_[condition.or_segments].insert(gid);
+        modified_or_groups.insert(condition.or_segments);
+      }
+
+      if (condition.and_segments.empty() && condition.or_segments.empty() &&
+          !initial_closure.contains(gid) &&
+          segmentation_info.FullClosure().contains(gid)) {
+        unmapped_glyphs_.insert(gid);
+      }
+    }
+
+    for (const auto& and_group : modified_and_groups) {
+      if (and_group.size() == 1) {
+        auto condition =
+            GlyphSegmentation::ActivationCondition::exclusive_segment(
+                *and_group.begin(), 0);
+        AddConditionAndGlyphs(condition, and_glyph_groups_[and_group]);
+        continue;
+      }
+
+      auto condition =
+          GlyphSegmentation::ActivationCondition::and_segments(and_group, 0);
+      AddConditionAndGlyphs(condition, and_glyph_groups_[and_group]);
+    }
+
+    // Any of the or_set conditions we've generated may have some additional
+    // conditions that were not detected. Therefore we need to rule out the
+    // presence of these additional conditions if an or group is able to be
+    // used.
+    for (const auto& or_group : modified_or_groups) {
+      auto& glyphs = or_glyph_groups_[or_group];
+      CodepointSet all_other_codepoints = segmentation_info.AllCodepoints();
+      for (uint32_t s : or_group) {
+        all_other_codepoints.subtract(segmentation_info.Segments()[s]);
+      }
+
+      const GlyphSet* or_gids = TRY(closure_cache.CodepointsToOrGids(
+          segmentation_info, all_other_codepoints));
+
+      // Any "OR" glyphs associated with all other codepoints have some
+      // additional conditions to activate so we can't safely include them into
+      // this or condition. They are instead moved to the set of unmapped
+      // glyphs.
+      for (uint32_t gid : *or_gids) {
+        if (glyphs.erase(gid) > 0) {
+          unmapped_glyphs_.insert(gid);
+        }
+      }
+
+      GlyphSegmentation::ActivationCondition condition =
+          GlyphSegmentation::ActivationCondition::or_segments(or_group, 0);
+      if (glyphs.empty()) {
+        // Group has been emptied out, so it's no longer needed.
+        or_glyph_groups_.erase(or_group);
+        RemoveConditionAndGlyphs(condition);
+        continue;
+      }
+
+      AddConditionAndGlyphs(condition, glyphs);
+    }
+
+    for (uint32_t gid : unmapped_glyphs_) {
+      // this glyph is not activated anywhere but is needed in the full closure
+      // so add it to an activation condition of any segment.
+      or_glyph_groups_[fallback_segments_].insert(gid);
+    }
+
+    // Note: we don't need to include the fallback segment/condition in
+    // context.conditions_and_glyphs since
+    //       all downstream processing which utilizes that map ignores the
+    //       fallback segment.
+
+    return absl::OkStatus();
+  }
+
+  StatusOr<GlyphSegmentation> ToGlyphSegmentation(
+      const RequestedSegmentationInformation& segmentation_info) const {
+    GlyphSegmentation segmentation(segmentation_info.InitFontCodepoints(),
+                                   segmentation_info.InitFontGlyphs(),
+                                   unmapped_glyphs_);
+    segmentation.CopySegments(segmentation_info.Segments());
+    TRYV(GlyphSegmentation::GroupsToSegmentation(
+        and_glyph_groups_, or_glyph_groups_, fallback_segments_, segmentation));
+    return segmentation;
+  }
+
+ private:
+  void AddConditionAndGlyphs(GlyphSegmentation::ActivationCondition condition,
+                             GlyphSet glyphs) {
+    const auto& [new_value_it, did_insert] =
+        conditions_and_glyphs_.insert(std::pair(condition, glyphs));
+    for (segment_index_t s : condition.TriggeringSegments()) {
+      triggering_segment_to_conditions_[s].insert(new_value_it->first);
+    }
+  }
+
+  void RemoveConditionAndGlyphs(
+      GlyphSegmentation::ActivationCondition condition) {
+    conditions_and_glyphs_.erase(condition);
+    for (segment_index_t s : condition.TriggeringSegments()) {
+      triggering_segment_to_conditions_[s].erase(condition);
+    }
+  }
+
+  btree_map<SegmentSet, GlyphSet> and_glyph_groups_;
+  btree_map<SegmentSet, GlyphSet> or_glyph_groups_;
+
+  // An alternate representation of and/or_glyph_groups_, derived from them.
+  btree_map<GlyphSegmentation::ActivationCondition, GlyphSet>
+      conditions_and_glyphs_;
+
+  // Index that maps segments to all conditions in conditions_and_glyphs_ which
+  // reference that segment.
+  flat_hash_map<uint32_t, btree_set<GlyphSegmentation::ActivationCondition>>
+      triggering_segment_to_conditions_;
+
+  // Set of segments in the fallback condition.
+  SegmentSet fallback_segments_;
+
+  // These glyphs aren't mapped by any conditions and as a result should be
+  // included in the fallback patch.
+  common::GlyphSet unmapped_glyphs_;
 };
 
 class SegmentationContext;
-
-Status AnalyzeSegment(SegmentationContext& context,
-                      const CodepointSet& codepoints, GlyphSet& and_gids,
-                      GlyphSet& or_gids, GlyphSet& exclusive_gids);
 
 class SegmentationContext {
  public:
   SegmentationContext(hb_face_t* face, const CodepointSet& initial_segment,
                       const std::vector<CodepointSet>& codepoint_segments)
-      : preprocessed_face(make_hb_face(hb_subset_preprocess(face))),
+      : glyph_closure_cache(face),
         original_face(make_hb_face(hb_face_reference(face))),
-        all_codepoints(),
-        full_closure(),
-        glyph_condition_set(hb_face_get_glyph_count(original_face.get())) {
-    init_font_codepoints.union_set(initial_segment);
-    all_codepoints.union_set(initial_segment);
-
-    this->segments = codepoint_segments;
-    uint32_t index = 0;
-    for (const auto& s : codepoint_segments) {
-      all_codepoints.union_set(s);
-      if (!s.empty()) {
-        fallback_segments.insert(index);
-      }
-      index++;
-    }
-
-    {
-      auto closure = GlyphClosure(initial_segment);
-      if (closure.ok()) {
-        init_font_glyphs = std::move(*closure);
-      }
-    }
-
-    auto closure = GlyphClosure(all_codepoints);
-    if (closure.ok()) {
-      full_closure = std::move(*closure);
-    }
-  }
+        segmentation_info(codepoint_segments, initial_segment,
+                          glyph_closure_cache),
+        glyph_condition_set(hb_face_get_glyph_count(face)),
+        glyph_groupings(codepoint_segments) {}
 
   /*
    * Ensures that the produce segmentation is:
@@ -203,7 +573,7 @@ class SegmentationContext {
       }
     }
 
-    IntSet full_minus_initial = this->full_closure;
+    IntSet full_minus_initial = segmentation_info.FullClosure();
     full_minus_initial.subtract(initial_closure);
 
     if (full_minus_initial != visited) {
@@ -215,12 +585,9 @@ class SegmentationContext {
   }
 
   StatusOr<GlyphSegmentation> ToGlyphSegmentation() const {
-    GlyphSegmentation segmentation(init_font_codepoints, init_font_glyphs,
-                                   unmapped_glyphs);
-    segmentation.CopySegments(segments);
-    TRYV(GlyphSegmentation::GroupsToSegmentation(
-        and_glyph_groups, or_glyph_groups, fallback_segments, segmentation));
-    LogCacheStats();
+    GlyphSegmentation segmentation =
+        TRY(glyph_groupings.ToGlyphSegmentation(segmentation_info));
+    glyph_closure_cache.LogCacheStats();
     TRYV(ValidateSegmentation(segmentation));
     return segmentation;
   }
@@ -235,161 +602,30 @@ class SegmentationContext {
     // so must be invalidated. Do this before modifying the conditions.
     for (uint32_t gid : glyphs) {
       const auto& condition = glyph_condition_set.ConditionsFor(gid);
-      RemoveGlyphFromAndOrGroups(condition, gid);
-      unmapped_glyphs.erase(gid);
+      glyph_groupings.InvalidateGlyphInformation(condition, gid);
     }
 
     glyph_condition_set.InvalidateGlyphInformation(glyphs, segments);
   }
 
-  void RemoveGlyphFromAndOrGroups(const GlyphConditions& condition,
-                                  uint32_t gid) {
-    auto it = and_glyph_groups.find(condition.and_segments);
-    if (it != and_glyph_groups.end()) {
-      it->second.erase(gid);
-      if (it->second.empty()) {
-        and_glyph_groups.erase(it);
-        GlyphSegmentation::ActivationCondition activation_condition =
-            GlyphSegmentation::ActivationCondition::and_segments(
-                condition.and_segments, 0);
-        if (condition.and_segments.size() == 1) {
-          activation_condition =
-              GlyphSegmentation::ActivationCondition::exclusive_segment(
-                  *condition.and_segments.begin(), 0);
-        }
-        RemoveConditionAndGlyphs(activation_condition);
-      }
-    }
-
-    it = or_glyph_groups.find(condition.or_segments);
-    if (it != or_glyph_groups.end()) {
-      it->second.erase(gid);
-      if (it->second.empty()) {
-        or_glyph_groups.erase(it);
-        GlyphSegmentation::ActivationCondition activation_condition =
-            GlyphSegmentation::ActivationCondition::or_segments(
-                condition.or_segments, 0);
-        RemoveConditionAndGlyphs(activation_condition);
-      }
-    }
+  Status AnalyzeSegment(const CodepointSet& codepoints, GlyphSet& and_gids,
+                        GlyphSet& or_gids, GlyphSet& exclusive_gids) {
+    return ::ift::encoder::AnalyzeSegment(segmentation_info,
+                                          glyph_closure_cache, codepoints,
+                                          and_gids, or_gids, exclusive_gids);
   }
 
-  void AddConditionAndGlyphs(GlyphSegmentation::ActivationCondition condition,
-                             GlyphSet glyphs) {
-    const auto& [new_value_it, did_insert] =
-        conditions_and_glyphs.insert(std::pair(condition, glyphs));
-    for (segment_index_t s : condition.TriggeringSegments()) {
-      triggering_segment_to_conditions[s].insert(new_value_it->first);
-    }
+  Status GroupGlyphs(const GlyphSet& glyphs) {
+    return glyph_groupings.GroupGlyphs(segmentation_info, glyph_condition_set,
+                                       glyph_closure_cache, glyphs);
   }
 
-  void RemoveConditionAndGlyphs(
-      GlyphSegmentation::ActivationCondition condition) {
-    conditions_and_glyphs.erase(condition);
-    for (segment_index_t s : condition.TriggeringSegments()) {
-      triggering_segment_to_conditions[s].erase(condition);
-    }
-  }
-
-  /*
-   * Index from segment index to the conditions that reference it.
-   */
-  const btree_set<GlyphSegmentation::ActivationCondition>&
-  TriggeringSegmentToConditions(segment_index_t segment) const {
-    static btree_set<GlyphSegmentation::ActivationCondition> empty;
-    auto it = triggering_segment_to_conditions.find(segment);
-    if (it != triggering_segment_to_conditions.end()) {
-      return it->second;
-    }
-    return empty;
-  }
-
-  StatusOr<GlyphSet> GlyphClosure(const CodepointSet& codepoints) {
-    auto it = glyph_closure_cache.find(codepoints);
-    if (it != glyph_closure_cache.end()) {
-      glyph_closure_cache_hit++;
-      return it->second;
-    }
-
-    glyph_closure_cache_miss++;
-    closure_count_cumulative++;
-    closure_count_delta++;
-
-    hb_subset_input_t* input = hb_subset_input_create_or_fail();
-    if (!input) {
-      return absl::InternalError("Closure subset configuration failed.");
-    }
-
-    codepoints.union_into(hb_subset_input_unicode_set(input));
-    // TODO(garretrieger): configure features (and other settings) appropriately
-    // based on the IFT default feature list.
-
-    hb_subset_plan_t* plan =
-        hb_subset_plan_create_or_fail(preprocessed_face.get(), input);
-    hb_subset_input_destroy(input);
-    if (!plan) {
-      return absl::InternalError("Closure calculation failed.");
-    }
-
-    hb_map_t* new_to_old = hb_subset_plan_new_to_old_glyph_mapping(plan);
-    hb_set_unique_ptr gids = make_hb_set();
-    hb_map_values(new_to_old, gids.get());
-    hb_subset_plan_destroy(plan);
-
-    glyph_closure_cache.insert(std::pair(codepoints, GlyphSet(gids)));
-
-    return GlyphSet(gids);
-  }
-
-  void LogClosureCount(absl::string_view operation) {
-    VLOG(0) << operation << ": cumulative number of glyph closures "
-            << closure_count_cumulative << " (+" << closure_count_delta << ")";
-    closure_count_delta = 0;
-  }
-
-  void LogCacheStats() const {
-    double hit_rate = 100.0 * ((double)code_point_set_to_or_gids_cache_hit) /
-                      ((double)(code_point_set_to_or_gids_cache_hit +
-                                code_point_set_to_or_gids_cache_miss));
-    VLOG(0) << "Codepoints to or_gids cache hit rate: " << hit_rate << "% ("
-            << code_point_set_to_or_gids_cache_hit << " hits, "
-            << code_point_set_to_or_gids_cache_miss << " misses)";
-
-    double closure_hit_rate =
-        100.0 * ((double)glyph_closure_cache_hit) /
-        ((double)(glyph_closure_cache_hit + glyph_closure_cache_miss));
-    VLOG(0) << "Glyph closure cache hit rate: " << closure_hit_rate << "% ("
-            << glyph_closure_cache_hit << " hits, " << glyph_closure_cache_miss
-            << " misses)";
-  }
-
-  StatusOr<const GlyphSet*> CodepointsToOrGids(const CodepointSet& codepoints) {
-    auto it = code_point_set_to_or_gids_cache.find(codepoints);
-    if (it != code_point_set_to_or_gids_cache.end()) {
-      code_point_set_to_or_gids_cache_hit++;
-      return &it->second;
-    }
-
-    code_point_set_to_or_gids_cache_miss++;
-    GlyphSet and_gids;
-    GlyphSet or_gids;
-    GlyphSet exclusive_gids;
-    TRYV(AnalyzeSegment(*this, codepoints, and_gids, or_gids, exclusive_gids));
-
-    auto [new_value, inserted] =
-        code_point_set_to_or_gids_cache.insert(std::pair(codepoints, or_gids));
-    return &new_value->second;
-  }
+  // Caches and logging
+  GlyphClosureCache glyph_closure_cache;
 
   // Init
-  common::hb_face_unique_ptr preprocessed_face;
-  common::hb_face_unique_ptr original_face;
-  std::vector<common::CodepointSet> segments;
-  common::CodepointSet init_font_codepoints;
-  common::GlyphSet init_font_glyphs;
-
-  CodepointSet all_codepoints;
-  GlyphSet full_closure;
+  hb_face_unique_ptr original_face;
+  RequestedSegmentationInformation segmentation_info;
 
   uint32_t patch_size_min_bytes = 0;
   uint32_t patch_size_max_bytes = UINT32_MAX;
@@ -397,32 +633,12 @@ class SegmentationContext {
   // Phase 1 - derived from segments and init information
   GlyphConditionSet glyph_condition_set;
 
-  // Phase 2 - derived from glyph_condition_set
-  btree_map<SegmentSet, GlyphSet> and_glyph_groups;
-  btree_map<SegmentSet, GlyphSet> or_glyph_groups;
-  btree_map<GlyphSegmentation::ActivationCondition, GlyphSet>
-      conditions_and_glyphs;
-  flat_hash_map<uint32_t, btree_set<GlyphSegmentation::ActivationCondition>>
-      triggering_segment_to_conditions;
-  SegmentSet fallback_segments;
-  common::GlyphSet unmapped_glyphs;
-
-  // Caches and logging
-  flat_hash_map<CodepointSet, GlyphSet> glyph_closure_cache;
-  uint32_t glyph_closure_cache_hit = 0;
-  uint32_t glyph_closure_cache_miss = 0;
-
-  // for this cache we return pointers to the sets so need node_hash_map for
-  // pointer stability.
-  node_hash_map<CodepointSet, GlyphSet> code_point_set_to_or_gids_cache;
-  uint32_t code_point_set_to_or_gids_cache_hit = 0;
-  uint32_t code_point_set_to_or_gids_cache_miss = 0;
-
-  uint32_t closure_count_cumulative = 0;
-  uint32_t closure_count_delta = 0;
+  // Phase 2 - derived from glyph_condition_set and init information.
+  GlyphGroupings glyph_groupings;
 };
 
-Status AnalyzeSegment(SegmentationContext& context,
+Status AnalyzeSegment(const RequestedSegmentationInformation& segmentation_info,
+                      GlyphClosureCache& closure_cache,
                       const CodepointSet& codepoints, GlyphSet& and_gids,
                       GlyphSet& or_gids, GlyphSet& exclusive_gids) {
   if (codepoints.empty()) {
@@ -454,16 +670,17 @@ Status AnalyzeSegment(SegmentationContext& context,
   // * I - D: the activation conditions for these glyphs is s_i OR …
   //          Where … is one or more additional segments.
   // * D intersection I: the activation conditions for these glyphs is only s_i
-  CodepointSet except_segment = context.all_codepoints;
+  CodepointSet except_segment = segmentation_info.AllCodepoints();
   except_segment.subtract(codepoints);
-  auto B_except_segment_closure = TRY(context.GlyphClosure(except_segment));
+  auto B_except_segment_closure =
+      TRY(closure_cache.GlyphClosure(except_segment));
 
-  CodepointSet only_segment = context.init_font_codepoints;
+  CodepointSet only_segment = segmentation_info.InitFontCodepoints();
   only_segment.union_set(codepoints);
-  auto I_only_segment_closure = TRY(context.GlyphClosure(only_segment));
-  I_only_segment_closure.subtract(context.init_font_glyphs);
+  auto I_only_segment_closure = TRY(closure_cache.GlyphClosure(only_segment));
+  I_only_segment_closure.subtract(segmentation_info.InitFontGlyphs());
 
-  GlyphSet D_dropped = context.full_closure;
+  GlyphSet D_dropped = segmentation_info.FullClosure();
   D_dropped.subtract(B_except_segment_closure);
 
   and_gids.union_set(D_dropped);
@@ -484,7 +701,8 @@ StatusOr<GlyphSet> AnalyzeSegment(SegmentationContext& context,
   GlyphSet and_gids;
   GlyphSet or_gids;
   GlyphSet exclusive_gids;
-  TRYV(AnalyzeSegment(context, codepoints, and_gids, or_gids, exclusive_gids));
+  TRYV(AnalyzeSegment(context.segmentation_info, context.glyph_closure_cache,
+                      codepoints, and_gids, or_gids, exclusive_gids));
 
   GlyphSet changed_gids;
   changed_gids.union_set(and_gids);
@@ -512,93 +730,6 @@ StatusOr<GlyphSet> AnalyzeSegment(SegmentationContext& context,
   return changed_gids;
 }
 
-Status GroupGlyphs(SegmentationContext& context, const GlyphSet& glyphs) {
-  const auto& initial_closure = context.init_font_glyphs;
-
-  btree_set<SegmentSet> modified_and_groups;
-  btree_set<SegmentSet> modified_or_groups;
-
-  for (glyph_id_t gid : glyphs) {
-    const auto& condition = context.glyph_condition_set.ConditionsFor(gid);
-    if (!condition.and_segments.empty()) {
-      context.and_glyph_groups[condition.and_segments].insert(gid);
-      modified_and_groups.insert(condition.and_segments);
-    }
-    if (!condition.or_segments.empty()) {
-      context.or_glyph_groups[condition.or_segments].insert(gid);
-      modified_or_groups.insert(condition.or_segments);
-    }
-
-    if (condition.and_segments.empty() && condition.or_segments.empty() &&
-        !initial_closure.contains(gid) && context.full_closure.contains(gid)) {
-      context.unmapped_glyphs.insert(gid);
-    }
-  }
-
-  for (const auto& and_group : modified_and_groups) {
-    if (and_group.size() == 1) {
-      auto condition =
-          GlyphSegmentation::ActivationCondition::exclusive_segment(
-              *and_group.begin(), 0);
-      context.AddConditionAndGlyphs(condition,
-                                    context.and_glyph_groups[and_group]);
-      continue;
-    }
-
-    auto condition =
-        GlyphSegmentation::ActivationCondition::and_segments(and_group, 0);
-    context.AddConditionAndGlyphs(condition,
-                                  context.and_glyph_groups[and_group]);
-  }
-
-  // Any of the or_set conditions we've generated may have some additional
-  // conditions that were not detected. Therefore we need to rule out the
-  // presence of these additional conditions if an or group is able to be used.
-  for (const auto& or_group : modified_or_groups) {
-    auto& glyphs = context.or_glyph_groups[or_group];
-    CodepointSet all_other_codepoints = context.all_codepoints;
-    for (uint32_t s : or_group) {
-      all_other_codepoints.subtract(context.segments[s]);
-    }
-
-    const GlyphSet* or_gids =
-        TRY(context.CodepointsToOrGids(all_other_codepoints));
-
-    // Any "OR" glyphs associated with all other codepoints have some additional
-    // conditions to activate so we can't safely include them into this or
-    // condition. They are instead moved to the set of unmapped glyphs.
-    for (uint32_t gid : *or_gids) {
-      if (glyphs.erase(gid) > 0) {
-        context.unmapped_glyphs.insert(gid);
-      }
-    }
-
-    GlyphSegmentation::ActivationCondition condition =
-        GlyphSegmentation::ActivationCondition::or_segments(or_group, 0);
-    if (glyphs.empty()) {
-      // Group has been emptied out, so it's no longer needed.
-      context.or_glyph_groups.erase(or_group);
-      context.RemoveConditionAndGlyphs(condition);
-      continue;
-    }
-
-    context.AddConditionAndGlyphs(condition, glyphs);
-  }
-
-  for (uint32_t gid : context.unmapped_glyphs) {
-    // this glyph is not activated anywhere but is needed in the full closure
-    // so add it to an activation condition of any segment.
-    context.or_glyph_groups[context.fallback_segments].insert(gid);
-  }
-
-  // Note: we don't need to include the fallback segment/condition in
-  // context.conditions_and_glyphs since
-  //       all downstream processing which utilizes that map ignores the
-  //       fallback segment.
-
-  return absl::OkStatus();
-}
-
 StatusOr<uint32_t> PatchSizeBytes(hb_face_t* original_face,
                                   const IntSet& gids) {
   FontData font_data(original_face);
@@ -614,10 +745,10 @@ StatusOr<uint32_t> PatchSizeBytes(hb_face_t* original_face,
   return patch_data.size();
 }
 
-void MergeSegments(const SegmentationContext& context, const IntSet& segments,
-                   IntSet& base) {
+void MergeSegments(const RequestedSegmentationInformation& segmentation_info,
+                   const IntSet& segments, IntSet& base) {
   for (uint32_t next : segments) {
-    base.union_set(context.segments[next]);
+    base.union_set(segmentation_info.Segments()[next]);
   }
 }
 
@@ -626,7 +757,7 @@ StatusOr<uint32_t> EstimatePatchSize(SegmentationContext& context,
   GlyphSet and_gids;
   GlyphSet or_gids;
   GlyphSet exclusive_gids;
-  TRYV(AnalyzeSegment(context, codepoints, and_gids, or_gids, exclusive_gids));
+  TRYV(context.AnalyzeSegment(codepoints, and_gids, or_gids, exclusive_gids));
   return PatchSizeBytes(context.original_face.get(), exclusive_gids);
 }
 
@@ -637,41 +768,38 @@ StatusOr<std::optional<GlyphSet>> TryMerge(
   SegmentSet to_merge_segments = to_merge_segments_;
   to_merge_segments.erase(base_segment_index);
 
-  uint32_t size_before = context.segments[base_segment_index].size();
+  const auto& segments = context.segmentation_info.Segments();
+  uint32_t size_before = segments[base_segment_index].size();
 
-  CodepointSet merged_codepoints = context.segments[base_segment_index];
-  MergeSegments(context, to_merge_segments, merged_codepoints);
+  CodepointSet merged_codepoints = segments[base_segment_index];
+  MergeSegments(context.segmentation_info, to_merge_segments,
+                merged_codepoints);
 
   uint32_t new_patch_size = TRY(EstimatePatchSize(context, merged_codepoints));
   if (new_patch_size > context.patch_size_max_bytes) {
     return std::nullopt;
   }
 
-  context.segments[base_segment_index].union_set(merged_codepoints);
-  uint32_t size_after = context.segments[base_segment_index].size();
-
+  uint32_t size_after = context.segmentation_info.MergeSegments(
+      base_segment_index, to_merge_segments, merged_codepoints);
   VLOG(0) << "  Merged " << size_before << " codepoints up to " << size_after
           << " codepoints for segment " << base_segment_index
           << ". New patch size " << new_patch_size << " bytes.";
 
   // Remove the fallback segment or group, it will be fully recomputed by
   // GroupGlyphs
-  context.or_glyph_groups.erase(context.fallback_segments);
+  context.glyph_groupings.RemoveFallbackSegments(to_merge_segments);
 
   GlyphSet gid_conditions_to_update;
   for (segment_index_t segment_index : to_merge_segments) {
-    // To avoid changing the indices of other segments set the ones we're
-    // removing to empty sets. That effectively disables them.
-    context.segments[segment_index].clear();
-    context.fallback_segments.erase(segment_index);
-
     // segments which are being removed/changed may appear in gid_conditions, we
     // need to update those (and the down stream and/or glyph groups) to reflect
     // the removal/change and allow recalculation during the GroupGlyphs steps
     //
     // Changes caused by adding new segments into the base segment will be
     // handled by the next AnalyzeSegment step.
-    gid_conditions_to_update.union_set(context.glyph_condition_set.GlyphsWithSegment(segment_index));
+    gid_conditions_to_update.union_set(
+        context.glyph_condition_set.GlyphsWithSegment(segment_index));
   }
 
   context.InvalidateGlyphInformation(gid_conditions_to_update,
@@ -689,7 +817,7 @@ StatusOr<std::optional<GlyphSet>> TryMergingACompositeCondition(
     SegmentationContext& context, segment_index_t base_segment_index,
     const GlyphSegmentation::ActivationCondition& base_condition) {
   auto candidate_conditions =
-      context.TriggeringSegmentToConditions(base_segment_index);
+      context.glyph_groupings.TriggeringSegmentToConditions(base_segment_index);
   for (GlyphSegmentation::ActivationCondition next_condition :
        candidate_conditions) {
     if (next_condition.IsFallback()) {
@@ -735,7 +863,8 @@ StatusOr<std::optional<GlyphSet>> TryMergingABaseSegment(
     const ConditionAndGlyphIt& condition_it) {
   auto next_condition_it = condition_it;
   next_condition_it++;
-  while (next_condition_it != context.conditions_and_glyphs.end()) {
+  while (next_condition_it !=
+         context.glyph_groupings.ConditionsAndGlyphs().end()) {
     auto next_condition = next_condition_it->first;
     if (!next_condition.IsExclusive()) {
       // Only interested in other base patches.
@@ -789,8 +918,9 @@ MergeNextBaseSegment(SegmentationContext& context, uint32_t start_segment) {
   auto start_condition =
       GlyphSegmentation::ActivationCondition::exclusive_segment(start_segment,
                                                                 0);
-  for (auto it = context.conditions_and_glyphs.lower_bound(start_condition);
-       it != context.conditions_and_glyphs.end(); it++) {
+  for (auto it = context.glyph_groupings.ConditionsAndGlyphs().lower_bound(
+           start_condition);
+       it != context.glyph_groupings.ConditionsAndGlyphs().end(); it++) {
     const auto& condition = it->first;
     if (!condition.IsExclusive()) {
       continue;
@@ -835,14 +965,16 @@ MergeNextBaseSegment(SegmentationContext& context, uint32_t start_segment) {
 Status ValidateIncrementalGroupings(hb_face_t* face,
                                     const SegmentationContext& context) {
   SegmentationContext non_incremental_context(
-      face, context.init_font_codepoints, context.segments);
+      face, context.segmentation_info.InitFontCodepoints(),
+      context.segmentation_info.Segments());
   non_incremental_context.patch_size_min_bytes = 0;
   non_incremental_context.patch_size_max_bytes = UINT32_MAX;
 
   // Compute the glyph groupings/conditions from scratch to compare against the
   // incrementall produced ones.
   segment_index_t segment_index = 0;
-  for (const auto& segment : non_incremental_context.segments) {
+  for (const auto& segment :
+       non_incremental_context.segmentation_info.Segments()) {
     TRY(AnalyzeSegment(non_incremental_context, segment_index, segment));
     segment_index++;
   }
@@ -850,23 +982,26 @@ Status ValidateIncrementalGroupings(hb_face_t* face,
   GlyphSet all_glyphs;
   uint32_t glyph_count = hb_face_get_glyph_count(face);
   all_glyphs.insert_range(0, glyph_count - 1);
-  TRYV(GroupGlyphs(non_incremental_context, all_glyphs));
+  TRYV(non_incremental_context.GroupGlyphs(all_glyphs));
 
-  if (non_incremental_context.conditions_and_glyphs !=
-      context.conditions_and_glyphs) {
+  if (non_incremental_context.glyph_groupings.ConditionsAndGlyphs() !=
+      context.glyph_groupings.ConditionsAndGlyphs()) {
     return absl::FailedPreconditionError(
         "conditions_and_glyphs aren't correct.");
   }
 
-  if (non_incremental_context.glyph_condition_set != context.glyph_condition_set) {
+  if (non_incremental_context.glyph_condition_set !=
+      context.glyph_condition_set) {
     return absl::FailedPreconditionError("glyph_condition_set isn't correct.");
   }
 
-  if (non_incremental_context.and_glyph_groups != context.and_glyph_groups) {
+  if (non_incremental_context.glyph_groupings.AndGlyphGroups() !=
+      context.glyph_groupings.AndGlyphGroups()) {
     return absl::FailedPreconditionError("and_glyph groups aren't correct.");
   }
 
-  if (non_incremental_context.or_glyph_groups != context.or_glyph_groups) {
+  if (non_incremental_context.glyph_groupings.OrGlyphGroups() !=
+      context.glyph_groupings.OrGlyphGroups()) {
     return absl::FailedPreconditionError("or_glyph groups aren't correct.");
   }
 
@@ -888,16 +1023,16 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
 
   VLOG(0) << "Forming initial segmentation plan.";
   segment_index_t segment_index = 0;
-  for (const auto& segment : context.segments) {
+  for (const auto& segment : context.segmentation_info.Segments()) {
     TRY(AnalyzeSegment(context, segment_index, segment));
     segment_index++;
   }
-  context.LogClosureCount("Inital segment analysis");
+  context.glyph_closure_cache.LogClosureCount("Inital segment analysis");
 
   GlyphSet all_glyphs;
   all_glyphs.insert_range(0, glyph_count - 1);
-  TRYV(GroupGlyphs(context, all_glyphs));
-  context.LogClosureCount("Condition grouping");
+  TRYV(context.GroupGlyphs(all_glyphs));
+  context.glyph_closure_cache.LogClosureCount("Condition grouping");
 
   if (patch_size_min_bytes == 0) {
     // No merging will be needed so we're done.
@@ -918,14 +1053,14 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
     VLOG(0) << "Re-analyzing segment " << last_merged_segment_index
             << " due to merge.";
 
-    GlyphSet analysis_modified_gids =
-        TRY(AnalyzeSegment(context, last_merged_segment_index,
-                           context.segments[last_merged_segment_index]));
+    GlyphSet analysis_modified_gids = TRY(AnalyzeSegment(
+        context, last_merged_segment_index,
+        context.segmentation_info.Segments()[last_merged_segment_index]));
     analysis_modified_gids.union_set(modified_gids);
 
-    TRYV(GroupGlyphs(context, analysis_modified_gids));
+    TRYV(context.GroupGlyphs(analysis_modified_gids));
 
-    context.LogClosureCount("Condition grouping");
+    context.glyph_closure_cache.LogClosureCount("Condition grouping");
   }
 
   return absl::InternalError("unreachable");

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -33,6 +33,7 @@ Status GlyphSegmentation::GroupsToSegmentation(
   patch_id_t next_id = 0;
   segmentation.patches_.clear();
   segmentation.conditions_.clear();
+  segmentation.triggering_segment_to_conditions_.clear();
 
   // Map segments into patch ids
   for (const auto& [and_segments, glyphs] : and_glyph_groups) {
@@ -79,6 +80,13 @@ Status GlyphSegmentation::GroupsToSegmentation(
         ActivationCondition::or_segments(or_segments, next_id, is_fallback));
 
     next_id++;
+  }
+
+  // Rebuild indices
+  for (const auto& condition : segmentation.conditions_) {
+    for (uint32_t s : condition.TriggeringSegments()) {
+      segmentation.triggering_segment_to_conditions_[s].push_back(&condition);
+    }
   }
 
   return absl::OkStatus();

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -31,6 +31,8 @@ Status GlyphSegmentation::GroupsToSegmentation(
     const btree_map<SegmentSet, GlyphSet>& or_glyph_groups,
     const SegmentSet& fallback_group, GlyphSegmentation& segmentation) {
   patch_id_t next_id = 0;
+  segmentation.patches_.clear();
+  segmentation.conditions_.clear();
 
   // Map segments into patch ids
   for (const auto& [and_segments, glyphs] : and_glyph_groups) {

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -33,7 +33,6 @@ Status GlyphSegmentation::GroupsToSegmentation(
   patch_id_t next_id = 0;
   segmentation.patches_.clear();
   segmentation.conditions_.clear();
-  segmentation.triggering_segment_to_conditions_.clear();
 
   // Map segments into patch ids
   for (const auto& [and_segments, glyphs] : and_glyph_groups) {
@@ -80,13 +79,6 @@ Status GlyphSegmentation::GroupsToSegmentation(
         ActivationCondition::or_segments(or_segments, next_id, is_fallback));
 
     next_id++;
-  }
-
-  // Rebuild indices
-  for (const auto& condition : segmentation.conditions_) {
-    for (uint32_t s : condition.TriggeringSegments()) {
-      segmentation.triggering_segment_to_conditions_[s].push_back(&condition);
-    }
   }
 
   return absl::OkStatus();

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -134,8 +134,6 @@ class GlyphSegmentation {
     patch_id_t activated_;
   };
 
-  GlyphSegmentation() {}
-
   GlyphSegmentation(common::CodepointSet init_font_codepoints,
                     common::GlyphSet init_font_glyphs,
                     common::GlyphSet unmapped_glyphs)
@@ -177,8 +175,6 @@ class GlyphSegmentation {
     return segments_;
   }
 
-  std::vector<common::CodepointSet>& Segments() { return segments_; }
-
   /*
    * The list of glyphs in each patch. The key in the map is an id used to
    * identify the patch within the activation conditions.
@@ -196,8 +192,6 @@ class GlyphSegmentation {
    */
   const common::GlyphSet& UnmappedGlyphs() const { return unmapped_glyphs_; };
 
-  common::GlyphSet& UnmappedGlyphs() { return unmapped_glyphs_; };
-
   /*
    * These glyphs should be included in the initial font.
    */
@@ -205,16 +199,10 @@ class GlyphSegmentation {
     return init_font_glyphs_;
   };
 
-  common::GlyphSet& InitialFontGlyphs() { return init_font_glyphs_; };
-
   /*
    * These codepoints should be included in the initial font.
    */
   const common::CodepointSet& InitialFontCodepoints() const {
-    return init_font_codepoints_;
-  };
-
-  common::CodepointSet& InitialFontCodepoints() {
     return init_font_codepoints_;
   };
 

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -177,9 +177,7 @@ class GlyphSegmentation {
     return segments_;
   }
 
-  std::vector<common::CodepointSet>& Segments() {
-    return segments_;
-  }
+  std::vector<common::CodepointSet>& Segments() { return segments_; }
 
   /*
    * The list of glyphs in each patch. The key in the map is an id used to
@@ -207,9 +205,7 @@ class GlyphSegmentation {
     return init_font_glyphs_;
   };
 
-  common::GlyphSet& InitialFontGlyphs() {
-    return init_font_glyphs_;
-  };
+  common::GlyphSet& InitialFontGlyphs() { return init_font_glyphs_; };
 
   /*
    * These codepoints should be included in the initial font.

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -221,7 +221,8 @@ class GlyphSegmentation {
   /*
    * Index from segment index to the conditions that reference it.
    */
-  const std::vector<const ActivationCondition*>& TriggeringSegmentToConditions(uint32_t segment) const {
+  const std::vector<const ActivationCondition*>& TriggeringSegmentToConditions(
+      uint32_t segment) const {
     static std::vector<const ActivationCondition*> empty;
     auto it = triggering_segment_to_conditions_.find(segment);
     if (it != triggering_segment_to_conditions_.end()) {
@@ -251,7 +252,8 @@ class GlyphSegmentation {
   absl::btree_map<patch_id_t, common::GlyphSet> patches_;
 
   // Indices
-  absl::flat_hash_map<uint32_t, std::vector<const ActivationCondition*>> triggering_segment_to_conditions_;
+  absl::flat_hash_map<uint32_t, std::vector<const ActivationCondition*>>
+      triggering_segment_to_conditions_;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -218,6 +218,18 @@ class GlyphSegmentation {
     return init_font_codepoints_;
   };
 
+  /*
+   * Index from segment index to the conditions that reference it.
+   */
+  const std::vector<const ActivationCondition*>& TriggeringSegmentToConditions(uint32_t segment) const {
+    static std::vector<const ActivationCondition*> empty;
+    auto it = triggering_segment_to_conditions_.find(segment);
+    if (it != triggering_segment_to_conditions_.end()) {
+      return it->second;
+    }
+    return empty;
+  }
+
   EncoderConfig ToConfigProto() const;
 
   static absl::Status GroupsToSegmentation(
@@ -237,6 +249,9 @@ class GlyphSegmentation {
   absl::btree_set<ActivationCondition> conditions_;
   std::vector<common::CodepointSet> segments_;
   absl::btree_map<patch_id_t, common::GlyphSet> patches_;
+
+  // Indices
+  absl::flat_hash_map<uint32_t, std::vector<const ActivationCondition*>> triggering_segment_to_conditions_;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -134,6 +134,8 @@ class GlyphSegmentation {
     patch_id_t activated_;
   };
 
+  GlyphSegmentation() {}
+
   GlyphSegmentation(common::CodepointSet init_font_codepoints,
                     common::GlyphSet init_font_glyphs,
                     common::GlyphSet unmapped_glyphs)
@@ -175,6 +177,10 @@ class GlyphSegmentation {
     return segments_;
   }
 
+  std::vector<common::CodepointSet>& Segments() {
+    return segments_;
+  }
+
   /*
    * The list of glyphs in each patch. The key in the map is an id used to
    * identify the patch within the activation conditions.
@@ -192,6 +198,8 @@ class GlyphSegmentation {
    */
   const common::GlyphSet& UnmappedGlyphs() const { return unmapped_glyphs_; };
 
+  common::GlyphSet& UnmappedGlyphs() { return unmapped_glyphs_; };
+
   /*
    * These glyphs should be included in the initial font.
    */
@@ -199,10 +207,18 @@ class GlyphSegmentation {
     return init_font_glyphs_;
   };
 
+  common::GlyphSet& InitialFontGlyphs() {
+    return init_font_glyphs_;
+  };
+
   /*
    * These codepoints should be included in the initial font.
    */
   const common::CodepointSet& InitialFontCodepoints() const {
+    return init_font_codepoints_;
+  };
+
+  common::CodepointSet& InitialFontCodepoints() {
     return init_font_codepoints_;
   };
 

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -218,19 +218,6 @@ class GlyphSegmentation {
     return init_font_codepoints_;
   };
 
-  /*
-   * Index from segment index to the conditions that reference it.
-   */
-  const std::vector<const ActivationCondition*>& TriggeringSegmentToConditions(
-      uint32_t segment) const {
-    static std::vector<const ActivationCondition*> empty;
-    auto it = triggering_segment_to_conditions_.find(segment);
-    if (it != triggering_segment_to_conditions_.end()) {
-      return it->second;
-    }
-    return empty;
-  }
-
   EncoderConfig ToConfigProto() const;
 
   static absl::Status GroupsToSegmentation(
@@ -250,10 +237,6 @@ class GlyphSegmentation {
   absl::btree_set<ActivationCondition> conditions_;
   std::vector<common::CodepointSet> segments_;
   absl::btree_map<patch_id_t, common::GlyphSet> patches_;
-
-  // Indices
-  absl::flat_hash_map<uint32_t, std::vector<const ActivationCondition*>>
-      triggering_segment_to_conditions_;
 };
 
 }  // namespace ift::encoder


### PR DESCRIPTION
This refactors the closure segmenter implmentation to allow for incremental updates on glyph groupings after applying a segment merge. Prior to this change after each merge all glyph groupings would be fully recalculated from scratch, which results in O(N^2) like runtime.

By doing incremental updates we significantly reduce the amount of work performed since only things affected by the merge  are recomputed on each iteration resulting in O(N) like runtime instead.

In an example test, the total time for computing the Noto Serif SC segmentation in the [IFT demo](https://github.com/garretrieger/ift-demo/blob/main/Makefile#L78) (which starts with segments of one codepoint each) went from 2m15s to 45s. In this test case profiling shows that after this change computation is now primarily bottlenecked on glyph closure and brotli compression. Further follow on work is planned which should be able to significantly reduce the number of closure and brotli operations needed.

Additionally, to help better track the flow of information through the various parts of SegmentationContext a number of classes have been introduced that encapsulate specific groups of information. The following high level information is stored in context:
1. requested segmentation: the input segmentation in terms of codepoints.
2. glyph closure cache: helper for computing glyph closures that caches the results.
3. glyph condition set: per glyph what conditions activate that glyph.
4. glyph groupings: glyphs grouped by activation conditions.

Information flows through these items:
1. Generated from the input and later updated by merging.
3. Generated based on 1.
4. Generated based on 1 and 3.

These pieces all support incremental update. For example if 1. is updated we can incrementally update the down stream items 3. and 4. Only needing to recompute the parts that change as a result of the changes in 1.