### PR TITLE
Fix IsVariable check in compiler.

### DIFF
--- a/common/axis_range.h
+++ b/common/axis_range.h
@@ -1,6 +1,8 @@
 #ifndef COMMON_AXIS_RANGE_H_
 #define COMMON_AXIS_RANGE_H_
 
+#include <optional>
+
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 
@@ -30,6 +32,15 @@ struct AxisRange {
 
   bool Intersects(const AxisRange& other) const {
     return other.end_ >= start_ && end_ >= other.start_;
+  }
+
+  std::optional<AxisRange> Intersection(const AxisRange& other) const {
+    if (!Intersects(other)) {
+      return std::nullopt;
+    }
+
+    return AxisRange(std::max(start_, other.start_),
+                     std::min(end_, other.end_));
   }
 
   AxisRange() : start_(0), end_(0) {}

--- a/common/axis_range_test.cc
+++ b/common/axis_range_test.cc
@@ -1,12 +1,14 @@
 #include "common/axis_range.h"
 
+#include <optional>
+
 #include "gtest/gtest.h"
 
 namespace common {
 
 class AxisRangeTest : public ::testing::Test {};
 
-TEST_F(AxisRangeTest, AxisRange_Intersection) {
+TEST_F(AxisRangeTest, AxisRange_Intersects) {
   auto a = AxisRange::Range(1, 4);
   auto b = AxisRange::Range(5, 9);
   ASSERT_FALSE(a->Intersects(*b));
@@ -31,6 +33,25 @@ TEST_F(AxisRangeTest, AxisRange_Intersection) {
 
   ASSERT_TRUE(f->Intersects(*g));
   ASSERT_TRUE(g->Intersects(*f));
+}
+
+TEST_F(AxisRangeTest, AxisRange_Intersection) {
+  auto a = AxisRange::Range(1, 4);
+  auto b = AxisRange::Range(2, 9);
+  auto c = AxisRange::Range(0, 5);
+  auto d = AxisRange::Range(4, 7);
+  auto e = AxisRange::Range(10, 12);
+
+  ASSERT_EQ(a->Intersection(*e), std::nullopt);
+
+  ASSERT_EQ(a->Intersection(*b), *AxisRange::Range(2, 4));
+  ASSERT_EQ(b->Intersection(*a), *AxisRange::Range(2, 4));
+
+  ASSERT_EQ(a->Intersection(*c), *AxisRange::Range(1, 4));
+  ASSERT_EQ(c->Intersection(*a), *AxisRange::Range(1, 4));
+
+  ASSERT_EQ(a->Intersection(*d), AxisRange::Point(4));
+  ASSERT_EQ(d->Intersection(*a), AxisRange::Point(4));
 }
 
 TEST_F(AxisRangeTest, AxisRange_Creation) {

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -154,8 +154,12 @@ cc_test(
     srcs = [
         "subset_definition_test.cc",
     ],
+    data = [
+        "//common:testdata",
+    ],
     deps = [
         ":encoder",
+        "@harfbuzz",
         "@googletest//:gtest_main",
     ],
 )

--- a/ift/encoder/compiler.cc
+++ b/ift/encoder/compiler.cc
@@ -229,33 +229,28 @@ StatusOr<Compiler::Encoding> Compiler::Compile() const {
     // loca table to remain at the full length from the start.
     //
     // TODO(garretrieger): this unnecessarily includes the last gid in the
-    // subset,
-    //                     should update the subsetter to retain the glyph count
-    //                     but not actually keep the last gid.
+    //  subset, should update the subsetter to retain the glyph count
+    //  but not actually keep the last gid.
     //
     // TODO(garretrieger): instead of forcing max glyph count here we can
-    // utilize
-    //                     table keyed patches to change loca len/glyph count to
-    //                     the max for any currently reachable segments. This
-    //                     would improve efficiency slightly by avoid including
-    //                     extra space in the initial font. However, it would
-    //                     require us to examine conditions against each subset
-    //                     to determine patch reachability.
+    //  utilize table keyed patches to change loca len/glyph count to
+    //  the max for any currently reachable segments. This would improve
+    //  efficiency slightly by avoid including extra space in the initial
+    //  font. However, it would require us to examine conditions against
+    //  each subset to determine patch reachability.
     //
     // TODO(garretrieger): in the mean time we can use the max glyph id from
-    // fully
-    //                     expanded subset instead. this will at least prune
-    //                     glyphs not used at any extension level.
+    //  fully expanded subset instead. this will at least prune glyphs not
+    //  used at any extension level.
     uint32_t gid_count = hb_face_get_glyph_count(face_.get());
     if (gid_count > 0) context.init_subset_.gids.insert(gid_count - 1);
   }
 
   // TODO(garretrieger): when generating the fully expanded subset don't use
-  // retain
-  //                     gids. Save the resulting glyph mapping and use it to
-  //                     translate encoder config gids into the space used by
-  //                     fully expanded subset. This will optimize for cases
-  //                     that don't include the entire original font.
+  //  retain gids. Save the resulting glyph mapping and use it to translate
+  //  encoder config gids into the space used by fully expanded subset.
+  //  This will optimize for cases that don't include the entire original
+  //  font.
   context.force_long_loca_and_gvar_ = false;
   auto expanded = FullyExpandedSubset(context);
   if (!expanded.ok()) {
@@ -266,9 +261,8 @@ StatusOr<Compiler::Encoding> Compiler::Compile() const {
   auto expanded_face = expanded->face();
 
   // TODO(garretrieger): we don't need to force long gvar anymore. The client is
-  // now capable of
-  //                     upgrading the offset size as needed. Forcing long loca
-  //                     is still needed though.
+  //  now capable of upgrading the offset size as needed. Forcing long loca
+  //  is still needed though.
   context.force_long_loca_and_gvar_ =
       FontHelper::HasLongLoca(expanded_face.get()) ||
       FontHelper::HasWideGvar(expanded_face.get());
@@ -856,7 +850,7 @@ StatusOr<FontData> Compiler::CutSubset(const ProcessingContext& context,
   }
 
   auto tags = FontHelper::GetTags(font);
-  if (generate_glyph_keyed_bases && def.IsVariable() &&
+  if (generate_glyph_keyed_bases && TRY(def.IsVariableFor(font)) &&
       tags.contains(FontHelper::kGvar)) {
     // In mixed mode glyph keyed patches handles gvar, except for when design
     // space is expanded, in which case a gvar table should be patched in that

--- a/ift/encoder/subset_definition.h
+++ b/ift/encoder/subset_definition.h
@@ -9,7 +9,9 @@
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "common/axis_range.h"
+#include "common/font_helper.h"
 #include "common/int_set.h"
+#include "common/try.h"
 #include "hb-subset.h"
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
@@ -54,14 +56,12 @@ struct SubsetDefinition {
   absl::btree_set<hb_tag_t> feature_tags;
   design_space_t design_space;
 
-  bool IsVariable() const {
-    for (const auto& [tag, range] : design_space) {
-      if (range.IsRange()) {
-        return true;
-      }
-    }
-    return false;
-  }
+  // Returns true if the design space in this subset definition will result in
+  // a variable font when applied to face.
+  //
+  // This will be true if the design space leaves at least one axis from face as
+  // a range.
+  absl::StatusOr<bool> IsVariableFor(hb_face_t* face) const;
 
   bool Empty() const {
     return codepoints.empty() && gids.empty() && feature_tags.empty() &&


### PR DESCRIPTION
When determining whether a subset definition will result in a variable font we have to take into account the font being subset by the definition.