### PR TITLE
Refactor GlyphGroupings to use separate exclusive glyphs grouping.

### DIFF
--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -258,8 +258,7 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
                               modified_conditions));
 
   double cost_delta = 0.0;
-  VLOG(1) << "cost_delta for merge of " << merged_segments.ToString()
-            << " =";
+  VLOG(1) << "cost_delta for merge of " << merged_segments.ToString() << " =";
   if (!moving_to_init_font) {
     // Merge will introduce a new patch (merged_segment) with size
     // "new_patch_size", add the associated cost.

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -738,7 +738,8 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
 
   // Basic no segment case.
   GlyphSegmentation segmentation1({'a', 'b', 'c'}, {}, {});
-  auto sc = GlyphSegmentation::GroupsToSegmentation({}, {}, {}, segmentation1);
+  auto sc =
+      GlyphSegmentation::GroupsToSegmentation({}, {}, {}, {}, segmentation1);
   ASSERT_TRUE(sc.ok()) << sc;
 
   ClosureGlyphSegmenter segmenter;
@@ -750,12 +751,12 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
 
   // Add some patches
   GlyphSegmentation segmentation2({'a', 'b', 'c'}, {}, {});
-  sc = GlyphSegmentation::GroupsToSegmentation(
-      {
-          {{0}, {100, 101, 102}},
-          {{1}, {103, 104, 105}},
-      },
-      {}, {}, segmentation2);
+  sc = GlyphSegmentation::GroupsToSegmentation({}, {},
+                                               {
+                                                   {0, {100, 101, 102}},
+                                                   {1, {103, 104, 105}},
+                                               },
+                                               {}, segmentation2);
   ASSERT_TRUE(sc.ok()) << sc;
 
   std::vector<SubsetDefinition> segments{

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -35,30 +35,20 @@ namespace ift::encoder {
 Status GlyphSegmentation::GroupsToSegmentation(
     const btree_map<SegmentSet, GlyphSet>& and_glyph_groups,
     const btree_map<SegmentSet, GlyphSet>& or_glyph_groups,
+    const btree_map<segment_index_t, GlyphSet>& exclusive_glyph_groups,
     const SegmentSet& fallback_group, GlyphSegmentation& segmentation) {
   patch_id_t next_id = 0;
   segmentation.patches_.clear();
   segmentation.conditions_.clear();
 
   // Map segments into patch ids
-  for (const auto& [and_segments, glyphs] : and_glyph_groups) {
-    if (and_segments.size() != 1) {
-      continue;
-    }
-
-    segment_index_t segment = *and_segments.begin();
+  for (const auto& [segment, glyphs] : exclusive_glyph_groups) {
     segmentation.patches_.insert(std::pair(next_id, glyphs));
-    // All 1 segment and conditions are considered to be exclusive
     segmentation.conditions_.insert(
         ActivationCondition::exclusive_segment(segment, next_id++));
   }
 
   for (const auto& [and_segments, glyphs] : and_glyph_groups) {
-    if (and_segments.size() == 1) {
-      // already processed above
-      continue;
-    }
-
     segmentation.patches_.insert(std::pair(next_id, glyphs));
     segmentation.conditions_.insert(
         ActivationCondition::and_segments(and_segments, next_id));

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -96,6 +96,8 @@ class GlyphSegmentation {
           and_glyph_groups,
       const absl::btree_map<common::SegmentSet, common::GlyphSet>&
           or_glyph_groups,
+      const absl::btree_map<segment_index_t, common::GlyphSet>&
+          exclusive_glyph_groups,
       const common::SegmentSet& fallback_group,
       GlyphSegmentation& segmentation);
 

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -96,12 +96,12 @@ StatusOr<segment_index_t> SegmentationContext::ComputeSegmentCutoff() const {
   double total_cost = 0.0;
   double overhead = merge_strategy_.NetworkOverheadCost();
   for (segment_index_t s : active_segments_) {
-    auto segment_glyphs = glyph_groupings.AndGlyphGroups().find(SegmentSet{s});
-    if (segment_glyphs == glyph_groupings.AndGlyphGroups().end()) {
+    auto segment_glyphs = glyph_groupings.ExclusiveGlyphs(s);
+    if (segment_glyphs.empty()) {
       continue;
     }
 
-    double size = TRY(patch_size_cache->GetPatchSize(segment_glyphs->second));
+    double size = TRY(patch_size_cache->GetPatchSize(segment_glyphs));
     double probability = segmentation_info_.Segments()[s].Probability();
     total_cost += probability * (size + overhead);
   }
@@ -112,12 +112,12 @@ StatusOr<segment_index_t> SegmentationContext::ComputeSegmentCutoff() const {
   for (auto it = active_segments_.rbegin(); it != active_segments_.rend();
        it++) {
     segment_index_t s = *it;
-    auto segment_glyphs = glyph_groupings.AndGlyphGroups().find(SegmentSet{s});
-    if (segment_glyphs == glyph_groupings.AndGlyphGroups().end()) {
+    auto segment_glyphs = glyph_groupings.ExclusiveGlyphs(s);
+    if (segment_glyphs.empty()) {
       continue;
     }
 
-    double size = TRY(patch_size_cache->GetPatchSize(segment_glyphs->second));
+    double size = TRY(patch_size_cache->GetPatchSize(segment_glyphs));
     double probability = segmentation_info_.Segments()[s].Probability();
     cutoff_tail_cost -= probability * (size + overhead);
     if (cutoff_tail_cost < 0.0) {


### PR DESCRIPTION
Prior to this change exclusive glyphs were being kep in the 'and glyph' groupings and down stream users needed to know that 'and glyph' groupings of size 1 are exclusive patches. This change moves exclusive groupings to their own map to make it clear and reduce the need for special casing in various other places.