### PR TITLE
In font2ift by default output a woff2 encoded font with an option to disable.

### DIFF
--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -51,6 +51,8 @@ class Encoder {
    */
   void SetUsePreloadLists(bool value) { this->use_preload_lists_ = value; }
 
+  void SetWoff2Encode(bool value) { this->woff2_encode_ = value; }
+
   /*
    * Adds a segmentation of glyph data.
    *
@@ -119,8 +121,6 @@ class Encoder {
    */
   absl::StatusOr<Encoding> Encode() const;
 
-  // TODO(garretrieger): update handling of encoding for use in woff2,
-  // see: https://w3c.github.io/IFT/Overview.html#ift-and-compression
   static absl::StatusOr<common::FontData> RoundTripWoff2(
       absl::string_view font, bool glyf_transform = true);
 
@@ -327,6 +327,7 @@ class Encoder {
   uint32_t jump_ahead_ = 1;
   uint32_t next_id_ = 0;
   bool use_preload_lists_ = false;
+  bool woff2_encode_ = false;
 
   struct ProcessingContext {
     ProcessingContext(uint32_t next_id)

--- a/util/font2ift.cc
+++ b/util/font2ift.cc
@@ -40,8 +40,14 @@ ABSL_FLAG(std::string, config, "",
 ABSL_FLAG(std::string, output_path, "./",
           "Path to write output files under (base font and patches).");
 
-ABSL_FLAG(std::string, output_font, "out.ttf",
+ABSL_FLAG(std::string, output_font, "out.woff2",
           "Name of the outputted base font.");
+
+ABSL_FLAG(
+    bool, woff2_encode, true,
+    "If enabled the output font will be woff2 encoded. Transformations "
+    "in woff2 will be disabled when necessary to keep the woff2 encoding "
+    "compatible with IFT.");
 
 using absl::btree_set;
 using absl::flat_hash_map;
@@ -254,6 +260,7 @@ Status ConfigureEncoder(EncoderConfig config, Encoder& encoder) {
     encoder.SetJumpAhead(config.jump_ahead());
   }
   encoder.SetUsePreloadLists(config.use_preload_lists());
+  encoder.SetWoff2Encode(absl::GetFlag(FLAGS_woff2_encode));
 
   // Check for unsupported settings
   if (config.include_all_segment_patches()) {


### PR DESCRIPTION
Automatically disables glyf transformations in woff2 when needed as noted in https://w3c.github.io/IFT/Overview.html#ift-and-compression.