### PR TITLE
Use the set of all glyphs in the full closure instead of all glyphs in the font.

### DIFF
--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -104,10 +104,7 @@ Status ValidateIncrementalGroupings(hb_face_t* face,
     TRYV(non_incremental_context.glyph_groupings.CombinePatches(group, {}));
   }
 
-  GlyphSet all_glyphs;
-  uint32_t glyph_count = hb_face_get_glyph_count(face);
-  all_glyphs.insert_range(0, glyph_count - 1);
-  TRYV(non_incremental_context.GroupGlyphs(all_glyphs));
+  TRYV(non_incremental_context.GroupGlyphs(context.SegmentationInfo().FullClosure()));
 
   if (non_incremental_context.glyph_groupings.ConditionsAndGlyphs() !=
       context.glyph_groupings.ConditionsAndGlyphs()) {
@@ -552,8 +549,7 @@ StatusOr<SegmentationContext>
 ClosureGlyphSegmenter::InitializeSegmentationContext(
     hb_face_t* face, SubsetDefinition initial_segment,
     std::vector<Segment> segments) const {
-  uint32_t glyph_count = hb_face_get_glyph_count(face);
-  if (!glyph_count) {
+  if (!hb_face_get_glyph_count(face)) {
     return absl::InvalidArgumentError("Provided font has no glyphs.");
   }
 
@@ -575,9 +571,7 @@ ClosureGlyphSegmenter::InitializeSegmentationContext(
   }
   context.glyph_closure_cache.LogClosureCount("Inital segment analysis");
 
-  GlyphSet all_glyphs;
-  all_glyphs.insert_range(0, glyph_count - 1);
-  TRYV(context.GroupGlyphs(all_glyphs));
+  TRYV(context.GroupGlyphs(context.SegmentationInfo().NonInitFontGlyphs()));
   context.glyph_closure_cache.LogClosureCount("Condition grouping");
 
   return context;

--- a/ift/encoder/requested_segmentation_information.cc
+++ b/ift/encoder/requested_segmentation_information.cc
@@ -3,32 +3,47 @@
 #include <vector>
 
 #include "ift/encoder/segment.h"
+#include "ift/encoder/subset_definition.h"
 
 namespace ift::encoder {
+
+static bool CheckSegmentsAreDisjoint(
+  const SubsetDefinition& init_segment,
+  const std::vector<Segment>& segments
+) {
+  bool segments_disjoint = true;
+  SubsetDefinition full_definition = init_segment;
+  for (const auto& s : segments) {
+    const auto& def = s.Definition();
+    if (segments_disjoint) {
+      for (hb_tag_t tag : def.feature_tags) {
+        if (full_definition.feature_tags.contains(tag)) {
+          segments_disjoint = false;
+        }
+      }
+      segments_disjoint =
+          segments_disjoint &&
+          !full_definition.codepoints.intersects(def.codepoints);
+    }
+    full_definition.Union(s.Definition());
+  }
+  return segments_disjoint;
+}
 
 RequestedSegmentationInformation::RequestedSegmentationInformation(
     std::vector<Segment> segments, SubsetDefinition init_font_segment,
     GlyphClosureCache& closure_cache)
     : segments_(std::move(segments)), init_font_segment_() {
-  ReassignInitSubset(closure_cache, std::move(init_font_segment));
 
-  segments_disjoint_ = true;
-
-  full_definition_ = init_font_segment_;
+  // ReassignInitSubset expects full_definition_ is already populated.
+  full_definition_ = init_font_segment;
   for (const auto& s : segments_) {
-    const auto& def = s.Definition();
-    if (segments_disjoint_) {
-      for (hb_tag_t tag : def.feature_tags) {
-        if (full_definition_.feature_tags.contains(tag)) {
-          segments_disjoint_ = false;
-        }
-      }
-      segments_disjoint_ =
-          segments_disjoint_ &&
-          !full_definition_.codepoints.intersects(def.codepoints);
-    }
     full_definition_.Union(s.Definition());
   }
+
+  ReassignInitSubset(closure_cache, std::move(init_font_segment));
+
+  segments_disjoint_ = CheckSegmentsAreDisjoint(init_font_segment, segments_);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -122,9 +122,7 @@ class SegmentationContext {
       TRY(ReprocessSegment(segment_index));
     }
 
-    common::GlyphSet all_glyphs;
-    all_glyphs.insert_range(0, glyph_count - 1);
-    TRYV(GroupGlyphs(all_glyphs));
+    TRYV(GroupGlyphs(SegmentationInfo().NonInitFontGlyphs()));
     glyph_closure_cache.LogClosureCount(
         "Segmentation reprocess for init def change.");
 


### PR DESCRIPTION
Only glyphs in the closure of the init font and all segments are inscope for segmenting. There were a few places that were incorrectly considering all glyphs in the font. This replaces those with the appropriate closure set of glyphs.