### PR TITLE
In closure segmenter optionally check for segments that can be merged into the initial font.

### DIFF
--- a/common/int_set.h
+++ b/common/int_set.h
@@ -232,6 +232,18 @@ class IntSet {
     return hb_set_is_subset(set_.get(), other.set_.get());
   }
 
+  bool intersects(const IntSet& other) const {
+    if (this->size() > other.size()) {
+      return other.intersects(*this);
+    }
+    for (const hb_codepoint_t value : *this) {
+      if (other.contains(value)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
   std::optional<hb_codepoint_t> min() const {
     hb_codepoint_t value = hb_set_get_min(set_.get());
     if (value == HB_SET_VALUE_INVALID) {

--- a/common/int_set_test.cc
+++ b/common/int_set_test.cc
@@ -412,4 +412,27 @@ TEST_F(IntSetTest, LowerBound) {
   ASSERT_EQ(*it, 0);
 }
 
+TEST_F(IntSetTest, Intersects) {
+  IntSet set1{1, 2, 3};
+  IntSet set2{3, 4, 5};
+  IntSet set3{4, 5, 6};
+  IntSet empty_set{};
+
+  ASSERT_TRUE(set1.intersects(set1));
+  ASSERT_TRUE(set1.intersects(set2));
+  ASSERT_TRUE(set2.intersects(set1));
+  ASSERT_FALSE(set1.intersects(set3));
+  ASSERT_FALSE(set3.intersects(set1));
+  ASSERT_FALSE(set1.intersects(empty_set));
+  ASSERT_FALSE(empty_set.intersects(set1));
+  ASSERT_FALSE(empty_set.intersects(empty_set));
+
+  IntSet set4{1, 2, 3};
+  ASSERT_TRUE(set1.intersects(set4));
+
+  IntSet set5{1, 2};
+  ASSERT_TRUE(set1.intersects(set5));
+  ASSERT_TRUE(set5.intersects(set1));
+}
+
 }  // namespace common

--- a/common/woff2.cc
+++ b/common/woff2.cc
@@ -15,7 +15,8 @@ using woff2::WOFF2StringOut;
 
 namespace common {
 
-StatusOr<FontData> Woff2::EncodeWoff2(string_view font, bool glyf_transform, int quality) {
+StatusOr<FontData> Woff2::EncodeWoff2(string_view font, bool glyf_transform,
+                                      int quality) {
   WOFF2Params params;
   params.brotli_quality = quality;
   params.allow_transforms = glyf_transform;

--- a/common/woff2.cc
+++ b/common/woff2.cc
@@ -15,9 +15,9 @@ using woff2::WOFF2StringOut;
 
 namespace common {
 
-StatusOr<FontData> Woff2::EncodeWoff2(string_view font, bool glyf_transform) {
+StatusOr<FontData> Woff2::EncodeWoff2(string_view font, bool glyf_transform, int quality) {
   WOFF2Params params;
-  params.brotli_quality = 11;
+  params.brotli_quality = quality;
   params.allow_transforms = glyf_transform;
   size_t buffer_size =
       MaxWOFF2CompressedSize((const uint8_t*)font.data(), font.size());

--- a/common/woff2.h
+++ b/common/woff2.h
@@ -9,7 +9,7 @@ namespace common {
 
 struct Woff2 {
   static absl::StatusOr<FontData> EncodeWoff2(absl::string_view font,
-                                              bool glyf_transform = true);
+                                              bool glyf_transform = true, int quality = 11);
   static absl::StatusOr<FontData> DecodeWoff2(absl::string_view font);
 };
 

--- a/common/woff2.h
+++ b/common/woff2.h
@@ -9,7 +9,8 @@ namespace common {
 
 struct Woff2 {
   static absl::StatusOr<FontData> EncodeWoff2(absl::string_view font,
-                                              bool glyf_transform = true, int quality = 11);
+                                              bool glyf_transform = true,
+                                              int quality = 11);
   static absl::StatusOr<FontData> DecodeWoff2(absl::string_view font);
 };
 

--- a/common/woff2_test.cc
+++ b/common/woff2_test.cc
@@ -34,6 +34,14 @@ TEST_F(Woff2Test, EncodeWoff2) {
   ASSERT_LT(woff2->size(), font.size());
 }
 
+TEST_F(Woff2Test, EncodeWoff2_Quality) {
+  auto woff2_high = Woff2::EncodeWoff2(font.str(), true, 11);
+  auto woff2_low = Woff2::EncodeWoff2(font.str(), true, 6);
+  ASSERT_TRUE(woff2_high.ok()) << woff2_high.status();
+  ASSERT_TRUE(woff2_low.ok()) << woff2_low.status();
+  ASSERT_LT(woff2_high->size(), woff2_low->size());
+}
+
 TEST_F(Woff2Test, EncodeWoff2_NoGlyfTransform) {
   auto woff2 = Woff2::EncodeWoff2(font.str(), true);
   auto woff2_no_transform = Woff2::EncodeWoff2(font.str(), false);

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -371,8 +371,11 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessMerge(
     // threshold on the segments to be merged that will allow us to quickly
     // discard merges which can't possibily beat the current best.
     unsigned segment_to_merge = segments_to_merge.min().value();
-    unsigned segment_to_merge_size = TRY(context.patch_size_cache->GetPatchSize(
-        context.glyph_condition_set.GlyphsWithSegment(segment_to_merge)));
+    const GlyphSet& glyphs = context.glyph_condition_set.GlyphsWithSegment(segment_to_merge);
+    unsigned segment_to_merge_size = 0;
+    if (!glyphs.empty()) {
+      segment_to_merge_size = TRY(context.patch_size_cache->GetPatchSize(glyphs));
+    }
     double threshold = best_merge_candidate->InertProbabilityThreshold(
         segment_to_merge_size, merged_segment.Probability());
     if (segments[segment_to_merge].Probability() <= threshold) {

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -258,17 +258,15 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
                               modified_conditions));
 
   double cost_delta = 0.0;
-  VLOG(1) << "cost delta for merge of " << merged_segments.ToString() << ":";
+  VLOG(1) << "cost_delta for merge of " << merged_segments.ToString()
+            << " =";
   if (!moving_to_init_font) {
     // Merge will introduce a new patch (merged_segment) with size
     // "new_patch_size", add the associated cost.
     double p = (*merged_segment)->Probability();
-    cost_delta += p * (new_patch_size + per_request_overhead);
-    VLOG(1) << "  cost_delta for merge of " << merged_segments.ToString()
-            << " =";
-
-    VLOG(1) << "    + (" << p << " * "
-            << (new_patch_size + per_request_overhead) << ") -> " << cost_delta
+    double s = new_patch_size + per_request_overhead;
+    cost_delta += p * s;
+    VLOG(1) << "    + (" << p << " * " << s << ") -> " << cost_delta
             << " [merged patch]";
   } else {
     // Otherwise the merged segments are being moved to the init font, compute
@@ -316,6 +314,10 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
       // the cost addition as usual.
       SegmentSet condition_segments = c.TriggeringSegments();
       condition_segments.subtract(merged_segments);
+      if (condition_segments.empty()) {
+        continue;
+      }
+
       ActivationCondition new_condition =
           ActivationCondition::and_segments(condition_segments, 0);
       double p = TRY(c.Probability(

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -130,6 +130,15 @@ struct CandidateMerge {
   static absl::StatusOr<bool> IsPatchTooSmall(
       SegmentationContext& context, segment_index_t base_segment_index,
       const common::GlyphSet& glyphs);
+
+  static absl::StatusOr<double> ComputeCostDelta(const SegmentationContext& context,
+                                                 const common::SegmentSet& merged_segments,
+                                                 std::optional<const Segment*> merged_segment,
+                                                 uint32_t new_patch_size);
+
+  static absl::StatusOr<uint32_t> Woff2SizeOf(hb_face_t* original_face,
+                                              const SubsetDefinition& def,
+                                              int quality);
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -109,7 +109,7 @@ struct CandidateMerge {
                                    network_overhead +
                                    BEST_CASE_MERGE_SIZE_DELTA;
     double total_base_size = base_size + network_overhead;
-    double total_patch_size = patch_size + network_overhead;
+    double total_patch_size = patch_size > 0 ? patch_size + network_overhead : 0;
 
     double numerator = merged_probability * best_case_merged_size -
                        base_probability * total_base_size - cost_delta;

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -109,7 +109,8 @@ struct CandidateMerge {
                                    network_overhead +
                                    BEST_CASE_MERGE_SIZE_DELTA;
     double total_base_size = base_size + network_overhead;
-    double total_patch_size = patch_size > 0 ? patch_size + network_overhead : 0;
+    double total_patch_size =
+        patch_size > 0 ? patch_size + network_overhead : 0;
 
     double numerator = merged_probability * best_case_merged_size -
                        base_probability * total_base_size - cost_delta;
@@ -131,10 +132,10 @@ struct CandidateMerge {
       SegmentationContext& context, segment_index_t base_segment_index,
       const common::GlyphSet& glyphs);
 
-  static absl::StatusOr<double> ComputeCostDelta(const SegmentationContext& context,
-                                                 const common::SegmentSet& merged_segments,
-                                                 std::optional<const Segment*> merged_segment,
-                                                 uint32_t new_patch_size);
+  static absl::StatusOr<double> ComputeCostDelta(
+      const SegmentationContext& context,
+      const common::SegmentSet& merged_segments,
+      std::optional<const Segment*> merged_segment, uint32_t new_patch_size);
 
   static absl::StatusOr<uint32_t> Woff2SizeOf(hb_face_t* original_face,
                                               const SubsetDefinition& def,

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -273,6 +273,12 @@ Status CollectExclusiveCandidateMerges(
       continue;
     }
 
+    if (context.InertSegments().contains(*it) && context.glyph_condition_set.GlyphsWithSegment(*it).empty()) {
+      // this segment is effectively a noop, it interacts with nothing and has no glyphs
+      // so don't consider it for a merge.
+      continue;
+    }
+
     if (*it >= context.OptimizationCutoffSegment() &&
         smallest_candidate_merge.has_value()) {
       // We are at the optimization cutoff, so we won't evaluate any further

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -509,7 +509,7 @@ static StatusOr<std::vector<Segment>> ToSegments(
   return segments;
 }
 
-StatusOr<SegmentationContext> ClosureGlyphSegmenter::MoveSegmentsToInitFont(SegmentationContext& context) const {
+Status ClosureGlyphSegmenter::MoveSegmentsToInitFont(SegmentationContext& context) const {
   if (!context.GetMergeStrategy().InitFontMergeThreshold().has_value()) {
     return absl::FailedPreconditionError("Cannot be called when there is no merge threshold configured.");
   }
@@ -517,46 +517,43 @@ StatusOr<SegmentationContext> ClosureGlyphSegmenter::MoveSegmentsToInitFont(Segm
   double threshold = *context.GetMergeStrategy().InitFontMergeThreshold();
 
   VLOG(0) << "Checking if there are any segments which should be moved into the initial font.";
-  SegmentSet segments_to_move;
-  for (const auto& [c, glyphs] : context.glyph_groupings.ConditionsAndGlyphs()) {
-    SegmentSet candidate_segments = c.TriggeringSegments();
-    if (!candidate_segments.intersects(context.ActiveSegments())) {
-      // Only do this check for things involving active segments, this let's us skip
-      // checks for conditions are are extremely unlikely to benefit from merging
-      // into the init font.
-      continue;
-    }
-
-    double delta = TRY(CandidateMerge::ComputeCostDelta(context, candidate_segments, std::nullopt, 0));
-    if (delta >= threshold * (double) candidate_segments.size()) {
-      // Merging doesn't improve cost, skip.
-      continue;
-    }
-
-    // TODO(garretrieger): to get a more accurate picture we should consider comparing
-    //   to an updated init subset definition on each iteration.
-    segments_to_move.union_set(candidate_segments);
-    VLOG(0) << "  Moving segments " << candidate_segments.ToString() << " into the initial font (cost delta = " << delta << ")";
-  }
 
   SubsetDefinition initial_segment = context.SegmentationInfo().InitFontSegment();
-  std::vector<Segment> segments;
-  for (unsigned i = 0; i < context.SegmentationInfo().Segments().size(); i++) {
-    const Segment& segment = context.SegmentationInfo().Segments()[i];
-    if (segments_to_move.contains(i)) {
-      initial_segment.Union(segment.Definition());
-    } else if (!segment.Definition().Empty()) {
-      segments.push_back(segment);
-    }
-  }
+  bool change_made;
+  do {
+    change_made = false;
+    SegmentSet segments_to_move;
+    for (const auto& [c, glyphs] : context.glyph_groupings.ConditionsAndGlyphs()) {
+      SegmentSet candidate_segments = c.TriggeringSegments();
+      if (!candidate_segments.intersects(context.ActiveSegments())) {
+        // Only do this check for things involving active segments, this let's us skip
+        // checks for conditions are are extremely unlikely to benefit from merging
+        // into the init font.
+        continue;
+      }
 
-  // Reset the context using the new initial font and segment definitions.
-  VLOG(0) << segments_to_move.size() << " segments moved into the initial font. "
-          << "Initial font now has " << initial_segment.codepoints.size() << " codepoints. "
-          << "Initial segmentation plan will be recomputed." << std::endl;
-  MergeStrategy strategy = context.GetMergeStrategy();
-  return TRY(InitializeSegmentationContext(
-      context.original_face.get(), initial_segment, std::move(segments), std::move(strategy)));
+      double delta = TRY(CandidateMerge::ComputeCostDelta(context, candidate_segments, std::nullopt, 0));
+      if (delta >= threshold * (double) candidate_segments.size()) {
+        // Merging doesn't improve cost, skip.
+        continue;
+      }
+
+      // TODO(garretrieger): to get a more accurate picture we should consider comparing
+      //   to an updated init subset definition on each iteration.
+      segments_to_move.union_set(candidate_segments);
+      VLOG(0) << "  Moving segments " << candidate_segments.ToString() << " into the initial font (cost delta = " << delta << ")";
+      for (segment_index_t s : segments_to_move) {
+        initial_segment.Union(context.SegmentationInfo().Segments()[s].Definition());
+      }
+
+      TRYV(context.ReassignInitSubset(initial_segment, segments_to_move));
+      change_made = true;
+      break;
+    }
+  } while (change_made);
+
+  VLOG(0) << "Initial font now has " << initial_segment.codepoints.size() << " codepoints.";
+  return absl::OkStatus();
 }
 
 StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
@@ -585,7 +582,7 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
   // ### First phase of merging is to check for any patches which should be moved to the initial font
   //     (eg. cases where the probability of a patch is ~1.0).
   if (context.GetMergeStrategy().UseCosts() && context.GetMergeStrategy().InitFontMergeThreshold().has_value()) {
-    context = TRY(MoveSegmentsToInitFont(context));
+    TRYV(MoveSegmentsToInitFont(context));
   }
 
   // ### Iteratively merge segments and incrementally reprocess affected data.

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -664,6 +664,9 @@ Status ClosureGlyphSegmenter::MoveSegmentsToInitFont(
   do {
     // TODO(garretrieger): as an optimization probably want to avoid rechecking
     //   segments that have previously been assessed for move into init font.
+    //   alternatively should be able to modify this to not immediately apply
+    //   the move, but scan all options and collect the set of segments to move
+    //   then repeat analysis until no changes.
     // TODO(garretrieger): consider reworking this using gids instead of
     //  codepoints. That is specify init font def in terms of gids. That will
     //  more closely match the intention of merging a specific patch into the

--- a/ift/encoder/closure_glyph_segmenter.h
+++ b/ift/encoder/closure_glyph_segmenter.h
@@ -63,6 +63,9 @@ class ClosureGlyphSegmenter {
   absl::StatusOr<SegmentationCost> TotalCost(
       hb_face_t* original_face, const GlyphSegmentation& segmentation,
       const freq::ProbabilityCalculator& probability_calculator) const;
+
+  private:
+    absl::StatusOr<SegmentationContext> MoveSegmentsToInitFont(SegmentationContext& context) const;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/closure_glyph_segmenter.h
+++ b/ift/encoder/closure_glyph_segmenter.h
@@ -65,7 +65,7 @@ class ClosureGlyphSegmenter {
       const freq::ProbabilityCalculator& probability_calculator) const;
 
   private:
-    absl::StatusOr<SegmentationContext> MoveSegmentsToInitFont(SegmentationContext& context) const;
+    absl::Status MoveSegmentsToInitFont(SegmentationContext& context) const;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/closure_glyph_segmenter.h
+++ b/ift/encoder/closure_glyph_segmenter.h
@@ -64,8 +64,8 @@ class ClosureGlyphSegmenter {
       hb_face_t* original_face, const GlyphSegmentation& segmentation,
       const freq::ProbabilityCalculator& probability_calculator) const;
 
-  private:
-    absl::Status MoveSegmentsToInitFont(SegmentationContext& context) const;
+ private:
+  absl::Status MoveSegmentsToInitFont(SegmentationContext& context) const;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -784,7 +784,11 @@ TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {
 
   auto segmentation = segmenter.CodepointToGlyphSegments(
       roboto.get(), {0x106 /* Cacute */},
-      {{'A'}, {'B'}, {'C'},},
+      {
+          {'A'},
+          {'B'},
+          {'C'},
+      },
       *MergeStrategy::CostBased(std::move(frequencies)));
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
@@ -793,7 +797,7 @@ TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {
   std::vector<SubsetDefinition> expected_segments = {
       {'A', 'B'},
       {},
-      {'C'}, // C glyph was already pulled in to the init font, so no merge
+      {'C'},  // C glyph was already pulled in to the init font, so no merge
   };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
@@ -806,29 +810,28 @@ if (s0) then p0
 )");
 }
 
-
 TEST_F(ClosureGlyphSegmenterTest, InitFontMerging) {
   // In this test we enable merging of segments into the init font
   UnicodeFrequencies frequencies{
       {{'a', 'a'}, 100},
-      {{'b', 'b'},  50},
-      {{'c', 'c'},  50},
+      {{'b', 'b'}, 50},
+      {{'c', 'c'}, 50},
       {{'d', 'd'}, 100},
 
       // b and c co-occur
-      {{'b', 'c'},  50},
+      {{'b', 'c'}, 50},
   };
 
-  MergeStrategy strategy = *MergeStrategy::BigramCostBased(std::move(frequencies));
+  MergeStrategy strategy =
+      *MergeStrategy::BigramCostBased(std::move(frequencies));
   strategy.SetInitFontMergeThreshold(-75);
 
   auto segmentation = segmenter.CodepointToGlyphSegments(
-      roboto.get(), {},
-      {{'a'}, {'d'}, {'b'}, {'c'}},
-      strategy);
+      roboto.get(), {}, {{'a'}, {'d'}, {'b'}, {'c'}}, strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  //  'a' and 'd' will be moved to the init font, leaving only two segments 'b', 'c'
+  //  'a' and 'd' will be moved to the init font, leaving only two segments 'b',
+  //  'c'
   std::vector<SubsetDefinition> expected_segments = {
       {},
       {},
@@ -848,16 +851,14 @@ TEST_F(ClosureGlyphSegmenterTest, InitFontMerging_CommonGlyphs) {
   UnicodeFrequencies frequencies{
       {{'A', 'A'}, 1},
       {{'C', 'C'}, 1},
-      {{0x106, 0x106}, 100}, // Cacute (contains C glyph)
+      {{0x106, 0x106}, 100},  // Cacute (contains C glyph)
   };
 
   MergeStrategy strategy = *MergeStrategy::CostBased(std::move(frequencies));
   strategy.SetInitFontMergeThreshold(-75);
 
   auto segmentation = segmenter.CodepointToGlyphSegments(
-      roboto.get(), {},
-      {{0x106}, {'A'}, {'C'}},
-      strategy);
+      roboto.get(), {}, {{0x106}, {'A'}, {'C'}}, strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
   std::vector<SubsetDefinition> expected_segments = {
@@ -867,7 +868,8 @@ TEST_F(ClosureGlyphSegmenterTest, InitFontMerging_CommonGlyphs) {
   };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
-  // C get's covered by the Cacute merge into int, so only A is left in the patch.
+  // C get's covered by the Cacute merge into int, so only A is left in the
+  // patch.
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0, gid39, gid117, gid700 }
 p0: { gid37 }

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -14,6 +14,7 @@
 #include "ift/encoder/requested_segmentation_information.h"
 #include "ift/encoder/segment.h"
 #include "ift/encoder/subset_definition.h"
+#include "ift/encoder/types.h"
 
 namespace ift::encoder {
 
@@ -35,6 +36,22 @@ class GlyphGroupings {
   const absl::btree_map<ActivationCondition, common::GlyphSet>&
   ConditionsAndGlyphs() const {
     return conditions_and_glyphs_;
+  }
+
+  // Returns the set all of segments that are part of a disjunctive condition.
+  // This includes segments that are part of exclusive conditions.
+  common::SegmentSet AllDisjunctiveSegments() const {
+    common::SegmentSet result;
+    for (const auto& [c, _] : conditions_and_glyphs_) {
+      if (c.conditions().size() != 1) {
+        // Any condition with more than one segment group is conjunctive.
+        continue;
+      }
+      for (segment_index_t s : *c.conditions().begin()) {
+        result.insert(s);
+      }
+    }
+    return result;
   }
 
   const absl::btree_map<common::SegmentSet, common::GlyphSet>& AndGlyphGroups()

--- a/ift/encoder/merge_strategy.h
+++ b/ift/encoder/merge_strategy.h
@@ -4,6 +4,7 @@
 #include <algorithm>
 #include <cstdint>
 #include <memory>
+#include <optional>
 
 #include "common/try.h"
 #include "ift/freq/bigram_probability_calculator.h"
@@ -130,6 +131,16 @@ class MergeStrategy {
     optimization_cutoff_fraction_ = value;
   }
 
+  // Configures the threshold (cost delta) for when to merge a segment into
+  // the init font. If not set then no segments will be merged into the init
+  // font.
+  std::optional<double> InitFontMergeThreshold() const {
+    return init_font_merge_threshold_;
+  }
+  void SetInitFontMergeThreshold(std::optional<double> value) {
+    init_font_merge_threshold_ = value;
+  }
+
   // Configures the brotli quality used when calculating patch sizes.
   // Defaults to 8.
   //
@@ -164,8 +175,9 @@ class MergeStrategy {
   // performed.
   uint32_t brotli_quality_ = 8;
   double optimization_cutoff_fraction_ = 0.001;
+  std::optional<double> init_font_merge_threshold_ = std::nullopt;
 
-  std::unique_ptr<freq::ProbabilityCalculator> probability_calculator_;
+  std::shared_ptr<freq::ProbabilityCalculator> probability_calculator_;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/requested_segmentation_information.cc
+++ b/ift/encoder/requested_segmentation_information.cc
@@ -9,8 +9,7 @@ namespace ift::encoder {
 RequestedSegmentationInformation::RequestedSegmentationInformation(
     std::vector<Segment> segments, SubsetDefinition init_font_segment,
     GlyphClosureCache& closure_cache)
-    : segments_(std::move(segments)),
-      init_font_segment_() {
+    : segments_(std::move(segments)), init_font_segment_() {
   ReassignInitSubset(closure_cache, std::move(init_font_segment), {});
 }
 

--- a/ift/encoder/requested_segmentation_information.cc
+++ b/ift/encoder/requested_segmentation_information.cc
@@ -10,24 +10,8 @@ RequestedSegmentationInformation::RequestedSegmentationInformation(
     std::vector<Segment> segments, SubsetDefinition init_font_segment,
     GlyphClosureCache& closure_cache)
     : segments_(std::move(segments)),
-      init_font_segment_(std::move(init_font_segment)) {
-  SubsetDefinition all;
-  all.Union(init_font_segment_);
-  for (const auto& s : segments_) {
-    all.Union(s.Definition());
-  }
-
-  {
-    auto closure = closure_cache.GlyphClosure(init_font_segment_);
-    if (closure.ok()) {
-      init_font_glyphs_ = std::move(*closure);
-    }
-  }
-
-  auto closure = closure_cache.GlyphClosure(all);
-  if (closure.ok()) {
-    full_closure_ = std::move(*closure);
-  }
+      init_font_segment_() {
+  ReassignInitSubset(closure_cache, std::move(init_font_segment), {});
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/requested_segmentation_information.h
+++ b/ift/encoder/requested_segmentation_information.h
@@ -33,6 +33,32 @@ class RequestedSegmentationInformation {
     return base_segment.Definition().codepoints.size();
   }
 
+  void ReassignInitSubset(GlyphClosureCache& closure_cache, SubsetDefinition new_def, const common::SegmentSet& removed_segments) {
+    for (segment_index_t s : removed_segments) {
+      segments_[s].Clear();
+    }
+
+    init_font_segment_ = std::move(new_def);
+
+    SubsetDefinition all;
+    all.Union(init_font_segment_);
+    for (const auto& s : segments_) {
+      all.Union(s.Definition());
+    }
+
+    {
+      auto closure = closure_cache.GlyphClosure(init_font_segment_);
+      if (closure.ok()) {
+        init_font_glyphs_ = std::move(*closure);
+      }
+    }
+
+    auto closure = closure_cache.GlyphClosure(all);
+    if (closure.ok()) {
+      full_closure_ = std::move(*closure);
+    }
+  }
+
   const SubsetDefinition& InitFontSegment() const { return init_font_segment_; }
 
   // Returns the init font segment with all default always included items

--- a/ift/encoder/requested_segmentation_information.h
+++ b/ift/encoder/requested_segmentation_information.h
@@ -33,7 +33,9 @@ class RequestedSegmentationInformation {
     return base_segment.Definition().codepoints.size();
   }
 
-  void ReassignInitSubset(GlyphClosureCache& closure_cache, SubsetDefinition new_def, const common::SegmentSet& removed_segments) {
+  void ReassignInitSubset(GlyphClosureCache& closure_cache,
+                          SubsetDefinition new_def,
+                          const common::SegmentSet& removed_segments) {
     for (segment_index_t s : removed_segments) {
       segments_[s].Clear();
     }

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -73,6 +73,19 @@ class SegmentationContext {
     return optimization_cutoff_segment_;
   }
 
+  common::SegmentSet CutoffSegments() const {
+    common::SegmentSet result;
+
+    unsigned num_segments = SegmentationInfo().Segments().size();
+    segment_index_t start = OptimizationCutoffSegment();
+    if (!num_segments || start > num_segments - 1) {
+      return result;
+    }
+
+    result.insert_range(start, num_segments - 1);
+    return result;
+  }
+
   const MergeStrategy& GetMergeStrategy() const { return merge_strategy_; }
 
   const RequestedSegmentationInformation& SegmentationInfo() const {

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -52,11 +52,7 @@ class SegmentationContext {
         glyph_groupings(segments),
         merge_strategy_(std::move(strategy)),
         optimization_cutoff_segment_(UINT32_MAX) {
-    for (unsigned i = 0; i < segments.size(); i++) {
-      if (!segments[i].Definition().Empty()) {
-        active_segments_.insert(i);
-      }
-    }
+    ComputeActiveSegments();
   }
 
   // Convert the information in this context into a finalized GlyphSegmentation
@@ -141,6 +137,39 @@ class SegmentationContext {
     glyph_condition_set.InvalidateGlyphInformation(glyphs, segments);
   }
 
+  /*
+   * Invalidates all grouping information and fully reprocesses all segments.
+   */
+  absl::Status ReassignInitSubset(SubsetDefinition new_def, const common::SegmentSet& removed_segments) {
+    unsigned glyph_count = hb_face_get_glyph_count(original_face.get());
+
+    segmentation_info_.ReassignInitSubset(glyph_closure_cache, std::move(new_def), removed_segments);
+    active_segments_.clear();
+    ComputeActiveSegments();
+
+    // All segments depend on the init subset def, so we must reprocess everything.
+    // First reset grouping information:
+    glyph_condition_set = GlyphConditionSet(glyph_count);
+    glyph_groupings = GlyphGroupings(SegmentationInfo().Segments());
+    inert_segments_.clear();
+
+    // Then reprocess segments:
+    for (segment_index_t segment_index = 0;
+       segment_index < SegmentationInfo().Segments().size();
+       segment_index++) {
+      TRY(ReprocessSegment(segment_index));
+    }
+
+    common::GlyphSet all_glyphs;
+    all_glyphs.insert_range(0, glyph_count - 1);
+    TRYV(GroupGlyphs(all_glyphs));
+    glyph_closure_cache.LogClosureCount("Segmentation reprocess for init def change.");
+
+    TRYV(InitOptimizationCutoff());
+
+    return absl::OkStatus();
+  }
+
   // Performs a closure analysis on codepoints and returns the associated
   // and, or, and exclusive glyph sets.
   absl::Status AnalyzeSegment(const common::SegmentSet& segment_ids,
@@ -166,6 +195,15 @@ class SegmentationContext {
   }
 
  private:
+
+  void ComputeActiveSegments() {
+    for (unsigned i = 0; i < segmentation_info_.Segments().size(); i++) {
+      if (!segmentation_info_.Segments()[i].Definition().Empty()) {
+        active_segments_.insert(i);
+      }
+    }
+  }
+
   /*
    * Ensures that the produce segmentation is:
    * - Disjoint (no duplicated glyphs) and doesn't overlap what's in the initial

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -140,30 +140,33 @@ class SegmentationContext {
   /*
    * Invalidates all grouping information and fully reprocesses all segments.
    */
-  absl::Status ReassignInitSubset(SubsetDefinition new_def, const common::SegmentSet& removed_segments) {
+  absl::Status ReassignInitSubset(SubsetDefinition new_def,
+                                  const common::SegmentSet& removed_segments) {
     unsigned glyph_count = hb_face_get_glyph_count(original_face.get());
 
-    segmentation_info_.ReassignInitSubset(glyph_closure_cache, std::move(new_def), removed_segments);
+    segmentation_info_.ReassignInitSubset(glyph_closure_cache,
+                                          std::move(new_def), removed_segments);
     active_segments_.clear();
     ComputeActiveSegments();
 
-    // All segments depend on the init subset def, so we must reprocess everything.
-    // First reset grouping information:
+    // All segments depend on the init subset def, so we must reprocess
+    // everything. First reset grouping information:
     glyph_condition_set = GlyphConditionSet(glyph_count);
     glyph_groupings = GlyphGroupings(SegmentationInfo().Segments());
     inert_segments_.clear();
 
     // Then reprocess segments:
     for (segment_index_t segment_index = 0;
-       segment_index < SegmentationInfo().Segments().size();
-       segment_index++) {
+         segment_index < SegmentationInfo().Segments().size();
+         segment_index++) {
       TRY(ReprocessSegment(segment_index));
     }
 
     common::GlyphSet all_glyphs;
     all_glyphs.insert_range(0, glyph_count - 1);
     TRYV(GroupGlyphs(all_glyphs));
-    glyph_closure_cache.LogClosureCount("Segmentation reprocess for init def change.");
+    glyph_closure_cache.LogClosureCount(
+        "Segmentation reprocess for init def change.");
 
     TRYV(InitOptimizationCutoff());
 
@@ -195,7 +198,6 @@ class SegmentationContext {
   }
 
  private:
-
   void ComputeActiveSegments() {
     for (unsigned i = 0; i < segmentation_info_.Segments().size(); i++) {
       if (!segmentation_info_.Segments()[i].Definition().Empty()) {

--- a/util/closure_glyph_keyed_segmenter_util.cc
+++ b/util/closure_glyph_keyed_segmenter_util.cc
@@ -81,6 +81,9 @@ ABSL_FLAG(double, optimization_cutoff_fraction, 0.001,
           "optimization of segments that have very little contribution to "
           "the total segmentation cost.");
 
+ABSL_FLAG(std::optional<double>, init_font_merge_threshold, std::nullopt,
+          "Merge all segments into the init font where the cost delta is less than this threshold.");
+
 enum MergingStrategy {
   HEURISTIC,
   COST,
@@ -606,6 +609,8 @@ int main(int argc, char** argv) {
 
     merge_strategy.SetOptimizationCutoffFraction(
         absl::GetFlag(FLAGS_optimization_cutoff_fraction));
+    merge_strategy.SetInitFontMergeThreshold(
+        absl::GetFlag(FLAGS_init_font_merge_threshold));
   }
 
   ClosureGlyphSegmenter segmenter;

--- a/util/closure_glyph_keyed_segmenter_util.cc
+++ b/util/closure_glyph_keyed_segmenter_util.cc
@@ -82,7 +82,8 @@ ABSL_FLAG(double, optimization_cutoff_fraction, 0.001,
           "the total segmentation cost.");
 
 ABSL_FLAG(std::optional<double>, init_font_merge_threshold, std::nullopt,
-          "Merge all segments into the init font where the cost delta is less than this threshold.");
+          "Merge all segments into the init font where the cost delta is less "
+          "than this threshold.");
 
 enum MergingStrategy {
   HEURISTIC,

--- a/util/closure_glyph_keyed_segmenter_util.cc
+++ b/util/closure_glyph_keyed_segmenter_util.cc
@@ -85,6 +85,10 @@ ABSL_FLAG(std::optional<double>, init_font_merge_threshold, std::nullopt,
           "Merge all segments into the init font where the cost delta is less "
           "than this threshold.");
 
+ABSL_FLAG(
+    int, verbosity, 0,
+    "Log verbosity level from. 0 is least verbose, higher values are more.");
+
 enum MergingStrategy {
   HEURISTIC,
   COST,
@@ -532,6 +536,7 @@ static int AnalysisWithFrequency(hb_face_t* font,
 
 int main(int argc, char** argv) {
   absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
+  absl::SetGlobalVLogLevel(absl::GetFlag(FLAGS_verbosity));
   auto args = absl::ParseCommandLine(argc, argv);
   absl::InitializeLog();
 


### PR DESCRIPTION
It's common that there are segments with 100% probabiliity, since these are always needed they can be moved to the initial font to make them available immediately. This adds an optional check (enabled via --init_font_merge_threshold) to find segments which give cost reductions larger than the threshold and move them into the initial font.

This step happens prior to merge processing since init font changes potentially affect all segments.