### PR TITLE
Use IFT spec default feature registry.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,9 +56,9 @@ http_archive(
 http_archive(
     name = "ift_spec",
     build_file = "//third_party:ift_spec.BUILD",
-    sha256 = "3c8e7f78c49272b89b878a61729b1863b9f37c722f6623ee2eb146adccb41333",
-    strip_prefix = "IFT-01037d264f657f9164f9522b8b16a7bab2e6917c",
-    urls = ["https://github.com/w3c/IFT/archive/01037d264f657f9164f9522b8b16a7bab2e6917c.zip"],
+    sha256 = "6c97f8da6a6997794da5417823711b54a7ace6ff8c7beb71824386d1e19a9ac5",
+    strip_prefix = "IFT-9594d696a6b35c22f97b072a1d64db603c204dfb",
+    urls = ["https://github.com/w3c/IFT/archive/9594d696a6b35c22f97b072a1d64db603c204dfb.zip"],
 )
 
 # Fontations

--- a/docs/experimental/compiler.md
+++ b/docs/experimental/compiler.md
@@ -254,17 +254,11 @@ non-exhaustive list of some possibilities:
 
 * Add support for producing "glyph keyed only" IFT fonts that make use of only glyph keyed patches.
 
-* Add the default feature list to encodings, see: https://w3c.github.io/IFT/Overview.html#feature-tag-list. The default
-  feature list should be imported from the spec and applied to generated font subsets. That is all generated subsets
-  should implicitly include these features.
-
 * Finish implementing support for all options in the encoder config schema. There's several options which we do not yet
   have support for.
 
 * Improved patch map compilation to reduce encoded size. The format2 patch map has several tools at it's disposal to
-  produce compact encodings which we are not yet fully leveraging. In particular for the table keyed patch map we do not
-  utilize child entry indices at all to reuse previously encoded code point sets. This would be quite effective at
-  reducing encoding sizes when jump ahead > 1 is used as the same code point set will be repeated multiple times.
+  produce compact encodings which we are not yet fully leveraging.
 
 * Additionally, some smaller size reductions could be realized by smartly picking entry ids that reduce the total number
   of entry deltas needed in the encoding.

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -25,6 +25,7 @@ cc_library(
     deps = [
         "//ift",
         "//ift/proto",
+        "//ift/feature_registry:feature_registry",
         "//util:segmentation_plan_cc_proto",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",

--- a/ift/encoder/compiler.cc
+++ b/ift/encoder/compiler.cc
@@ -22,6 +22,7 @@
 #include "ift/encoder/activation_condition.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
+#include "ift/feature_registry/feature_registry.h"
 #include "ift/glyph_keyed_diff.h"
 #include "ift/proto/ift_table.h"
 #include "ift/proto/patch_encoding.h"
@@ -47,6 +48,7 @@ using common::make_hb_set;
 using common::SegmentSet;
 using common::Woff2;
 using ift::GlyphKeyedDiff;
+using ift::feature_registry::DefaultFeatureTags;
 using ift::proto::GLYPH_KEYED;
 using ift::proto::IFTTable;
 using ift::proto::PatchEncoding;
@@ -55,6 +57,14 @@ using ift::proto::TABLE_KEYED_FULL;
 using ift::proto::TABLE_KEYED_PARTIAL;
 
 namespace ift::encoder {
+
+// Configures a subset definition to contain all of the default, always included
+// items (eg. https://w3c.github.io/IFT/Overview.html#feature-tag-list)
+void Compiler::AddInitSubsetDefaults(SubsetDefinition& subset_definition) {
+  std::copy(DefaultFeatureTags().begin(), DefaultFeatureTags().end(),
+            std::inserter(subset_definition.feature_tags,
+                          subset_definition.feature_tags.begin()));
+}
 
 static void AddCombinations(const std::vector<const SubsetDefinition*>& in,
                             uint32_t choose, std::vector<Compiler::Edge>& out) {
@@ -219,6 +229,7 @@ StatusOr<Compiler::Encoding> Compiler::Compile() const {
 
   ProcessingContext context(next_id_);
   context.init_subset_ = init_subset_;
+  AddInitSubsetDefaults(context.init_subset_);
   if (IsMixedMode()) {
     // Glyph keyed patches can't change the glyph count in the font (and hence
     // loca len) so always include the last gid in the init subset to force the

--- a/ift/encoder/compiler.h
+++ b/ift/encoder/compiler.h
@@ -45,6 +45,8 @@ class Compiler {
   Compiler& operator=(const Compiler&) = delete;
   Compiler& operator=(Compiler&& other) = delete;
 
+  static void AddInitSubsetDefaults(SubsetDefinition& subset_definition);
+
   /*
    * Configures how many graph levels can be reached from each node in the
    * encoded graph. Defaults to 1.

--- a/ift/feature_registry/BUILD
+++ b/ift/feature_registry/BUILD
@@ -18,12 +18,12 @@ cc_library(
     ":feature_registry_h",
   ],
   deps = [
-    "@abseil-cpp//absl/container:flat_hash_map",
+    "@abseil-cpp//absl/container:flat_hash_set",
     "@abseil-cpp//absl/base:no_destructor",
     "@harfbuzz",
   ],
-  visibility = [
-    "//ift/proto:__pkg__",
+  visibility = [    
+    "//ift/encoder:__pkg__",
   ],
 )
 

--- a/ift/feature_registry/feature_registry_test.cc
+++ b/ift/feature_registry/feature_registry_test.cc
@@ -9,46 +9,23 @@ class FeatureRegistryTest : public ::testing::Test {
   FeatureRegistryTest() {}
 };
 
-TEST_F(FeatureRegistryTest, FeatureTagToIndex) {
+TEST_F(FeatureRegistryTest, DefaultFeatureTags) {
   // Should match the feature registry in the specification found here:
   // https://w3c.github.io/IFT/Overview.html#feature-tag-list
   //
   // Spot check a few entries to make sure things seem to line up.
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('a', 'b', 'v', 'f')), 1);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('c', 'u', 'r', 's')), 15);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('a', 'a', 'l', 't')), 66);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('l', 'n', 'u', 'm')), 90);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('s', 's', '0', '1')), 123);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('s', 's', '1', '2')), 134);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('s', 's', '2', '0')), 142);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('c', 'v', '0', '1')), 143);
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('c', 'v', '9', '9')), 241);
-}
+  ASSERT_TRUE(DefaultFeatureTags().contains(HB_TAG('f', 'r', 'a', 'c')));
+  ASSERT_TRUE(DefaultFeatureTags().contains(HB_TAG('v', 'a', 't', 'u')));
+  ASSERT_TRUE(DefaultFeatureTags().contains(HB_TAG('v', 'r', 't', 'r')));
 
-TEST_F(FeatureRegistryTest, IndexToFeatureTag) {
-  // Should match the feature registry in the specification found here:
-  // https://w3c.github.io/IFT/Overview.html#feature-tag-list
-  //
-  // Spot check a few entries to make sure things seem to line up.
-  ASSERT_EQ(IndexToFeatureTag(1), HB_TAG('a', 'b', 'v', 'f'));
-  ASSERT_EQ(IndexToFeatureTag(15), HB_TAG('c', 'u', 'r', 's'));
-  ASSERT_EQ(IndexToFeatureTag(66), HB_TAG('a', 'a', 'l', 't'));
-  ASSERT_EQ(IndexToFeatureTag(90), HB_TAG('l', 'n', 'u', 'm'));
-  ASSERT_EQ(IndexToFeatureTag(123), HB_TAG('s', 's', '0', '1'));
-  ASSERT_EQ(IndexToFeatureTag(134), HB_TAG('s', 's', '1', '2'));
-  ASSERT_EQ(IndexToFeatureTag(142), HB_TAG('s', 's', '2', '0'));
-  ASSERT_EQ(IndexToFeatureTag(143), HB_TAG('c', 'v', '0', '1'));
-  ASSERT_EQ(IndexToFeatureTag(241), HB_TAG('c', 'v', '9', '9'));
-}
+  ASSERT_FALSE(DefaultFeatureTags().contains(HB_TAG('f', 'w', 'i', 'd')));
+  ASSERT_FALSE(DefaultFeatureTags().contains(HB_TAG('z', 'e', 'r', 'o')));
 
-TEST_F(FeatureRegistryTest, FeatureTagToIndex_NotFound) {
-  ASSERT_EQ(FeatureTagToIndex(HB_TAG('x', 'x', 'x', 'x')),
-            HB_TAG('x', 'x', 'x', 'x'));
-}
+  ASSERT_FALSE(DefaultFeatureTags().contains(HB_TAG('c', 'v', '0', '1')));
+  ASSERT_FALSE(DefaultFeatureTags().contains(HB_TAG('c', 'v', '5', '8')));
+  ASSERT_FALSE(DefaultFeatureTags().contains(HB_TAG('c', 'v', '9', '9')));
 
-TEST_F(FeatureRegistryTest, IndexToFeatureTag_NotFound) {
-  ASSERT_EQ(IndexToFeatureTag(HB_TAG('x', 'x', 'x', 'x')),
-            HB_TAG('x', 'x', 'x', 'x'));
+  ASSERT_GT(DefaultFeatureTags().size(), 10);
 }
 
 }  // namespace ift::feature_registry

--- a/ift/feature_registry/registry_to_cc.py
+++ b/ift/feature_registry/registry_to_cc.py
@@ -2,48 +2,36 @@ import csv
 import re
 import sys
 
-def print_mapping(reversed=False):
+def print_set():
   with open(sys.argv[1]) as r:
     reader = csv.reader(r, delimiter=",")
     lines = [row for row in reader]
 
     i = 1
-    for is_default in [True, False]:
-      version = 1
-      for row in lines:
-        if row[0].startswith("VERSION_2"):
-          version = 2
-          continue
+    for row in lines:
+      if row[0] == "Tag" or row[0].startswith("#"):
+        continue
 
-        if row[0] == "Tag" or row[0].startswith("#"):
-          continue
+      if int(row[2]) != 1:
+        continue
 
-        if is_default != (int(row[2]) == 1):
-          continue
+      m = re.search("[a-z]{2}([0-9]{2})-[a-z]{2}([0-9]{2})", row[0])
+      if m:
+        start = i
+        end = i + (int(m.group(2)) - int(m.group(1)))
+        i += end - start + 1
+      else:
+        start = i
+        end = i
+        i += 1
 
-        m = re.search("[a-z]{2}([0-9]{2})-[a-z]{2}([0-9]{2})", row[0])
-        if m:
-          start = i
-          end = i + (int(m.group(2)) - int(m.group(1)))
-          i += end - start + 1
+      for v in range(start, end + 1):
+        if start == end:
+          tag_str = f"HB_TAG('{row[0][0]}', '{row[0][1]}', '{row[0][2]}', '{row[0][3]}')"
         else:
-          start = i
-          end = i
-          i += 1
+          tag_str = f"HB_TAG('{row[0][0]}', '{row[0][1]}', '{v_str[0]}', '{v_str[1]}')"
 
-        count = 1
-        for v in range(start, end + 1):
-          if start == end:
-            tag_str = f"HB_TAG('{row[0][0]}', '{row[0][1]}', '{row[0][2]}', '{row[0][3]}')"
-          else:
-            v_str = f"{count:02}"
-            tag_str = f"HB_TAG('{row[0][0]}', '{row[0][1]}', '{v_str[0]}', '{v_str[1]}')"
-
-          if not reversed:
-            print(f"    {{ {tag_str}, {v} }},")
-          else:
-            print(f"    {{ {v}, {tag_str} }},")
-          count += 1
+        print(f"    {tag_str},")
 
 
 print("#ifndef IFT_FEATURE_REGISTRY_FEATURE_REGISTRY_H_")
@@ -51,30 +39,15 @@ print("#define IFT_FEATURE_REGISTRY_FEATURE_REGISTRY_H_")
 print("")
 print("#include \"hb.h\"")
 print("#include \"absl/base/no_destructor.h\"")
-print("#include \"absl/container/flat_hash_map.h\"")
+print("#include \"absl/container/flat_hash_set.h\"")
 print("")
 print("namespace ift::feature_registry {")
 print("")
-print("static const uint32_t FeatureTagToIndex(hb_tag_t tag) {")
-print("  static const absl::NoDestructor<absl::flat_hash_map<uint32_t, uint32_t>> kFeatureTagToIndex({")
-print_mapping(False)
+print("static const absl::flat_hash_set<hb_tag_t>& DefaultFeatureTags() {")
+print("  static const absl::NoDestructor<absl::flat_hash_set<hb_tag_t>> kDefaultFeatures({")
+print_set()
 print("  });")
-print("  auto it = kFeatureTagToIndex->find(tag);")
-print("  if (it == kFeatureTagToIndex->end()) {")
-print("    return tag;")
-print("  }")
-print("  return it->second;")
-print("}")
-print("")
-print("static const hb_tag_t IndexToFeatureTag(uint32_t index) {")
-print("  static const absl::NoDestructor<absl::flat_hash_map<uint32_t, uint32_t>> kIndexToFeatureTag({")
-print_mapping(True)
-print("  });")
-print("  auto it = kIndexToFeatureTag->find(index);")
-print("  if (it == kIndexToFeatureTag->end()) {")
-print("    return index;")
-print("  }")
-print("  return it->second;")
+print("  return *kDefaultFeatures;")
 print("}")
 print("")
 print("}  // namespace ift::feature_registry")

--- a/ift/integration_test.cc
+++ b/ift/integration_test.cc
@@ -1583,8 +1583,7 @@ TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_DropsUnusedPatches) {
   ASSERT_GT(FontHelper::GvarData(extended_face.get(), chunk4_gid)->size(), 0);
 }
 
-TEST_F(IntegrationTest,
-       MixedMode_DesignSpaceAugmentation_NoOverfetch) {
+TEST_F(IntegrationTest, MixedMode_DesignSpaceAugmentation_NoOverfetch) {
   Compiler compiler;
   auto init_gids = InitEncoderForVfMixedMode(compiler);
   ASSERT_TRUE(init_gids.ok()) << init_gids.status();

--- a/ift/proto/BUILD
+++ b/ift/proto/BUILD
@@ -15,7 +15,6 @@ cc_library(
     "//ift/encoder:__pkg__",
   ],
   deps = [
-      "//ift/feature_registry",
       "//common",
       "@abseil-cpp//absl/status:statusor",
       "@abseil-cpp//absl/container:flat_hash_map",

--- a/ift/proto/patch_map.cc
+++ b/ift/proto/patch_map.cc
@@ -9,7 +9,6 @@
 #include "common/font_helper.h"
 #include "common/int_set.h"
 #include "common/sparse_bit_set.h"
-#include "ift/feature_registry/feature_registry.h"
 #include "ift/proto/patch_encoding.h"
 
 using absl::btree_set;
@@ -20,8 +19,6 @@ using absl::StatusOr;
 using common::FontHelper;
 using common::IntSet;
 using common::SparseBitSet;
-using ift::feature_registry::FeatureTagToIndex;
-using ift::feature_registry::IndexToFeatureTag;
 
 namespace ift::proto {
 


### PR DESCRIPTION
Fixes https://github.com/w3c/ift-encoder/issues/106. Pull in the feature registry from the spec repository and include the default features in compiled IFT font's initial subset definition.