### PR TITLE
In segmenter/compiler subsetting ops don't rely on hb default feature list.

### DIFF
--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -15,6 +15,7 @@
 #include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
 #include "ift/freq/probability_bound.h"
+#include "ift/encoder/init_subset_defaults.h"
 
 namespace ift::encoder {
 
@@ -64,6 +65,8 @@ class GlyphGroupingsTest : public ::testing::Test {
     uint32_t num_glyphs = hb_face_get_glyph_count(roboto_.get());
 
     SubsetDefinition init_font_segment;
+    AddInitSubsetDefaults(init_font_segment);
+
     closure_cache_ = std::make_unique<GlyphClosureCache>(roboto_.get());
     requested_segmentation_info_ =
         std::make_unique<RequestedSegmentationInformation>(
@@ -131,6 +134,8 @@ class GlyphGroupingsTest : public ::testing::Test {
     glyph_conditions_complex_->AddAndCondition(ToGlyph(0x6C), 1);
 
     SubsetDefinition init_font_segment;
+    AddInitSubsetDefaults(init_font_segment);
+
     requested_segmentation_info_complex_ =
         std::make_unique<RequestedSegmentationInformation>(
             segments_complex_, init_font_segment, *closure_cache_,
@@ -581,6 +586,7 @@ TEST_F(GlyphGroupingsTest, ExclusiveGlyphsRespectsPatchCombinations) {
 
 TEST_F(GlyphGroupingsTest, ComplexConditionFinding_LeaveUnmapped) {
   SubsetDefinition init_font_segment;
+  AddInitSubsetDefaults(init_font_segment);
   RequestedSegmentationInformation segmentation_info(
       segments_complex_, init_font_segment, *closure_cache_, PATCH);
 

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -718,7 +718,7 @@ Status Merger::ApplyInitFontMove(const GlyphSet& glyphs_to_move, double delta) {
           << " glyphs into the initial font (cost delta = " << delta << ")";
 
   SubsetDefinition initial_segment =
-      Context().SegmentationInfo().InitFontSegmentWithoutDefaults();
+      Context().SegmentationInfo().InitFontSegment();
   initial_segment.gids.union_set(glyphs_to_move);
 
   TRYV(Context().ReassignInitSubset(initial_segment));

--- a/ift/encoder/subset_definition.cc
+++ b/ift/encoder/subset_definition.cc
@@ -183,6 +183,10 @@ void SubsetDefinition::ConfigureInput(hb_subset_input_t* input,
 
   hb_set_t* features =
       hb_subset_input_set(input, HB_SUBSET_SETS_LAYOUT_FEATURE_TAG);
+  // hb_input_t has a set of layout featurs configured by default, we
+  // instead rely on the IFT spec default feature list so clear out the
+  // harfbuzz provided ones.
+  hb_set_clear(features);
   for (hb_tag_t tag : feature_tags) {
     hb_set_add(features, tag);
   }


### PR DESCRIPTION
Use only the IFT spec default feature list.