### PR TITLE
Prep for integrating complex condition finding into the merging process.

### DIFF
--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -94,12 +94,8 @@ class SegmentationContext {
    */
   void InvalidateGlyphInformation(const common::GlyphSet& glyphs,
                                   const common::SegmentSet& segments) {
-    // unmapped, and and/or glyph groups are down stream of glyph conditions
-    // so must be invalidated. Do this before modifying the conditions.
-    for (uint32_t gid : glyphs) {
-      glyph_groupings.InvalidateGlyphInformation(gid);
-    }
-
+    // Note: glyph_groupings will be automatically invalidated as needed when
+    // group glyphs is called.
     glyph_condition_set.InvalidateGlyphInformation(glyphs, segments);
   }
 


### PR DESCRIPTION
Some fixes, cleanups, and simplifications to invalidation handling in GlyphGroupings, notably:
- Adds an internal `glyph -> condition` index which will be needed to handle complex condition invalidation correctly.
- Removes the need for explicit invalidation calls in the public api of GlyphGroupings, now invalidation is done automatically when calling GroupGlyphs() or AddGlyphsToExclusiveGroup()
- Detect cases where the grouping process attempts to add conflicting condition mappings.
- Fix case where combined patches were not being recomputed by the special casing path for inert segment merges.