### PR TITLE
Use full invalidation (instead of partial) patches when modifying design space.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,10 +64,10 @@ http_archive(
 # Fontations
 http_archive(
     name = "fontations",
-    urls = ["https://github.com/googlefonts/fontations/archive/e8dbf2a0bf68ca7526cb4d507c25c75b7d2e3e9f.zip"],
-    strip_prefix = "fontations-e8dbf2a0bf68ca7526cb4d507c25c75b7d2e3e9f",
+    urls = ["https://github.com/googlefonts/fontations/archive/430e4fe1c22f58328400583c8cb4af9b60ce42c8.zip"],
+    strip_prefix = "fontations-430e4fe1c22f58328400583c8cb4af9b60ce42c8",
     build_file = "//third_party:fontations.BUILD",
-    integrity = "sha256-FVqusXECprz/Sp9vGY/dBCcqIzFBBR8SGMiy/Z6nXxE=",
+    integrity = "sha256-QdAedF9Bnj3uaXRHEDsU76s3+S93bQtdWKFnQPOuMd8=",
 )
 
 

--- a/fontations/Cargo.lock
+++ b/fontations/Cargo.lock
@@ -1273,7 +1273,7 @@ dependencies = [
 
 [[package]]
 name = "read-fonts"
-version = "0.29.3"
+version = "0.30.1"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -1500,7 +1500,7 @@ checksum = "bbbb5d9659141646ae647b42fe094daf6c6192d1620870b449d9557f748b2daa"
 
 [[package]]
 name = "skrifa"
-version = "0.31.3"
+version = "0.32.0"
 dependencies = [
  "bytemuck",
  "core_maths",
@@ -1974,7 +1974,7 @@ dependencies = [
 
 [[package]]
 name = "write-fonts"
-version = "0.38.2"
+version = "0.39.0"
 dependencies = [
  "bincode",
  "diff",

--- a/ift/encoder/encoder.h
+++ b/ift/encoder/encoder.h
@@ -182,6 +182,12 @@ class Encoder {
     // Returns the total effective subset definition added by this edge.
     const SubsetDefinition& Combined() const { return combined_; }
 
+    bool ChangesDesignSpace(const SubsetDefinition& base) const {
+      SubsetDefinition combined_and_base = Combined();
+      combined_and_base.Union(base);
+      return combined_and_base.design_space != base.design_space;
+    }
+
     std::vector<Jump> Jumps(const SubsetDefinition& base,
                             bool use_preload_lists) const {
       std::vector<Jump> result;


### PR DESCRIPTION
Design space changes require the glyph keyed patch map to be rewritten (since the glyph keyed patches in use are changed to match the new design space). Since the glyph keyed compat id is changed full invalidation is needed. Concretely this prevents unnecessary preloads for glyph keyed patches that can't be used after the design space change.