### PR TITLE
Rename Encoder and Encoder Config to Compiler and Segmentation Plan

### DIFF
--- a/ift/client/fontations_client.cc
+++ b/ift/client/fontations_client.cc
@@ -9,7 +9,7 @@
 #include "common/axis_range.h"
 #include "common/font_data.h"
 #include "common/int_set.h"
-#include "ift/encoder/encoder.h"
+#include "ift/encoder/compiler.h"
 
 using absl::btree_set;
 using absl::flat_hash_map;
@@ -20,7 +20,7 @@ using common::FontData;
 using common::IntSet;
 using common::make_hb_blob;
 using common::make_hb_face;
-using ift::encoder::Encoder;
+using ift::encoder::Compiler;
 
 namespace ift::client {
 
@@ -68,7 +68,7 @@ void ParseFetched(const std::string& text, btree_set<std::string>& uris_out) {
   }
 }
 
-StatusOr<std::string> WriteFontToDisk(const Encoder::Encoding& encoding) {
+StatusOr<std::string> WriteFontToDisk(const Compiler::Encoding& encoding) {
   char template_str[] = "fontations_client_XXXXXX";
   const char* temp_dir = mkdtemp(template_str);
 
@@ -112,7 +112,7 @@ StatusOr<std::string> Exec(const char* cmd) {
   return result;
 }
 
-Status ToGraph(const Encoder::Encoding& encoding, graph& out,
+Status ToGraph(const Compiler::Encoding& encoding, graph& out,
                bool include_patch_paths) {
   auto font_path = WriteFontToDisk(encoding);
   if (!font_path.ok()) {
@@ -136,7 +136,7 @@ Status ToGraph(const Encoder::Encoding& encoding, graph& out,
 }
 
 StatusOr<FontData> ExtendWithDesignSpace(
-    const Encoder::Encoding& encoding, const IntSet& codepoints,
+    const Compiler::Encoding& encoding, const IntSet& codepoints,
     const btree_set<hb_tag_t>& feature_tags,
     const flat_hash_map<hb_tag_t, AxisRange>& design_space,
     btree_set<std::string>* applied_uris, uint32_t max_round_trips,
@@ -205,7 +205,7 @@ StatusOr<FontData> ExtendWithDesignSpace(
   return FontData(make_hb_blob(hb_blob_create_from_file(output.c_str())));
 }
 
-StatusOr<FontData> Extend(const Encoder::Encoding& encoding,
+StatusOr<FontData> Extend(const Compiler::Encoding& encoding,
                           const IntSet& codepoints, uint32_t max_round_trips,
                           uint32_t max_fetches) {
   absl::flat_hash_map<hb_tag_t, common::AxisRange> design_space;

--- a/ift/client/fontations_client.h
+++ b/ift/client/fontations_client.h
@@ -12,7 +12,7 @@
 #include "common/axis_range.h"
 #include "common/font_data.h"
 #include "common/int_set.h"
-#include "ift/encoder/encoder.h"
+#include "ift/encoder/compiler.h"
 
 namespace ift::client {
 
@@ -22,7 +22,7 @@ typedef absl::btree_map<std::string, absl::btree_set<std::string>> graph;
  * Runs 'ift_graph' on the IFT font created by encoder and writes a
  * representation of the graph into 'out'.
  */
-absl::Status ToGraph(const ift::encoder::Encoder::Encoding& encoding,
+absl::Status ToGraph(const ift::encoder::Compiler::Encoding& encoding,
                      graph& out, bool include_patch_paths = false);
 
 /**
@@ -33,7 +33,7 @@ absl::Status ToGraph(const ift::encoder::Encoder::Encoding& encoding,
  * the client ended up fetching and applying.
  */
 absl::StatusOr<common::FontData> ExtendWithDesignSpace(
-    const ift::encoder::Encoder::Encoding& encoding,
+    const ift::encoder::Compiler::Encoding& encoding,
     const common::IntSet& codepoints,
     const absl::btree_set<hb_tag_t>& feature_tags,
     const absl::flat_hash_map<hb_tag_t, common::AxisRange>& design_space,
@@ -41,7 +41,7 @@ absl::StatusOr<common::FontData> ExtendWithDesignSpace(
     uint32_t max_round_trips = UINT32_MAX, uint32_t max_fetches = UINT32_MAX);
 
 absl::StatusOr<common::FontData> Extend(
-    const ift::encoder::Encoder::Encoding& encoding,
+    const ift::encoder::Compiler::Encoding& encoding,
     const common::IntSet& codepoints, uint32_t max_round_trips = UINT32_MAX,
     uint32_t max_fetches = UINT32_MAX);
 

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -3,8 +3,8 @@ cc_library(
     srcs = [
         "closure_glyph_segmenter.cc",
         "closure_glyph_segmenter.h",
-        "encoder.cc",
-        "encoder.h",
+        "compiler.cc",
+        "compiler.h",
         "glyph_segmentation.cc",
         "glyph_segmentation.h",
         "subset_definition.cc",
@@ -34,10 +34,10 @@ cc_library(
 )
 
 cc_test(
-    name = "encoder_test",
+    name = "compiler_test",
     size = "small",
     srcs = [
-        "encoder_test.cc",
+        "compiler_test.cc",
     ],
     data = [
         "//common:testdata",

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -22,7 +22,7 @@ cc_library(
     deps = [
         "//ift",
         "//ift/proto",
-        "//util:encoder_config_cc_proto",
+        "//util:segmentation_plan_cc_proto",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",

--- a/ift/encoder/compiler.h
+++ b/ift/encoder/compiler.h
@@ -124,7 +124,7 @@ class Compiler {
 
   /*
    * Create an IFT encoded version of 'font' that initially supports
-   * the configured base subset but can be extended via patches to support any
+   * the configured init subset but can be extended via patches to support any
    * combination of of extension subsets.
    *
    * Returns: the IFT encoded initial font. Patches() will be populated with the

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -490,8 +490,8 @@ ActivationConditionProto GlyphSegmentation::ActivationCondition::ToConfigProto()
   return proto;
 }
 
-EncoderConfig GlyphSegmentation::ToConfigProto() const {
-  EncoderConfig config;
+SegmentationPlan GlyphSegmentation::ToSegmentationPlanProto() const {
+  SegmentationPlan config;
 
   uint32_t set_index = 0;
   for (const auto& s : Segments()) {

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -10,7 +10,7 @@
 #include "common/int_set.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/proto/patch_map.h"
-#include "util/encoder_config.pb.h"
+#include "util/segmentation_plan.pb.h"
 
 namespace ift::encoder {
 
@@ -205,7 +205,7 @@ class GlyphSegmentation {
     return init_font_segment_;
   };
 
-  EncoderConfig ToConfigProto() const;
+  SegmentationPlan ToSegmentationPlanProto() const;
 
   static absl::Status GroupsToSegmentation(
       const absl::btree_map<common::SegmentSet, common::GlyphSet>&

--- a/ift/encoder/glyph_segmentation_test.cc
+++ b/ift/encoder/glyph_segmentation_test.cc
@@ -199,7 +199,7 @@ TEST_F(GlyphSegmentationTest, SimpleSegmentation_ToConfigProto) {
       segmenter.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'b'}, {'c'}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  auto config = segmentation->ToConfigProto();
+  auto config = segmentation->ToSegmentationPlanProto();
   std::string config_string;
   TextFormat::PrintToString(config, &config_string);
 
@@ -273,7 +273,7 @@ TEST_F(GlyphSegmentationTest, SimpleSegmentationWithFeatures_ToConfigProto) {
                                                          {{'b'}, {'c'}, smcp});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  auto config = segmentation->ToConfigProto();
+  auto config = segmentation->ToSegmentationPlanProto();
   std::string config_string;
   TextFormat::PrintToString(config, &config_string);
 
@@ -399,7 +399,7 @@ TEST_F(GlyphSegmentationTest, MixedAndOr_ToConfigProto) {
       roboto.get(), {'a'}, {{'f', 0xc1}, {'i', 0x106}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  auto config = segmentation->ToConfigProto();
+  auto config = segmentation->ToSegmentationPlanProto();
   std::string config_string;
   TextFormat::PrintToString(config, &config_string);
 
@@ -508,7 +508,7 @@ TEST_F(GlyphSegmentationTest, MergeBases_ToConfigProto) {
       {{'a', 'b', 'd'}, {'e', 'f'}, {'j', 'k'}, {'m', 'n', 'o', 'p'}}, 370);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  auto config = segmentation->ToConfigProto();
+  auto config = segmentation->ToSegmentationPlanProto();
   std::string config_string;
   TextFormat::PrintToString(config, &config_string);
 

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -12,7 +12,7 @@
 #include "gtest/gtest.h"
 #include "hb.h"
 #include "ift/client/fontations_client.h"
-#include "ift/encoder/encoder.h"
+#include "ift/encoder/compiler.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
@@ -35,7 +35,7 @@ using common::make_hb_face;
 using common::make_hb_set;
 using ift::client::Extend;
 using ift::client::ExtendWithDesignSpace;
-using ift::encoder::Encoder;
+using ift::encoder::Compiler;
 using ift::encoder::SubsetDefinition;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
@@ -94,7 +94,7 @@ class IntegrationTest : public ::testing::Test {
     roboto_vf_.set(blob.get());
   }
 
-  StatusOr<GlyphSet> InitEncoderForMixedMode(Encoder& encoder) {
+  StatusOr<GlyphSet> InitEncoderForMixedMode(Compiler& compiler) {
     auto face = noto_sans_jp_.face();
 
     GlyphSet init;
@@ -108,13 +108,13 @@ class IntegrationTest : public ::testing::Test {
 
     init.subtract(excluded);
 
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
 
-    auto sc = encoder.AddGlyphDataPatch(0, init);
-    sc.Update(encoder.AddGlyphDataPatch(1, TestSegment1()));
-    sc.Update(encoder.AddGlyphDataPatch(2, TestSegment2()));
-    sc.Update(encoder.AddGlyphDataPatch(3, TestSegment3()));
-    sc.Update(encoder.AddGlyphDataPatch(4, TestSegment4()));
+    auto sc = compiler.AddGlyphDataPatch(0, init);
+    sc.Update(compiler.AddGlyphDataPatch(1, TestSegment1()));
+    sc.Update(compiler.AddGlyphDataPatch(2, TestSegment2()));
+    sc.Update(compiler.AddGlyphDataPatch(3, TestSegment3()));
+    sc.Update(compiler.AddGlyphDataPatch(4, TestSegment4()));
 
     if (!sc.ok()) {
       return sc;
@@ -123,12 +123,12 @@ class IntegrationTest : public ::testing::Test {
     return init;
   }
 
-  Status InitEncoderForMixedModeCff(Encoder& encoder) {
+  Status InitEncoderForMixedModeCff(Compiler& compiler) {
     auto face = noto_sans_jp_cff_.face();
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
 
-    auto sc = encoder.AddGlyphDataPatch(1, {34, 35, 46, 47});   // A, B, M, N
-    sc.Update(encoder.AddGlyphDataPatch(2, {41, 42, 43, 59}));  // H, I, J, Z
+    auto sc = compiler.AddGlyphDataPatch(1, {34, 35, 46, 47});   // A, B, M, N
+    sc.Update(compiler.AddGlyphDataPatch(2, {41, 42, 43, 59}));  // H, I, J, Z
 
     if (!sc.ok()) {
       return sc;
@@ -137,19 +137,19 @@ class IntegrationTest : public ::testing::Test {
     return absl::OkStatus();
   }
 
-  Status InitEncoderForMixedModeCff2(Encoder& encoder) {
+  Status InitEncoderForMixedModeCff2(Compiler& compiler) {
     auto face = noto_sans_jp_cff2_.face();
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
 
-    TRYV(encoder.AddGlyphDataPatch(1, {34, 35, 36}));      // A, B, C
-    TRYV(encoder.AddGlyphDataPatch(2, {46, 47, 49, 59}));  // M, N, P, Z
+    TRYV(compiler.AddGlyphDataPatch(1, {34, 35, 36}));      // A, B, C
+    TRYV(compiler.AddGlyphDataPatch(2, {46, 47, 49, 59}));  // M, N, P, Z
 
     return absl::OkStatus();
   }
 
-  StatusOr<GlyphSet> InitEncoderForVfMixedMode(Encoder& encoder) {
+  StatusOr<GlyphSet> InitEncoderForVfMixedMode(Compiler& compiler) {
     auto face = noto_sans_vf_.face();
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
 
     GlyphSet init;
     init.insert_range(0, hb_face_get_glyph_count(face.get()) - 1);
@@ -162,17 +162,17 @@ class IntegrationTest : public ::testing::Test {
 
     init.subtract(excluded);
 
-    auto sc = encoder.AddGlyphDataPatch(0, init);
-    sc.Update(encoder.AddGlyphDataPatch(1, TestVfSegment1()));
-    sc.Update(encoder.AddGlyphDataPatch(2, TestVfSegment2()));
-    sc.Update(encoder.AddGlyphDataPatch(3, TestVfSegment3()));
-    sc.Update(encoder.AddGlyphDataPatch(4, TestVfSegment4()));
+    auto sc = compiler.AddGlyphDataPatch(0, init);
+    sc.Update(compiler.AddGlyphDataPatch(1, TestVfSegment1()));
+    sc.Update(compiler.AddGlyphDataPatch(2, TestVfSegment2()));
+    sc.Update(compiler.AddGlyphDataPatch(3, TestVfSegment3()));
+    sc.Update(compiler.AddGlyphDataPatch(4, TestVfSegment4()));
     return init;
   }
 
-  StatusOr<GlyphSet> InitEncoderForMixedModeFeatureTest(Encoder& encoder) {
+  StatusOr<GlyphSet> InitEncoderForMixedModeFeatureTest(Compiler& compiler) {
     auto face = feature_test_.face();
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
 
     GlyphSet init;
     init.insert_range(0, hb_face_get_glyph_count(face.get()) - 1);
@@ -187,25 +187,25 @@ class IntegrationTest : public ::testing::Test {
 
     init.subtract(excluded);
 
-    auto sc = encoder.AddGlyphDataPatch(0, init);
-    sc.Update(encoder.AddGlyphDataPatch(1, TestFeatureSegment1()));
-    sc.Update(encoder.AddGlyphDataPatch(2, TestFeatureSegment2()));
-    sc.Update(encoder.AddGlyphDataPatch(3, TestFeatureSegment3()));
-    sc.Update(encoder.AddGlyphDataPatch(4, TestFeatureSegment4()));
-    sc.Update(encoder.AddGlyphDataPatch(5, TestFeatureSegment5()));
-    sc.Update(encoder.AddGlyphDataPatch(6, TestFeatureSegment6()));
+    auto sc = compiler.AddGlyphDataPatch(0, init);
+    sc.Update(compiler.AddGlyphDataPatch(1, TestFeatureSegment1()));
+    sc.Update(compiler.AddGlyphDataPatch(2, TestFeatureSegment2()));
+    sc.Update(compiler.AddGlyphDataPatch(3, TestFeatureSegment3()));
+    sc.Update(compiler.AddGlyphDataPatch(4, TestFeatureSegment4()));
+    sc.Update(compiler.AddGlyphDataPatch(5, TestFeatureSegment5()));
+    sc.Update(compiler.AddGlyphDataPatch(6, TestFeatureSegment6()));
     return init;
   }
 
-  Status InitEncoderForTableKeyed(Encoder& encoder) {
+  Status InitEncoderForTableKeyed(Compiler& compiler) {
     auto face = noto_sans_jp_.face();
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
     return absl::OkStatus();
   }
 
-  Status InitEncoderForVf(Encoder& encoder) {
+  Status InitEncoderForVf(Compiler& compiler) {
     auto face = roboto_vf_.face();
-    encoder.SetFace(face.get());
+    compiler.SetFace(face.get());
     return absl::OkStatus();
   }
 
@@ -297,18 +297,18 @@ bool GvarDataMatches(hb_face_t* a, hb_face_t* b, uint32_t codepoint,
 // TODO(garretrieger): test of a woff2 encoded IFT font.
 
 TEST_F(IntegrationTest, TableKeyedOnly) {
-  Encoder encoder;
-  auto sc = InitEncoderForTableKeyed(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForTableKeyed(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = encoder.SetInitSubset(IntSet{0x41, 0x42, 0x43});
-  encoder.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
-  encoder.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
+  sc = compiler.SetInitSubset(IntSet{0x41, 0x42, 0x43});
+  compiler.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
+  compiler.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto encoded_face = encoding->init_font.face();
@@ -338,23 +338,23 @@ TEST_F(IntegrationTest, TableKeyedOnly) {
 }
 
 TEST_F(IntegrationTest, TableKeyed_CodepointsAndFeatureSegment) {
-  Encoder encoder;
-  auto sc = InitEncoderForVf(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForVf(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = encoder.SetInitSubset(IntSet{0x41, 0x42, 0x43});
+  sc = compiler.SetInitSubset(IntSet{0x41, 0x42, 0x43});
 
   SubsetDefinition s1{0x45, 0x46, 0x47};
   s1.feature_tags = {HB_TAG('s', 'm', 'c', 'p')};
-  encoder.AddNonGlyphDataSegment(s1);
+  compiler.AddNonGlyphDataSegment(s1);
 
   SubsetDefinition s2{0x48};
   s2.feature_tags = {HB_TAG('d', 'l', 'i', 'g')};
-  encoder.AddNonGlyphDataSegment(s2);
+  compiler.AddNonGlyphDataSegment(s2);
 
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto encoded_face = encoding->init_font.face();
@@ -396,20 +396,20 @@ TEST_F(IntegrationTest, TableKeyed_CodepointsAndFeatureSegment) {
 }
 
 TEST_F(IntegrationTest, TableKeyedOnly_Woff2Encoded) {
-  Encoder encoder;
-  auto sc = InitEncoderForTableKeyed(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForTableKeyed(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = encoder.SetInitSubset(IntSet{0x41, 0x42, 0x43});
-  encoder.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
-  encoder.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
+  sc = compiler.SetInitSubset(IntSet{0x41, 0x42, 0x43});
+  compiler.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
+  compiler.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  encoder.SetWoff2Encode(true);
+  compiler.SetWoff2Encode(true);
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto woff2_decoded = common::Woff2::DecodeWoff2(encoding->init_font.str());
@@ -443,18 +443,18 @@ TEST_F(IntegrationTest, TableKeyedOnly_Woff2Encoded) {
 }
 
 TEST_F(IntegrationTest, TableKeyedMultiple) {
-  Encoder encoder;
-  auto sc = InitEncoderForTableKeyed(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForTableKeyed(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = encoder.SetInitSubset(IntSet{0x41, 0x42, 0x43});
-  encoder.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
-  encoder.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
+  sc = compiler.SetInitSubset(IntSet{0x41, 0x42, 0x43});
+  compiler.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
+  compiler.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto encoded_face = encoding->init_font.face();
@@ -484,20 +484,20 @@ TEST_F(IntegrationTest, TableKeyedMultiple) {
 }
 
 TEST_F(IntegrationTest, TableKeyed_JumpAheadAndPreloadLists) {
-  Encoder encoder;
-  auto sc = InitEncoderForTableKeyed(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForTableKeyed(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = encoder.SetInitSubset(IntSet{0x41, 0x42, 0x43});
-  encoder.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
-  encoder.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
-  encoder.SetJumpAhead(3);
-  encoder.SetUsePreloadLists(true);
+  sc = compiler.SetInitSubset(IntSet{0x41, 0x42, 0x43});
+  compiler.AddNonGlyphDataSegment(IntSet{0x45, 0x46, 0x47});
+  compiler.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
+  compiler.SetJumpAhead(3);
+  compiler.SetUsePrefetchLists(true);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto encoded_face = encoding->init_font.face();
@@ -530,19 +530,19 @@ TEST_F(IntegrationTest, TableKeyed_JumpAheadAndPreloadLists) {
 }
 
 TEST_F(IntegrationTest, TableKeyedWithOverlaps) {
-  Encoder encoder;
-  auto sc = InitEncoderForTableKeyed(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForTableKeyed(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = encoder.SetInitSubset(IntSet{0x41, 0x42, 0x43});
-  encoder.AddNonGlyphDataSegment(
+  sc = compiler.SetInitSubset(IntSet{0x41, 0x42, 0x43});
+  compiler.AddNonGlyphDataSegment(
       IntSet{0x45, 0x46, 0x47, 0x48});  // 0x48 is in two subsets
-  encoder.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
-  encoder.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
+  compiler.AddNonGlyphDataSegment(IntSet{0x48, 0x49, 0x4A});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4B, 0x4C, 0x4D});
+  compiler.AddNonGlyphDataSegment(IntSet{0x4E, 0x4F, 0x50});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto encoded_face = encoding->init_font.face();
@@ -580,20 +580,20 @@ TEST_F(IntegrationTest, TableKeyedWithOverlaps) {
 }
 
 TEST_F(IntegrationTest, TableKeyed_DesignSpaceAugmentation_IgnoresDesignSpace) {
-  Encoder encoder;
-  auto sc = InitEncoderForVf(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForVf(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
   SubsetDefinition def{'a', 'b', 'c'};
   def.design_space[kWdth] = AxisRange::Point(100.0f);
-  sc = encoder.SetInitSubsetFromDef(def);
+  sc = compiler.SetInitSubsetFromDef(def);
 
-  encoder.AddNonGlyphDataSegment(IntSet{'d', 'e', 'f'});
-  encoder.AddNonGlyphDataSegment(IntSet{'h', 'i', 'j'});
-  encoder.AddDesignSpaceSegment({{kWdth, *AxisRange::Range(75.0f, 100.0f)}});
+  compiler.AddNonGlyphDataSegment(IntSet{'d', 'e', 'f'});
+  compiler.AddNonGlyphDataSegment(IntSet{'h', 'i', 'j'});
+  compiler.AddDesignSpaceSegment({{kWdth, *AxisRange::Range(75.0f, 100.0f)}});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -630,20 +630,20 @@ TEST_F(IntegrationTest, TableKeyed_DesignSpaceAugmentation_IgnoresDesignSpace) {
 }
 
 TEST_F(IntegrationTest, SharedBrotli_DesignSpaceAugmentation) {
-  Encoder encoder;
-  auto sc = InitEncoderForVf(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForVf(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
   SubsetDefinition def{'a', 'b', 'c'};
   def.design_space[kWdth] = AxisRange::Point(100.0f);
-  sc = encoder.SetInitSubsetFromDef(def);
+  sc = compiler.SetInitSubsetFromDef(def);
 
-  encoder.AddNonGlyphDataSegment(IntSet{'d', 'e', 'f'});
-  encoder.AddNonGlyphDataSegment(IntSet{'h', 'i', 'j'});
-  encoder.AddDesignSpaceSegment({{kWdth, *AxisRange::Range(75.0f, 100.0f)}});
+  compiler.AddNonGlyphDataSegment(IntSet{'d', 'e', 'f'});
+  compiler.AddNonGlyphDataSegment(IntSet{'h', 'i', 'j'});
+  compiler.AddDesignSpaceSegment({{kWdth, *AxisRange::Range(75.0f, 100.0f)}});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -702,8 +702,8 @@ TEST_F(IntegrationTest, SharedBrotli_DesignSpaceAugmentation) {
 }
 
 TEST_F(IntegrationTest, MixedMode) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_jp_.face();
@@ -719,24 +719,24 @@ TEST_F(IntegrationTest, MixedMode) {
   IntSet base;
   base.insert(segment_0.begin(), segment_0.end());
   base.insert(segment_1.begin(), segment_1.end());
-  auto sc = encoder.SetInitSubset(base);
+  auto sc = compiler.SetInitSubset(base);
 
-  encoder.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_2);
 
   auto segment = segment_3;
   segment.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment);
+  compiler.AddNonGlyphDataSegment(segment);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // Setup activations for 2 through 4 (1 is init)
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -778,8 +778,8 @@ TEST_F(IntegrationTest, MixedMode) {
 }
 
 TEST_F(IntegrationTest, MixedMode_Woff2Encoded) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_jp_.face();
@@ -795,26 +795,26 @@ TEST_F(IntegrationTest, MixedMode_Woff2Encoded) {
   IntSet base;
   base.insert(segment_0.begin(), segment_0.end());
   base.insert(segment_1.begin(), segment_1.end());
-  auto sc = encoder.SetInitSubset(base);
+  auto sc = compiler.SetInitSubset(base);
 
-  encoder.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_2);
 
   auto segment = segment_3;
   segment.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment);
+  compiler.AddNonGlyphDataSegment(segment);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // Setup activations for 2 through 4 (1 is init)
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
 
-  encoder.SetWoff2Encode(true);
+  compiler.SetWoff2Encode(true);
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
 
   auto woff2_decoded = common::Woff2::DecodeWoff2(encoding->init_font.str());
@@ -860,8 +860,8 @@ TEST_F(IntegrationTest, MixedMode_Woff2Encoded) {
 }
 
 TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedModeFeatureTest(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedModeFeatureTest(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   // target paritions: {{0}, {1}, {2}, {3}, {4}}
@@ -875,20 +875,20 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
   auto segment_3 = FontHelper::GidsToUnicodes(face.get(), TestSegment3());
   auto segment_4 = FontHelper::GidsToUnicodes(face.get(), TestSegment4());
 
-  auto sc = encoder.SetInitSubset(segment_0);
+  auto sc = compiler.SetInitSubset(segment_0);
 
-  encoder.AddNonGlyphDataSegment(segment_1);
-  encoder.AddNonGlyphDataSegment(segment_2);
-  encoder.AddNonGlyphDataSegment(segment_3);
-  encoder.AddNonGlyphDataSegment(segment_4);
+  compiler.AddNonGlyphDataSegment(segment_1);
+  compiler.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_3);
+  compiler.AddNonGlyphDataSegment(segment_4);
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_1, 1, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
 
   {
@@ -897,7 +897,7 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
     entry.coverage.features = {kVrt3};
     entry.patch_indices.push_back(5);
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -906,7 +906,7 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
     entry.coverage.features = {kVrt3};
     entry.patch_indices.push_back(5);
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -915,13 +915,13 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
     entry.coverage.features = {kVrt3};
     entry.patch_indices.push_back(6);
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
-  encoder.AddFeatureGroupSegment({kVrt3});
+  compiler.AddFeatureGroupSegment({kVrt3});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -974,8 +974,8 @@ TEST_F(IntegrationTest, MixedMode_OptionalFeatureTags) {
 }
 
 TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_jp_.face();
@@ -990,8 +990,8 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
   all.insert(segment_4.begin(), segment_4.end());
 
   // target paritions: {}, {{1}, {2}, {3, 4}}
-  auto sc = encoder.SetInitSubset(IntSet{});
-  encoder.AddNonGlyphDataSegment(all);
+  auto sc = compiler.SetInitSubset(IntSet{});
+  compiler.AddNonGlyphDataSegment(all);
   ASSERT_TRUE(sc.ok()) << sc;
 
   // Setup some composite activation conditions
@@ -1002,7 +1002,7 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.patch_indices.push_back(0);
     entry.ignored = true;
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -1012,7 +1012,7 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.patch_indices.push_back(0);
     entry.ignored = true;
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -1022,7 +1022,7 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.patch_indices.push_back(0);
     entry.ignored = true;
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -1033,7 +1033,7 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.patch_indices.push_back(0);
     entry.ignored = true;
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -1043,7 +1043,7 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.coverage.child_indices = {3, 2};  // (1 OR 2) AND 3
     entry.patch_indices.push_back(4);
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -1054,7 +1054,7 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.patch_indices.push_back(0);
     entry.ignored = true;
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
   {
@@ -1064,10 +1064,10 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
     entry.coverage.conjunctive = true;
     entry.patch_indices.push_back(3);
     entry.encoding = PatchEncoding::GLYPH_KEYED;
-    sc.Update(encoder.AddGlyphDataPatchCondition(entry));
+    sc.Update(compiler.AddGlyphDataPatchCondition(entry));
   }
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1121,8 +1121,8 @@ TEST_F(IntegrationTest, MixedMode_CompositeConditions) {
 }
 
 TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_jp_.face();
@@ -1133,24 +1133,24 @@ TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
   auto segment_4 = FontHelper::GidsToUnicodes(face.get(), TestSegment4());
 
   // target paritions: {{0}, {1}, {2}, {3}, {4}}
-  auto sc = encoder.SetInitSubset(segment_0);
-  encoder.AddNonGlyphDataSegment(segment_1);
-  encoder.AddNonGlyphDataSegment(segment_2);
-  encoder.AddNonGlyphDataSegment(segment_3);
-  encoder.AddNonGlyphDataSegment(segment_4);
+  auto sc = compiler.SetInitSubset(segment_0);
+  compiler.AddNonGlyphDataSegment(segment_1);
+  compiler.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_3);
+  compiler.AddNonGlyphDataSegment(segment_4);
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_1, 1, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
 
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1202,8 +1202,8 @@ TEST_F(IntegrationTest, MixedMode_LocaLenChange) {
 }
 
 TEST_F(IntegrationTest, MixedMode_Complex) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_jp_.face();
@@ -1214,25 +1214,25 @@ TEST_F(IntegrationTest, MixedMode_Complex) {
   auto segment_4 = FontHelper::GidsToUnicodes(face.get(), TestSegment4());
 
   // target paritions: {{0}, {1, 2}, {3, 4}}
-  auto sc = encoder.SetInitSubset(segment_0);
+  auto sc = compiler.SetInitSubset(segment_0);
   auto segment_1_and_2 = segment_1;
   segment_1_and_2.insert(segment_2.begin(), segment_2.end());
-  encoder.AddNonGlyphDataSegment(segment_1_and_2);
+  compiler.AddNonGlyphDataSegment(segment_1_and_2);
   auto segment_3_and_4 = segment_3;
   segment_3_and_4.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment_3_and_4);
+  compiler.AddNonGlyphDataSegment(segment_3_and_4);
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_1, 1, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1263,8 +1263,8 @@ TEST_F(IntegrationTest, MixedMode_Complex) {
 }
 
 TEST_F(IntegrationTest, MixedMode_SequentialDependentPatches) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_jp_.face();
@@ -1277,20 +1277,20 @@ TEST_F(IntegrationTest, MixedMode_SequentialDependentPatches) {
   // target paritions: {{0, 1}, {2}, {3}, {4}}
   IntSet segment_0_and_1 = segment_0;
   segment_0_and_1.union_set(segment_1);
-  auto sc = encoder.SetInitSubset(segment_0_and_1);
-  encoder.AddNonGlyphDataSegment(segment_2);
-  encoder.AddNonGlyphDataSegment(segment_3);
-  encoder.AddNonGlyphDataSegment(segment_4);
+  auto sc = compiler.SetInitSubset(segment_0_and_1);
+  compiler.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_3);
+  compiler.AddNonGlyphDataSegment(segment_4);
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1307,8 +1307,8 @@ TEST_F(IntegrationTest, MixedMode_SequentialDependentPatches) {
 }
 
 TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForVfMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForVfMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_vf_.face();
@@ -1324,23 +1324,23 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation) {
   base_def.codepoints.insert(segment_0.begin(), segment_0.end());
   base_def.codepoints.insert(segment_1.begin(), segment_1.end());
   base_def.design_space = {{kWght, AxisRange::Point(100)}};
-  auto sc = encoder.SetInitSubsetFromDef(base_def);
+  auto sc = compiler.SetInitSubsetFromDef(base_def);
 
-  encoder.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_2);
   auto segment_3_and_4 = segment_3;
   segment_3_and_4.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment_3_and_4);
-  encoder.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
+  compiler.AddNonGlyphDataSegment(segment_3_and_4);
+  compiler.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1388,10 +1388,10 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation) {
 
 TEST_F(IntegrationTest,
        MixedMode_DesignSpaceAugmentation_UsesFullInvalidation) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForVfMixedMode(encoder);
-  encoder.SetJumpAhead(2);
-  encoder.SetUsePreloadLists(false);
+  Compiler compiler;
+  auto init_gids = InitEncoderForVfMixedMode(compiler);
+  compiler.SetJumpAhead(2);
+  compiler.SetUsePrefetchLists(false);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_vf_.face();
@@ -1407,23 +1407,23 @@ TEST_F(IntegrationTest,
   base_def.codepoints.insert(segment_0.begin(), segment_0.end());
   base_def.codepoints.insert(segment_1.begin(), segment_1.end());
   base_def.design_space = {{kWght, AxisRange::Point(100)}};
-  auto sc = encoder.SetInitSubsetFromDef(base_def);
+  auto sc = compiler.SetInitSubsetFromDef(base_def);
 
-  encoder.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_2);
   auto segment_3_and_4 = segment_3;
   segment_3_and_4.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment_3_and_4);
-  encoder.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
+  compiler.AddNonGlyphDataSegment(segment_3_and_4);
+  compiler.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1456,10 +1456,10 @@ TEST_F(IntegrationTest,
 
 TEST_F(IntegrationTest,
        MixedMode_DesignSpaceAugmentation_UsesFullInvalidationWithPreloadLists) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForVfMixedMode(encoder);
-  encoder.SetJumpAhead(2);
-  encoder.SetUsePreloadLists(true);
+  Compiler compiler;
+  auto init_gids = InitEncoderForVfMixedMode(compiler);
+  compiler.SetJumpAhead(2);
+  compiler.SetUsePrefetchLists(true);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_vf_.face();
@@ -1475,23 +1475,23 @@ TEST_F(IntegrationTest,
   base_def.codepoints.insert(segment_0.begin(), segment_0.end());
   base_def.codepoints.insert(segment_1.begin(), segment_1.end());
   base_def.design_space = {{kWght, AxisRange::Point(100)}};
-  auto sc = encoder.SetInitSubsetFromDef(base_def);
+  auto sc = compiler.SetInitSubsetFromDef(base_def);
 
-  encoder.AddNonGlyphDataSegment(segment_2);
+  compiler.AddNonGlyphDataSegment(segment_2);
   auto segment_3_and_4 = segment_3;
   segment_3_and_4.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment_3_and_4);
-  encoder.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
+  compiler.AddNonGlyphDataSegment(segment_3_and_4);
+  compiler.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1525,8 +1525,8 @@ TEST_F(IntegrationTest,
 }
 
 TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_DropsUnusedPatches) {
-  Encoder encoder;
-  auto init_gids = InitEncoderForVfMixedMode(encoder);
+  Compiler compiler;
+  auto init_gids = InitEncoderForVfMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();
 
   auto face = noto_sans_vf_.face();
@@ -1541,23 +1541,23 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_DropsUnusedPatches) {
   base_def.codepoints.insert(segment_0.begin(), segment_0.end());
   base_def.codepoints.insert(segment_1.begin(), segment_1.end());
   base_def.design_space = {{kWght, AxisRange::Point(100)}};
-  auto sc = encoder.SetInitSubsetFromDef(base_def);
-  encoder.AddNonGlyphDataSegment(segment_2);
+  auto sc = compiler.SetInitSubsetFromDef(base_def);
+  compiler.AddNonGlyphDataSegment(segment_2);
   auto segment_3_and_4 = segment_3;
   segment_3_and_4.insert(segment_4.begin(), segment_4.end());
-  encoder.AddNonGlyphDataSegment(segment_3_and_4);
-  encoder.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
+  compiler.AddNonGlyphDataSegment(segment_3_and_4);
+  compiler.AddDesignSpaceSegment({{kWght, *AxisRange::Range(100, 900)}});
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_2, 2, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_3, 3, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry(segment_4, 4, PatchEncoding::GLYPH_KEYED)));
 
   ASSERT_TRUE(sc.ok()) << sc;
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1607,23 +1607,23 @@ StatusOr<FontData> desubroutinize(hb_face_t* font) {
 }
 
 TEST_F(IntegrationTest, MixedMode_Cff) {
-  Encoder encoder;
-  auto sc = InitEncoderForMixedModeCff(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForMixedModeCff(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  ASSERT_TRUE(encoder.SetInitSubset(IntSet{}).ok());
+  ASSERT_TRUE(compiler.SetInitSubset(IntSet{}).ok());
 
   IntSet all_codepoints{'A', 'B', 'H', 'I', 'J', 'M', 'N', 'Z'};
   auto face = noto_sans_jp_cff_.face();
-  encoder.AddNonGlyphDataSegment(all_codepoints);
+  compiler.AddNonGlyphDataSegment(all_codepoints);
 
   // Setup activations for patches 1 and 2
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry({'A', 'B', 'M', 'N'}, 1, PatchEncoding::GLYPH_KEYED)));
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry({'H', 'I', 'J', 'Z'}, 2, PatchEncoding::GLYPH_KEYED)));
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 
@@ -1670,24 +1670,24 @@ TEST_F(IntegrationTest, MixedMode_Cff) {
 }
 
 TEST_F(IntegrationTest, MixedMode_Cff2) {
-  Encoder encoder;
-  auto sc = InitEncoderForMixedModeCff2(encoder);
+  Compiler compiler;
+  auto sc = InitEncoderForMixedModeCff2(compiler);
   ASSERT_TRUE(sc.ok()) << sc;
 
-  ASSERT_TRUE(encoder.SetInitSubset(IntSet{}).ok());
+  ASSERT_TRUE(compiler.SetInitSubset(IntSet{}).ok());
 
   IntSet all_codepoints{'A', 'B', 'C', 'M', 'N', 'P', 'Z'};
   auto face = noto_sans_jp_cff2_.face();
-  encoder.AddNonGlyphDataSegment(all_codepoints);
+  compiler.AddNonGlyphDataSegment(all_codepoints);
 
   // Setup activations for patches 1 and 2
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry({'A', 'B', 'C'}, 1, PatchEncoding::GLYPH_KEYED)));
 
-  sc.Update(encoder.AddGlyphDataPatchCondition(
+  sc.Update(compiler.AddGlyphDataPatchCondition(
       PatchMap::Entry({'M', 'N', 'P', 'Z'}, 2, PatchEncoding::GLYPH_KEYED)));
 
-  auto encoding = encoder.Encode();
+  auto encoding = compiler.Encode();
   ASSERT_TRUE(encoding.ok()) << encoding.status();
   auto encoded_face = encoding->init_font.face();
 

--- a/util/BUILD
+++ b/util/BUILD
@@ -1,11 +1,11 @@
 proto_library(
-    name = "encoder_config_proto",
-    srcs = ["encoder_config.proto"],
+    name = "segmentation_plan_proto",
+    srcs = ["segmentation_plan.proto"],
 )
 
 cc_proto_library(
-    name = "encoder_config_cc_proto",
-    deps = [":encoder_config_proto"],
+    name = "segmentation_plan_cc_proto",
+    deps = [":segmentation_plan_proto"],
     visibility = [
         "//ift/encoder:__pkg__",
     ]
@@ -20,7 +20,7 @@ cc_binary(
         "//ift",
         "//ift/encoder",
         "//common",
-        ":encoder_config_cc_proto",
+        ":segmentation_plan_cc_proto",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
@@ -36,7 +36,7 @@ cc_binary(
         "generate_table_keyed_config.cc",
     ],
     deps = [
-        ":encoder_config_cc_proto",
+        ":segmentation_plan_cc_proto",
         ":load_codepoints",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",
@@ -54,7 +54,7 @@ cc_binary(
         "//ift",
         "//ift/encoder",
         "//common",
-        ":encoder_config_cc_proto",
+        ":segmentation_plan_cc_proto",
         ":load_codepoints",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/flags:flag",
@@ -73,7 +73,7 @@ cc_library(
     ],
     deps = [
         "//common",
-        ":encoder_config_cc_proto",
+        ":segmentation_plan_cc_proto",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/container:flat_hash_set",
@@ -138,7 +138,7 @@ cc_binary(
     ],
     deps = [
         ":convert_iftb",
-        ":encoder_config_cc_proto",
+        ":segmentation_plan_cc_proto",
         "@abseil-cpp//absl/container:flat_hash_set",
         "@abseil-cpp//absl/flags:flag",
         "@abseil-cpp//absl/flags:parse",

--- a/util/closure_glyph_keyed_segmenter_util.cc
+++ b/util/closure_glyph_keyed_segmenter_util.cc
@@ -25,8 +25,8 @@
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
 #include "ift/url_template.h"
-#include "util/encoder_config.pb.h"
 #include "util/load_codepoints.h"
+#include "util/segmentation_plan.pb.h"
 
 /*
  * Given a code point based segmentation creates an appropriate glyph based
@@ -37,8 +37,8 @@
 ABSL_FLAG(std::string, input_font, "in.ttf",
           "Name of the font to convert to IFT.");
 
-ABSL_FLAG(bool, output_encoder_config, false,
-          "If set an encoder config representing the determined segmentation "
+ABSL_FLAG(bool, output_segmentation_plan, false,
+          "If set a segmentation plan representing the determined segmentation "
           "will be output to stdout.");
 
 ABSL_FLAG(bool, include_initial_codepoints_in_config, true,
@@ -393,11 +393,11 @@ int main(int argc, char** argv) {
     return -1;
   }
 
-  if (absl::GetFlag(FLAGS_output_encoder_config)) {
-    EncoderConfig config = result->ToConfigProto();
+  if (absl::GetFlag(FLAGS_output_segmentation_plan)) {
+    SegmentationPlan plan = result->ToSegmentationPlanProto();
     if (!absl::GetFlag(FLAGS_include_initial_codepoints_in_config)) {
       // Requested to not include init codepoints in the generated config.
-      config.clear_initial_codepoints();
+      plan.clear_initial_codepoints();
     }
 
     // TODO(garretrieger): assign a basic (single segment) table keyed config.
@@ -405,7 +405,7 @@ int main(int argc, char** argv) {
     // segments should be grouped together for the table keyed portion of the
     // font.
     std::string config_string;
-    TextFormat::PrintToString(config, &config_string);
+    TextFormat::PrintToString(plan, &config_string);
     std::cout << config_string;
   } else {
     // No config requested, just output a simplified plain text representation

--- a/util/convert_iftb.cc
+++ b/util/convert_iftb.cc
@@ -10,7 +10,7 @@
 #include "common/font_helper.h"
 #include "common/int_set.h"
 #include "hb.h"
-#include "util/encoder_config.pb.h"
+#include "util/segmentation_plan.pb.h"
 
 using absl::btree_map;
 using absl::StatusOr;
@@ -66,11 +66,11 @@ btree_map<std::uint32_t, uint32_t> load_gid_map(string_view line) {
   return result;
 }
 
-StatusOr<EncoderConfig> create_config(
+StatusOr<SegmentationPlan> create_config(
     const btree_map<std::uint32_t, uint32_t>& gid_map,
     const IntSet& loaded_chunks, hb_face_t* face) {
   auto gid_to_unicode = FontHelper::GidToUnicodeMap(face);
-  EncoderConfig config;
+  SegmentationPlan config;
   // Populate segments in the config. chunks are directly analagous to segments.
   auto segments = config.mutable_glyph_patches();
   for (const auto [gid, chunk] : gid_map) {
@@ -115,7 +115,8 @@ StatusOr<EncoderConfig> create_config(
   return config;
 }
 
-StatusOr<EncoderConfig> convert_iftb(string_view iftb_dump, hb_face_t* face) {
+StatusOr<SegmentationPlan> convert_iftb(string_view iftb_dump,
+                                        hb_face_t* face) {
   btree_map<std::uint32_t, uint32_t> gid_map;
   IntSet loaded_chunks;
 

--- a/util/convert_iftb.h
+++ b/util/convert_iftb.h
@@ -4,12 +4,12 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/string_view.h"
 #include "hb.h"
-#include "util/encoder_config.pb.h"
+#include "util/segmentation_plan.pb.h"
 
 namespace util {
 
-absl::StatusOr<EncoderConfig> convert_iftb(absl::string_view iftb_dump,
-                                           hb_face_t* face);
+absl::StatusOr<SegmentationPlan> convert_iftb(absl::string_view iftb_dump,
+                                              hb_face_t* face);
 
 }
 

--- a/util/generate_table_keyed_config.cc
+++ b/util/generate_table_keyed_config.cc
@@ -9,8 +9,8 @@
 #include "common/font_data.h"
 #include "common/font_helper.h"
 #include "common/int_set.h"
-#include "util/encoder_config.pb.h"
 #include "util/load_codepoints.h"
+#include "util/segmentation_plan.pb.h"
 
 using common::FontData;
 using common::FontHelper;
@@ -112,7 +112,7 @@ int main(int argc, char** argv) {
     }
   }
 
-  EncoderConfig config;
+  SegmentationPlan config;
 
   bool initial = true;
   for (const auto& set : sets) {

--- a/util/segmentation_plan.proto
+++ b/util/segmentation_plan.proto
@@ -1,6 +1,6 @@
 edition = "2023";
 
-// This message is used to configure an IFT encoder to generate and IFT encoding of some input font.
+// This message is used to configure an IFT compiler to generate and IFT encoding of some input font.
 //
 // Note: this is still a work in progress. Final naming and the specific structure is still being finalized.
 //
@@ -8,10 +8,10 @@ edition = "2023";
 // patches to extend non-glyph data (everything other than glyf, gvar, CFF, and CFF2) and glyph keyed patches
 // to extend the glyph data tables (glyf, gvar, CFF, CFF2).
 //
-// The configuration has three distinct parts, the first "Codepoint Sets" defines a list of unicode codepoint
+// The plan has three distinct parts, the first "Codepoint Sets" defines a list of unicode codepoint
 // sets which will be reused in the remainder of the configuration.
 //
-// Next, "Glyph Data Extension Configuration" section configures how the font will be split into a set of
+// Next, "Glyph Data Extension Configuration" section specifies how the font will be split into a set of
 // glyph keyed patches. The generated encoding will contain one glyph keyed patch per specified glyph id set
 // and unique configuration of the design space reachable via the non glyph table keyed patches.
 //
@@ -19,7 +19,7 @@ edition = "2023";
 // the conditions under which the activated patch should be loaded into the font. Patches which are not assigned
 // conditions will not be reachable.
 //
-// The last section of the configuration is the "Non Glyph Extension Configuration" which describes how to
+// The last section of the plan is the "Non Glyph Extension Configuration" which describes how to
 // segment the data in all non-glyph tables (everything but glyf, gvar, CFF, and CFF2). These tables will be
 // extended by table keyed patches. Since table keyed patches are invalidating
 // (see: https://w3c.github.io/IFT/Overview.html#font-patch-invalidations) a graph of patches will be
@@ -48,7 +48,7 @@ edition = "2023";
 //                                segments to the font. This makes it possible for the client to reach any
 //                                combination of coverage in at most one round trip from any intermediate
 //                                (or initial) state.
-message EncoderConfig {
+message SegmentationPlan {
 
   // TODO validation criteria for the configuration:
   // - check that fully expanded font meets closure requirement.
@@ -89,9 +89,9 @@ message EncoderConfig {
   // segments in a single patch. Defaults to 1.
   uint32 jump_ahead = 4;
 
-  // For table keyed patches when jump_ahead is > 1 the multi segment patches will use preload lists
+  // For table keyed patches when jump_ahead is > 1 the multi segment patches will use prefetch lists
   // instead of a single patch to make the multi segment jump.
-  bool use_preload_lists = 5;
+  bool use_prefetch_lists = 5;
 
   // For table keyed patches the patch graph will be at most this many levels deep, or in other
   // words at most max depth round trips will ever be needed to reach any content in the font.


### PR DESCRIPTION
The Encoder class is not the complete IFT encoder implementation. Instead it's just one piece of the full solution, so rename it to Compiler to better reflect it's role. Likewise Encoder Config is being renamed Segmentation Plan as that more accurately describes it's function.