### PR TITLE
[closure segmenter] Further speed up the closure segmenter run time.

### DIFF
--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -408,8 +408,7 @@ class GlyphGroupings {
     GlyphSegmentation::ActivationCondition condition =
         GlyphSegmentation::ActivationCondition::exclusive_segment(
             exclusive_segment, 0);
-    conditions_and_glyphs_.erase(condition);
-    conditions_and_glyphs_[condition] = and_glyphs;
+    conditions_and_glyphs_[condition].union_set(glyphs);
     // triggering segment to conditions is not affected by this change, so
     // doesn't need an update.
   }
@@ -792,7 +791,7 @@ StatusOr<uint32_t> EstimatePatchSizeBytes(hb_face_t* original_face,
   GlyphKeyedDiff diff(font_data, id,
                       {FontHelper::kGlyf, FontHelper::kGvar, FontHelper::kCFF,
                        FontHelper::kCFF2},
-                      9);
+                      8);
 
   auto patch_data = TRY(diff.CreatePatch(gids));
   return patch_data.size();


### PR DESCRIPTION
This implements the following two changes to significantly speed up the run time of the closure segmenter:
1.  Brotli compression (used to estimated patch sizes) accounts for most of the time spent in the analysis. Reduce brotli quality from 9  to 8. Reduces run time of analysis of Noto Serif SC from approximately 45s -> 3s.
2. Track which segments are inert (non interacting). When merging a set of segments that are all inert we can bypass closure analysis on the new segment and form the new glyph set by unioning the exclusive gids from the merged segments. This roughly halves the number of closure calls in an example analysis of Noto Serif SC. Only a minor improvement to runtime, as the closure cost is dwarfed by brotli compression cost.