### PR TITLE
Use average rather than minimum probability from the probability bound.

### DIFF
--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -371,10 +371,10 @@ StatusOr<double> ActivationCondition::Probability(
     }
 
     // TODO(garretrieger): The full probability bound should be utilized here.
-    return calculator.ComputeMergedProbability(union_segments).Min();
+    return calculator.ComputeMergedProbability(union_segments).Average();
   }
 
-  return calculator.ComputeConjunctiveProbability(conjunctive_segments).Min();
+  return calculator.ComputeConjunctiveProbability(conjunctive_segments).Average();
 }
 
 StatusOr<double> ActivationCondition::MergedProbability(
@@ -431,10 +431,10 @@ StatusOr<double> ActivationCondition::MergedProbability(
       union_segments.push_back(&merged_segment);
     }
 
-    return calculator.ComputeMergedProbability(union_segments).Min();
+    return calculator.ComputeMergedProbability(union_segments).Average();
   }
 
-  return calculator.ComputeConjunctiveProbability(conjunctive_segments).Min();
+  return calculator.ComputeConjunctiveProbability(conjunctive_segments).Average();
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -176,19 +176,16 @@ struct SegmentOrdering {
 
   bool operator<(const SegmentOrdering& other) const {
     if (group_index != other.group_index) {
+      // Group index ascending.
       return group_index < other.group_index;
     }
 
-    if (probability.Min() != other.probability.Min()) {
-      // Probability descending.
-      return probability.Min() > other.probability.Min();
+    if (probability.Average() != other.probability.Average()) {
+      // Segment probability descending.
+      return probability.Average() > other.probability.Average();
     }
 
-    if (probability.Max() != other.probability.Max()) {
-      // Probability descending.
-      return probability.Max() > other.probability.Max();
-    }
-
+    // Break ties with original segment index ascending.
     return original_index < other.original_index;
   }
 };
@@ -595,7 +592,7 @@ StatusOr<SegmentationCost> ClosureGlyphSegmenter::TotalCost(
   double incremental_size =
       non_ift_font_size / (double)non_ift.codepoints.size();
   for (unsigned cp : non_ift.codepoints) {
-    double Pcp = probability_calculator.ComputeProbability({cp}).Min();
+    double Pcp = probability_calculator.ComputeProbability({cp}).Average();
     ideal_cost += Pcp * incremental_size;
   }
 

--- a/ift/encoder/segment.h
+++ b/ift/encoder/segment.h
@@ -10,7 +10,7 @@ struct Segment {
   Segment(SubsetDefinition definition, freq::ProbabilityBound probability)
       : definition(std::move(definition)), probability(probability) {}
 
-  double Probability() const { return probability.Min(); }
+  double Probability() const { return probability.Average(); }
   const freq::ProbabilityBound& ProbabilityBound() const { return probability; }
 
   const SubsetDefinition& Definition() const { return definition; }

--- a/ift/freq/probability_bound.h
+++ b/ift/freq/probability_bound.h
@@ -17,6 +17,7 @@ struct ProbabilityBound {
 
   double Min() const { return min_; }
   double Max() const { return max_; }
+  double Average() const { return (min_ + max_) / 2.0; }
 
   bool operator==(const ProbabilityBound& other) const {
     return min_ == other.min_ && max_ == other.max_;


### PR DESCRIPTION
Testing shows this is neutral on performance of produced segmentations vs min bound, but gives a pretty good reduction in brotli calls by making best case pruning more effective.