### PR TITLE
In ValidateIncrementalGroupings enforce equivalence not equality.

### DIFF
--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -263,6 +263,27 @@ cc_test(
 )
 
 cc_test(
+    name = "glyph_closure_cache_test",
+    size = "small",
+    srcs = [
+        "glyph_closure_cache_test.cc",
+    ],
+    copts = [
+        "-DHB_EXPERIMENTAL_API",
+        "-DHB_DEPEND_API",
+    ],
+    data = [
+        "//common:testdata",
+    ],
+    deps = [
+        ":encoder",
+        ":segmentation_info",
+        "//common",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "glyph_groupings_test",
     srcs = ["glyph_groupings_test.cc"],
     data = [

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -22,6 +22,8 @@
 #include "common/int_set.h"
 #include "common/try.h"
 #include "common/woff2.h"
+#include "ift/encoder/activation_condition.h"
+#include "ift/encoder/glyph_groupings.h"
 #include "ift/encoder/glyph_segmentation.h"
 #include "ift/encoder/invalidation_set.h"
 #include "ift/encoder/merge_strategy.h"
@@ -114,6 +116,65 @@ static void PrintDiff(const btree_map<ActivationCondition, GlyphSet>& a,
   }
 }
 
+// Returns true if the glyph groupings a and b are equivalent (not necessarily equal).
+//
+// Complex condition finding can return multiple possible valid conditions for a glyph
+// so for these we allowe differences as long as the closure condition is satisfied
+// (that is there are no additional conditions.)
+static StatusOr<bool> GlyphGroupingsAreEquivalent(
+  const SegmentationContext& context,
+  const GlyphGroupings& a,
+  const GlyphGroupings& b
+) {
+  if (a.ConditionsAndGlyphs() == b.ConditionsAndGlyphs()) {
+    return true;
+  }
+
+  for (glyph_id_t gid = 0; gid < hb_face_get_glyph_count(context.original_face.get()); gid++) {
+    auto maybe_cond_a = a.GlyphToCondition(gid);
+    auto maybe_cond_b = b.GlyphToCondition(gid);
+
+    if (maybe_cond_a.has_value() != maybe_cond_b.has_value()) {
+      return false;
+    }
+
+    if (!maybe_cond_a.has_value()) {
+      continue;
+    }
+
+    ActivationCondition cond_a = *maybe_cond_a;
+    ActivationCondition cond_b = *maybe_cond_b;
+
+    if (cond_a == cond_b) {
+      continue;
+    }
+
+    if (!a.FoundConditionGlyphs().contains(gid) || !b.FoundConditionGlyphs().contains(gid)) {
+      // diffs only allowed if gid is a found conditions gid in both a and b.
+      return false;
+    }
+
+    if (cond_a.conditions().size() > 1 || cond_b.conditions().size() > 1) {
+      // diffs only allowed for purely disjunctive conditions
+      return false;
+    }
+
+    if (TRY(context.glyph_closure_cache->HasAdditionalConditions(&context.SegmentationInfo(),
+      cond_a.TriggeringSegments(), GlyphSet {gid}))) {
+      return false;
+    }
+
+    if (TRY(context.glyph_closure_cache->HasAdditionalConditions(&context.SegmentationInfo(),
+      cond_b.TriggeringSegments(), GlyphSet {gid}))) {
+      return false;
+    }
+
+    // If no additional conditions are present on either side then we allow the diff.
+  }
+
+  return true;
+}
+
 /*
  * Checks that the incrementally generated glyph conditions and groupings in
  * context match what would have been produced by a non incremental process.
@@ -145,14 +206,18 @@ Status ValidateIncrementalGroupings(hb_face_t* face,
   TRYV(non_incremental_context.GroupGlyphs(
       context.SegmentationInfo().FullClosure(), {}));
 
+  bool glyph_groupings_diffs_allowed = false;
   if (non_incremental_context.glyph_groupings.ConditionsAndGlyphs() !=
       context.glyph_groupings.ConditionsAndGlyphs()) {
-    VLOG(0) << "-- incremental grouping";
-    VLOG(0) << "++ non-incremental grouping";
-    PrintDiff(context.glyph_groupings.ConditionsAndGlyphs(),
-              non_incremental_context.glyph_groupings.ConditionsAndGlyphs());
-    return absl::FailedPreconditionError(
-        "conditions_and_glyphs aren't correct.");
+    if (!TRY(GlyphGroupingsAreEquivalent(context, context.glyph_groupings, non_incremental_context.glyph_groupings))) {
+      VLOG(0) << "-- incremental grouping";
+      VLOG(0) << "++ non-incremental grouping";
+      PrintDiff(context.glyph_groupings.ConditionsAndGlyphs(),
+                non_incremental_context.glyph_groupings.ConditionsAndGlyphs());
+      return absl::FailedPreconditionError(
+          "conditions_and_glyphs aren't correct.");
+    }
+    glyph_groupings_diffs_allowed = true;
   }
 
   if (non_incremental_context.glyph_condition_set !=
@@ -160,7 +225,8 @@ Status ValidateIncrementalGroupings(hb_face_t* face,
     return absl::FailedPreconditionError("glyph_condition_set isn't correct.");
   }
 
-  if (non_incremental_context.glyph_groupings != context.glyph_groupings) {
+  if (!glyph_groupings_diffs_allowed &&
+      non_incremental_context.glyph_groupings != context.glyph_groupings) {
     return absl::FailedPreconditionError("glyph groups aren't correct.");
   }
 
@@ -538,6 +604,7 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
         continue;
       }
 
+      VLOG(0) << "Last merge group finished. Producing final segmentation.";
       // Nothing was merged so we're done.
       TRYV(ValidateIncrementalGroupings(face, context));
       context.patch_size_cache->LogBrotliCallCount();

--- a/ift/encoder/complex_condition_finder.cc
+++ b/ift/encoder/complex_condition_finder.cc
@@ -103,7 +103,7 @@ struct Context {
                   SegmentSet to_be_tested, GlyphSet glyphs) {
     SegmentSet all = sub_condition;
     all.union_set(to_be_tested);
-    SubsetDefinition task_definition = CombinedDefinition(all);
+    SubsetDefinition task_definition = segmentation_info->CombinedDefinition(all);
     return Task{
         .full_condition = full_condition,
         .sub_condition = sub_condition,
@@ -138,7 +138,7 @@ struct Context {
 
   // Returns true if all glyphs are in the closure of segments.
   StatusOr<bool> InClosure(const SegmentSet& segments, const GlyphSet& glyphs) {
-    GlyphSet closure = TRY(SegmentClosure(segments));
+    GlyphSet closure = TRY(glyph_closure_cache->SegmentClosure(segmentation_info, segments));
     return glyphs.is_subset_of(closure);
   }
 
@@ -146,7 +146,7 @@ struct Context {
       const SegmentSet& segments, const GlyphSet& glyphs) {
     SegmentSet except = all_segments;
     except.subtract(segments);
-    GlyphSet closure_glyphs = TRY(SegmentClosure(except));
+    GlyphSet closure_glyphs = TRY(glyph_closure_cache->SegmentClosure(segmentation_info, except));
     closure_glyphs.intersect(glyphs);
 
     except.intersect(inscope_segments);
@@ -248,27 +248,6 @@ struct Context {
     queue.push_back(CreateTask(task.full_condition, {}, remaining,
                                additional_condition_glyphs));
     return absl::OkStatus();
-  }
-
-  SubsetDefinition CombinedDefinition(const SegmentSet& segments) {
-    // TODO(garretrieger): this approach is inefficient vs the subtraction
-    // method, add the special case path or remove use of this function in
-    // favour of incrementally produced defs.
-    SubsetDefinition def;
-    for (segment_index_t s : segments) {
-      def.Union(segmentation_info->Segments().at(s).Definition());
-    }
-
-    // Init font subset definition must be part of the closure input
-    // since it contributes to reachability of things.
-    def.Union(segmentation_info->InitFontSegment());
-
-    return def;
-  }
-
-  StatusOr<GlyphSet> SegmentClosure(const SegmentSet& segments) {
-    SubsetDefinition closure_def = CombinedDefinition(segments);
-    return glyph_closure_cache->GlyphClosure(closure_def);
   }
 };
 

--- a/ift/encoder/glyph_closure_cache.cc
+++ b/ift/encoder/glyph_closure_cache.cc
@@ -19,6 +19,28 @@ using common::FontHelper;
 
 namespace ift::encoder {
 
+StatusOr<common::GlyphSet> GlyphClosureCache::SegmentClosure(
+  const RequestedSegmentationInformation* segmentation_info,
+  const common::SegmentSet& segments) {
+  SubsetDefinition closure_def = segmentation_info->CombinedDefinition(segments);
+  return GlyphClosure(closure_def);
+}
+
+StatusOr<bool> GlyphClosureCache::HasAdditionalConditions(
+  const RequestedSegmentationInformation* segmentation_info,
+  const SegmentSet& segments,
+  const GlyphSet& glyphs
+) {
+  SegmentSet except;
+  if (!segmentation_info->Segments().empty()) {
+    except.insert_range(0, segmentation_info->Segments().size() - 1);
+  }
+  except.subtract(segments);
+
+  GlyphSet closure_glyphs = TRY(SegmentClosure(segmentation_info, except));
+  return closure_glyphs.intersects(glyphs);
+}
+
 StatusOr<common::GlyphSet> GlyphClosureCache::GlyphClosure(
     const SubsetDefinition& segment) {
   auto it = glyph_closure_cache_.find(segment);

--- a/ift/encoder/glyph_closure_cache.h
+++ b/ift/encoder/glyph_closure_cache.h
@@ -23,6 +23,18 @@ class GlyphClosureCache {
   absl::StatusOr<common::GlyphSet> GlyphClosure(
       const SubsetDefinition& segment);
 
+  absl::StatusOr<common::GlyphSet> SegmentClosure(
+    const RequestedSegmentationInformation* segmentation_info,
+    const common::SegmentSet& segments);
+
+  // Checks if a disjunction accross segments satisifies the closure require for glyphs,
+  // returns true if there are potential additional conditions beyond segments that may
+  // activate glyphs.
+  absl::StatusOr<bool> HasAdditionalConditions(
+      const RequestedSegmentationInformation* segmentation_info,
+      const common::SegmentSet& segments, const common::GlyphSet& glyphs);
+
+  // Analyzes the provided segments with AnalyzeSegment() and returns just the or_gids
   absl::StatusOr<common::GlyphSet> CodepointsToOrGids(
       const RequestedSegmentationInformation& segmentation_info,
       const common::SegmentSet& segment_ids);

--- a/ift/encoder/glyph_closure_cache_test.cc
+++ b/ift/encoder/glyph_closure_cache_test.cc
@@ -1,0 +1,179 @@
+#include "ift/encoder/glyph_closure_cache.h"
+
+#include <vector>
+
+#include "common/font_data.h"
+#include "gtest/gtest.h"
+#include "ift/encoder/requested_segmentation_information.h"
+#include "ift/encoder/subset_definition.h"
+#include "ift/freq/probability_bound.h"
+
+using absl::StatusOr;
+using common::CodepointSet;
+using common::FontData;
+using common::GlyphSet;
+using common::hb_face_unique_ptr;
+using common::make_hb_face;
+using common::SegmentSet;
+using ift::freq::ProbabilityBound;
+
+namespace ift::encoder {
+
+class GlyphClosureCacheTest : public ::testing::Test {
+ protected:
+  GlyphClosureCacheTest() : roboto(make_hb_face(nullptr)) {
+    roboto = from_file("common/testdata/Roboto-Regular.ttf");
+  }
+
+  hb_face_unique_ptr from_file(const char* filename) {
+    hb_blob_t* blob = hb_blob_create_from_file_or_fail(filename);
+    if (!blob) {
+      assert(false);
+    }
+    FontData result(blob);
+    hb_blob_destroy(blob);
+    return result.face();
+  }
+
+  hb_face_unique_ptr roboto;
+};
+
+TEST_F(GlyphClosureCacheTest, GlyphClosure) {
+  GlyphClosureCache cache(roboto.get());
+  auto closure = cache.GlyphClosure({'a'});
+  ASSERT_TRUE(closure.ok());
+  ASSERT_EQ(*closure, (GlyphSet{0, 69}));
+}
+
+TEST_F(GlyphClosureCacheTest, SegmentClosure) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'f'}, ProbabilityBound::Zero()},
+      {{'i'}, ProbabilityBound::Zero()},
+  };
+
+  SubsetDefinition init;
+  init.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
+  auto info =
+      RequestedSegmentationInformation::Create(segments, init, cache, PATCH);
+  ASSERT_TRUE(info.ok());
+
+  auto closure = cache.SegmentClosure(info->get(), {0});
+  ASSERT_TRUE(closure.ok());
+  ASSERT_EQ(*closure, (GlyphSet{0, 74 /* f */}));
+
+  closure = cache.SegmentClosure(info->get(), {1});
+  ASSERT_TRUE(closure.ok());
+  ASSERT_EQ(*closure, (GlyphSet{0, 77 /* i */}));
+
+  closure = cache.SegmentClosure(info->get(), {0, 1});
+  ASSERT_TRUE(closure.ok());
+  ASSERT_EQ(*closure, (GlyphSet{0, 74, 77, 444, 446}));
+}
+
+TEST_F(GlyphClosureCacheTest, HasAdditionalConditions) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'A'}, ProbabilityBound::Zero()},
+      {{0xC1 /* Aacute*/}, ProbabilityBound::Zero()},
+  };
+
+  // s0 or s1 -> g37 (A)
+
+  auto info =
+      RequestedSegmentationInformation::Create(segments, {}, cache, PATCH);
+  ASSERT_TRUE(info.ok());
+
+  ASSERT_TRUE(*cache.HasAdditionalConditions(info->get(), {0}, {37 /* A */}));
+  ASSERT_TRUE(*cache.HasAdditionalConditions(info->get(), {1}, {37 /* A */}));
+  ASSERT_FALSE(
+      *cache.HasAdditionalConditions(info->get(), {0, 1}, {37 /* A */}));
+
+  ASSERT_FALSE(
+      *cache.HasAdditionalConditions(info->get(), {0}, {668 /* Aacute */}));
+  ASSERT_FALSE(
+      *cache.HasAdditionalConditions(info->get(), {1}, {668 /* Aacute */}));
+}
+
+TEST_F(GlyphClosureCacheTest, HasAdditionalConditions_IncludesInitFont) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'A'}, ProbabilityBound::Zero()},
+      {{0xC1 /* Aacute*/}, ProbabilityBound::Zero()},
+  };
+
+  SubsetDefinition init;
+  init.feature_tags = {HB_TAG('c', '2', 's', 'c')};
+
+  auto info =
+      RequestedSegmentationInformation::Create(segments, init, cache, PATCH);
+  ASSERT_TRUE(info.ok());
+
+  // s0 or s1 -> g563 (smcap A)
+  EXPECT_EQ(*cache.CodepointsToOrGids(*info->get(), {0}), (GlyphSet{37, 563}));
+  EXPECT_EQ(*cache.CodepointsToOrGids(*info->get(), {1}), (GlyphSet{37, 563}));
+
+  EXPECT_TRUE(*cache.HasAdditionalConditions(info->get(), {0}, {563}));
+  EXPECT_TRUE(*cache.HasAdditionalConditions(info->get(), {1}, {563}));
+  EXPECT_FALSE(*cache.HasAdditionalConditions(info->get(), {0, 1}, {563}));
+}
+
+TEST_F(GlyphClosureCacheTest, AnalyzeSegment) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'f'}, ProbabilityBound::Zero()},
+      {{'i'}, ProbabilityBound::Zero()},
+  };
+
+  SubsetDefinition init;
+  init.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
+  auto info =
+      RequestedSegmentationInformation::Create(segments, init, cache, PATCH);
+  ASSERT_TRUE(info.ok());
+
+  GlyphSet and_gids, or_gids, exclusive_gids;
+  auto status = cache.AnalyzeSegment(*info->get(), {0}, and_gids, or_gids,
+                                     exclusive_gids);
+  ASSERT_TRUE(status.ok());
+
+  EXPECT_EQ(exclusive_gids, (GlyphSet{74 /* f */}));
+  EXPECT_EQ(or_gids, (GlyphSet{}));
+  EXPECT_EQ(and_gids, (GlyphSet{444 /* fi */, 446 /* ffi */}));
+}
+
+TEST_F(GlyphClosureCacheTest, ExpandClosure) {
+  GlyphClosureCache cache(roboto.get());
+  SubsetDefinition def;
+  def.gids = {74 /* f */, 77 /* i */};
+  def.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
+
+  SubsetDefinition expected{'f', 'i', 0xFB01 /* fi */, 0xFB03 /* ffi */};
+  expected.gids = {0, 74, 77, 444, 446};
+  expected.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
+
+  auto expanded = cache.ExpandClosure(def);
+  ASSERT_TRUE(expanded.ok());
+  ASSERT_EQ(*expanded, expected);
+}
+
+TEST_F(GlyphClosureCacheTest, CodepointsToOrGids) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'A'}, ProbabilityBound::Zero()},
+      {{0xC1 /* Aacute */}, ProbabilityBound::Zero()},
+  };
+
+  SubsetDefinition init_font;
+  auto info = RequestedSegmentationInformation::Create(segments, init_font,
+                                                       cache, PATCH);
+  ASSERT_TRUE(info.ok());
+
+  SegmentSet segs;
+  segs.insert(0);
+
+  auto or_gids = cache.CodepointsToOrGids(*info->get(), {0});
+  ASSERT_TRUE(or_gids.ok());
+  EXPECT_EQ(*or_gids, (GlyphSet{37}));
+}
+
+}  // namespace ift::encoder

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -26,6 +26,7 @@ namespace ift::encoder {
 
 void GlyphGroupings::InvalidateGlyphInformation(uint32_t gid) {
   unmapped_glyphs_.erase(gid);
+  found_condition_glyphs_.erase(gid);
 
   auto it = glyph_to_condition_.find(gid);
   if (it == glyph_to_condition_.end()) {
@@ -343,6 +344,7 @@ Status GlyphGroupings::FindFallbackGlyphConditions(
           segmentation_info, glyph_condition_set, closure_cache,
           unmapped_glyphs_, inscope));
 
+  found_condition_glyphs_.union_set(unmapped_glyphs_);
   unmapped_glyphs_.clear();
   for (const auto& [s, g] : complex_conditions) {
     if (s.empty()) {

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -79,6 +79,10 @@ class GlyphGroupings {
   // which will be placed in the fallback (always loaded) patch.
   common::GlyphSet UnmappedGlyphs() const { return unmapped_glyphs_; }
 
+  // Returns the set of glyphs that were unmapped but had conditions
+  // found for them.
+  const common::GlyphSet& FoundConditionGlyphs() const { return found_condition_glyphs_; }
+
   // Returns a list of conditions which include segment.
   const absl::btree_set<ActivationCondition>& TriggeringSegmentToConditions(
       segment_index_t segment) const {
@@ -333,6 +337,10 @@ class GlyphGroupings {
   // These glyphs aren't mapped by any conditions and as a result should be
   // included in the fallback patch.
   common::GlyphSet unmapped_glyphs_;
+
+  // These glyphs were previously considered unmapped, but have had conditions
+  // found for them.
+  common::GlyphSet found_condition_glyphs_;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/requested_segmentation_information.h
+++ b/ift/encoder/requested_segmentation_information.h
@@ -124,6 +124,22 @@ class RequestedSegmentationInformation {
     return segments;
   }
 
+  SubsetDefinition CombinedDefinition(const common::SegmentSet& segments) const {
+    // TODO(garretrieger): this approach is inefficient vs the subtraction
+    // method, add the special case path or remove use of this function in
+    // favour of incrementally produced defs.
+    SubsetDefinition def;
+    for (segment_index_t s : segments) {
+      def.Union(Segments().at(s).Definition());
+    }
+
+    // Init font subset definition must be part of the closure input
+    // since it contributes to reachability of things.
+    def.Union(InitFontSegment());
+
+    return def;
+  }
+
  private:
   std::vector<Segment> segments_;
   SubsetDefinition init_font_segment_;


### PR DESCRIPTION
Complex condition finding can produce different but equivalent found conditions for glyphs (where both are valid superset conditions), as a result the incrementally generated groupings can differ from the non-incremental ones via differences in found conditions. In the validation which ensures the incremental and non-incremental groupings are equal don't fail if they differ only by valid found conditions. Found conditions are considered valid if they meet the glyph closure requirement and do not have any additional conditions.

This also introduces some tests for GlyphClosureCache which were missing.