### PR TITLE
Implement design space union/subtraction.

### DIFF
--- a/ift/encoder/compiler.cc
+++ b/ift/encoder/compiler.cc
@@ -99,12 +99,6 @@ StatusOr<FontData> Compiler::FullyExpandedSubset(
     all.gids.insert(gids.begin(), gids.end());
   }
 
-  // Union doesn't work completely correctly with respect to design spaces so
-  // clear out design space which will just include the full original design
-  // space.
-  // TODO(garretrieger): once union works correctly remove this.
-  all.design_space.clear();
-
   return CutSubset(context, face_.get(), all, false);
 }
 
@@ -131,14 +125,6 @@ std::vector<Compiler::Edge> Compiler::OutgoingEdges(
     AddCombinations(input, i, result);
   }
 
-  return result;
-}
-
-SubsetDefinition Compiler::Combine(const SubsetDefinition& s1,
-                                   const SubsetDefinition& s2) const {
-  SubsetDefinition result;
-  result.Union(s1);
-  result.Union(s2);
   return result;
 }
 

--- a/ift/encoder/compiler.h
+++ b/ift/encoder/compiler.h
@@ -261,9 +261,6 @@ class Compiler {
     return out;
   }
 
-  SubsetDefinition Combine(const SubsetDefinition& s1,
-                           const SubsetDefinition& s2) const;
-
   /*
    * Create an IFT encoded version of 'font' that initially supports
    * 'base_subset' but can be extended via patches to support any combination of

--- a/ift/encoder/compiler_test.cc
+++ b/ift/encoder/compiler_test.cc
@@ -289,10 +289,7 @@ TEST_F(CompilerTest, OutgoingEdges_DesignSpace_AddAxis_OverlappingAxisRange) {
   SubsetDefinition s1{3, 4};
 
   SubsetDefinition s2{};
-  // TODO(garretrieger): since the current subtract implementation is limited
-  //   we don't support partially subtracting a range. Once support is
-  //   available this case can be updated to check wght range is partially
-  //   subtracted instead of being ignored.
+  s2.design_space[kWght] = *AxisRange::Range(500, 700);
   s2.design_space[kWdth] = *AxisRange::Range(300, 400);
 
   auto combos = compiler.OutgoingEdges(base, 2);


### PR DESCRIPTION
This was previously left unhandled pending a decision on how to approach it. This provides an implementation where disjoint ranges resulting from union/subtraction operations are avoided by replacing them with a continous superset range.