### PR TITLE
Rename primary cli tools to use a consistent naming scheme.

### DIFF
--- a/docs/creating_ift_fonts.md
+++ b/docs/creating_ift_fonts.md
@@ -75,10 +75,10 @@ There are two main options for generating a segmenter config:
     This option is useful when maximum control over segmentation parameters is needed, or custom frequency
     data is being supplied.
 
-2. Auto generate the segmenter config using `util:generate_segmenter_config`.
+2. Auto generate the segmenter config using `util:gen_ift_segmenter_config`.
 
    ```
-   CC=clang bazel run //util:generate_segmenter_config -- \
+   CC=clang bazel run //util:gen_ift_segmenter_config -- \
      --quality=5 \
      --input_font=$HOME/MyFont.ttf > config.txtpb
    ```
@@ -97,31 +97,30 @@ possible to write plans by hand, or develop new utilities to generate plans.
 
 In this repo two options are currently provided:
 
-1. [Recommended] `util/closure_glyph_keyed_segmenter_util`: this utility uses a subsetting closure based approach
+1. [Recommended] `util/gen_ift_segmentation_plan`: this utility uses a subsetting closure based approach
     to generate a glyph keyed segmentation plan (extension segments that augment glyph data). It can optionally
     generate the table keyed portion of the config as well. Example execution:
 
     ```sh
-    bazel run -c opt //util:closure_glyph_keyed_segmenter_util  -- \
+    bazel run -c opt //util:gen_ift_segmentation_plan  -- \
       --input_font=$(pwd)/myfont.ttf \
-      --config=path/to/config.textpb
-      --include_initial_codepoints_in_config \
-      --output_segmentation_plan > glyph_keyed.txtpb
+      --config=path/to/config.textpb > segmentation_plan.txtpb
     ```
 
-    The closure glyph segmenter is configured via an input configuration file using the
+    The gen_ift_segmentation_plan tool is configured via an input configuration file using the
     [segmenter_config.proto](util/segmenter_config.proto) schema, see the comments there for more details.
 
     Note: this utility is under active development and still very experimental. See
     [the status section](docs/experimental/closure_glyph_segmentation.md#status) for more details.
 
-2.  `util/generate_table_keyed_config`: this utility generates the table keyed (extension segments that augment non
-    glyph data in the font) portion of a plan. Example execution:
+2.  `util/gen_ift_table_keyed_plan`: this utility generates the table keyed (extension segments that augment non
+    glyph data in the font) portion of a plan. Useful when not using the optional table keyed plan generation in
+    `util/gen_ift_segmentation_plan`. Example execution:
 
     ```sh
-    bazel run -c opt util:generate_table_keyed_config -- \
+    bazel run -c opt util:gen_ift_table_keyed_plan -- \
       --font=$(pwd)/myfont.ttf \
-      latin.txt cyrillic.txt greek.txt > table_keyed.txtpb
+      latin.txt cyrillic.txt greek.txt > table_keyed_segmentation_plan.txtpb
     ```
 
 If separate glyph keyed and table keyed configs were generated using #1 and #2 they can then be combined into one

--- a/docs/experimental/closure_glyph_segmentation.md
+++ b/docs/experimental/closure_glyph_segmentation.md
@@ -37,10 +37,10 @@ segmentation which is of high importance to the production of performant overall
 segmentations.
 
 The code that implements the procedures in this document can be found in
-[closure_glyph_segmenter.cc](../ift/encoder/closure_glyph_segmenter.cc)
+[closure_glyph_segmenter.cc](../../ift/encoder/closure_glyph_segmenter.cc)
 
 There is also a command line utility to generate segmentations:
-[util/closure_glyph_keyed_segmenter_util](../util/closure_glyph_keyed_segmenter_util.cc)
+[util/gen_ift_segmentation_plan.cc](../../util/gen_ift_segmentation_plan.cc)
 
 At the end of this document you can find a couple of [examples](#examples) which illustrate how the
 procedures work in practice.
@@ -48,11 +48,11 @@ procedures work in practice.
 ## Status
 
 The current prototype implementation in
-[closure_glyph_segmenter.cc](../ift/encoder/closure_glyph_segmenter.cc) can produce segmentations
+[closure_glyph_segmenter.cc](../../ift/encoder/closure_glyph_segmenter.cc) can produce segmentations
 that satisfy the closure requirement and are performant (via merging).  The approach laid
 out in this document is just one possible approach to solving the problem. This document aims
 primarily to describe how the prototype implementation in
-[closure_glyph_segmenter.cc](../ift/encoder/closure_glyph_segmenter.cc) functions, and is not
+[closure_glyph_segmenter.cc](../../ift/encoder/closure_glyph_segmenter.cc) functions, and is not
 intended to present the final (or only) solution to the problem. There are several unsolved problems
 and remaining areas for development in this particular approach:
 
@@ -60,12 +60,12 @@ and remaining areas for development in this particular approach:
   That's discussed in the separate
   [closure_glyph_segmentation_merging.md](closure_glyph_segmentation_merging.md) document.
   See the implementation status and areas for further development sections for more specifics.
-  
+
 * Running the segmenter currently requires manual configuration to get good results. Configuration
   is needed to select appropriate frequency data and settings for parameters controlling merger
   behaviour. The goal is to get to the point where good results can be produced with zero
   configuration.
-  
+
 * Support for merging segmentations involving multiple overlapping scripts is not yet implemented
   (for example creating a segmentation that supports Chinese and Japanese simultaneously).
 
@@ -73,7 +73,7 @@ and remaining areas for development in this particular approach:
   approximates multi segment analysis by finding superset disjunctive conditions for multi segment
   conditions. See:
   [closure_glyph_segmentation_complex_conditions.md](./closure_glyph_segmentation_complex_conditions.md).
-  
+
 * Input segmentation generation: the glyph segmentation process starts with an existing
   codepoint/feature based segmentation. Good results can be achieved by starting with one input
   segment per codepoint/feature and letting merging join segments as needed. However, there is still
@@ -81,7 +81,7 @@ and remaining areas for development in this particular approach:
   together. This can significantly reduce the amount of work the merger needs to do. Therefore it
   may be useful to develop functionality that creates a first pass input segmentation based on
   codepoint frequency data.
-  
+
 * Incorporating dependency information: whatever produces the input code point segments will likely
   have discovered dependency information related to those code points. That information can be
   reused in this process to narrow selections during patch merging and multi segment
@@ -107,7 +107,7 @@ The segmentation procedure described in this document aims to achieve the follow
   values. The input unicode code point segmentations are used to form the conditions.
 
 * Optimize for minimal data transfer by avoiding duplicating glyphs across patches where possible.
-  
+
 * Support optimization of a generated segmentation via merging to reduce network overhead.
 
 * The chosen glyph segmentation and activation conditions must satisfy the closure requirement:
@@ -115,8 +115,8 @@ The segmentation procedure described in this document aims to achieve the follow
   The set of glyphs contained in patches loaded for a font subset definition (a set of Unicode
   code points and a set of layout feature tags) through the patch map tables must be a superset of
   those in the glyph closure of the font subset definition.
-    
-  
+
+
 ## Subsetter Glyph Closures
 
 Font subsetters run into a similar problem faced here and solve it with an operation called the glyph
@@ -154,13 +154,13 @@ It generates three sets of glyph ids:
 
 1. Exclusive Glyph Set: these glyphs are needed exclusively by this segment. That is they are only
    needed if and only if the $s_i$ is present.
-   
+
 2. Conjunctive Glyph Set: the presence of this input segment is a requirement for these glyphs to be
-   needed, but there may be additional segments required as well. The condition for the 
+   needed, but there may be additional segments required as well. The condition for the
    set of glyphs to be needed is: ($s_i ∧ …$).
-   
+
 3. Disjunctive Glyph Set: these glyphs are needed when the input segment is present, but the input
-   segment is not a requirement for the glyphs to be needed. The condition for the 
+   segment is not a requirement for the glyphs to be needed. The condition for the
    set of glyphs to be needed is: ($s_i ∨ …$)
 
 The process utilizes a subsetter glyph closure computation to group glyphs together based on how
@@ -211,11 +211,11 @@ which is discussed later on.
 Next, we can use the per glyph information to form the glyph groupings:
 
 1. For each unique exclusive segment, $s_i$, collect the associated set of glyphs into a group. This forms
-   an exclusive patch whose activation condition is $s_i$. 
+   an exclusive patch whose activation condition is $s_i$.
 
 2. For each unique conjunctive segment set, $C$, collect the group of glyphs that is marked with that set. This
    group forms a conditional patch whose activation condition is $\bigwedge s_j \in C$.
-   
+
 3. For each unique disjunctive segment set, $C$, collect the group of glyphs that is marked with that set. This
    group forms a conditional patch whose activation condition is $(\bigvee s_j \in C) \vee \text{additional conditions}$. As
    noted above we will need to rule out the additional conditions, the process for this follows.
@@ -223,10 +223,10 @@ Next, we can use the per glyph information to form the glyph groupings:
    Compute the Segment Closure Analysis for a new composite segment $\bigcup s_i \notin C$. Remove any glyphs from the
    group that are found in $I - D$. These glyphs may appear as a result of additional conditions and so
    need to be considered unmapped. If the group has no remaining glyphs don’t make a patch for it.
-   
+
 4. Lastly, collect the set of glyphs that are not part of any patch formed in steps 1 through 3. These form a fallback patch
    whose activation condition is $\bigvee_{1}^{n} s_j$.
-   
+
 ## Fallback Patch
 
 An output of the segmentation process above will include a fallback patch which is activated on the
@@ -292,7 +292,7 @@ needed to reduce the amount of combinations to test. Some suggestions:
 * The performance of a segmentation is likely driven solely by the high frequency code points. So
   divide the font into a high frequency set and low frequency set of code points. Where a more
   extensive multi segment dependency check is done for only the high frequency segments.
-  
+
 As an alternative a simpler approach to the problem is to limit the scope to just finding conditions which are a superset
 of the true condition. This superset condition can be used in place of the true condition without violating the closure
 requirement. This is the approach currently used in the segmenter implementation. This procedure is discussed in more

--- a/ift/config/segmenter_config.proto
+++ b/ift/config/segmenter_config.proto
@@ -24,9 +24,9 @@ enum ConditionAnalysisMode {
   CLOSURE_AND_VALIDATE_DEP_GRAPH = 2;
 }
 
-// This messages provides the configuration details for closure_glyph_keyed_segmenter_util
+// This messages provides the configuration details for util/gen_ift_segmentation_plan.cc
 //
-// The closure_glyph_keyed_segmenter_util is used to turn a series of codepoint/feature based
+// The gen_ift_segmentation_plan tool is used to turn a series of codepoint/feature based
 // segments into a set of glyph based patches and activation conditions which respect a font's
 // glyph substitution rules. This means that no matter what codepoints being rendered as long
 // as the provided activation conditions are followed all needed glyphs will always be present.

--- a/util/BUILD
+++ b/util/BUILD
@@ -32,9 +32,9 @@ cc_binary(
 )
 
 cc_binary(
-    name = "generate_table_keyed_config",
+    name = "gen_ift_table_keyed_plan",
     srcs = [
-        "generate_table_keyed_config.cc",
+        "gen_ift_table_keyed_plan.cc",
     ],
     deps = [
         "//ift/config:load_codepoints",
@@ -48,9 +48,9 @@ cc_binary(
 )
 
 cc_binary(
-    name = "closure_glyph_keyed_segmenter_util",
+    name = "gen_ift_segmentation_plan",
     srcs = [
-        "closure_glyph_keyed_segmenter_util.cc",
+        "gen_ift_segmentation_plan.cc",
     ],
     data = [
         "@ift_encoder_data//:freq_data",
@@ -102,9 +102,9 @@ cc_library(
 )
 
 cc_binary(
-    name = "generate_segmenter_config",
+    name = "gen_ift_segmenter_config",
     srcs = [
-        "generate_segmenter_config.cc",
+        "gen_ift_segmenter_config.cc",
     ],
     data = [
         "@ift_encoder_data//:freq_data",

--- a/util/fallback_analysis/count-fallback-glyphs-for-font.sh
+++ b/util/fallback_analysis/count-fallback-glyphs-for-font.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 
 FONT_NAME=$(basename $1)
-./bazel-bin/util/closure_glyph_keyed_segmenter_util \
+./bazel-bin/util/gen_ift_segmentation_plan \
     --input_font="$1" \
     --config=util/fallback_analysis/fallback_count_config.txtpb \
     --noinclude_initial_codepoints_in_config \

--- a/util/fallback_analysis/count-fallback-glyphs.sh
+++ b/util/fallback_analysis/count-fallback-glyphs.sh
@@ -13,7 +13,7 @@
 TARGET_DIR=$1
 CONCURRENCY=$2
 
-bazel build -c opt util:closure_glyph_keyed_segmenter_util
+bazel build -c opt util:gen_ift_segmentation_plan
 echo "file; num_fallback_glyphs; total_glyphs; fallback_glyphs_compressed_bytes; all_glyphs_compressed_bytes"
 find $TARGET_DIR \( -iname "*.ttf" -or -iname "*.otf" \) -print0 | xargs -0 -n 1 -P $CONCURRENCY \
   ./util/fallback_analysis/count-fallback-glyphs-for-font.sh

--- a/util/gen_ift_segmentation_plan.cc
+++ b/util/gen_ift_segmentation_plan.cc
@@ -52,15 +52,16 @@ ABSL_FLAG(
     "segmenter configuration will be automatically generated "
     "based on the input font.");
 
-ABSL_FLAG(bool, output_segmentation_plan, false,
+ABSL_FLAG(bool, output_segmentation_plan, true,
           "If set a segmentation plan representing the determined segmentation "
-          "will be output to stdout.");
+          "will be output to stdout. If not set, then a plain text summary of "
+          "the segmentation will be output to stdout instead.");
 
 ABSL_FLAG(bool, include_initial_codepoints_in_config, true,
           "If set the generated encoder config will include the initial "
           "codepoint set.");
 
-ABSL_FLAG(bool, output_segmentation_analysis, true,
+ABSL_FLAG(bool, output_segmentation_analysis, false,
           "If set an analysis of the segmentation will be output to stderr.");
 
 ABSL_FLAG(
@@ -234,8 +235,8 @@ int main(int argc, char** argv) {
   absl::SetProgramUsageMessage(
       "Generates a segmentation plan for a font.\n"
       "\n"
-      "Usage: closure_glyph_keyed_segmenter_util --input_font=\"myfont.ttf\" "
-      "[--config=\"config.txtpb\"] [--output_segmentation_plan]\n");
+      "Usage: gen_ift_segmentation_plan --input_font=\"myfont.ttf\" "
+      "[--config=\"config.txtpb\"]\n");
   absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
   absl::SetGlobalVLogLevel(absl::GetFlag(FLAGS_verbosity));
   auto args = absl::ParseCommandLine(argc, argv);

--- a/util/gen_ift_segmenter_config.cc
+++ b/util/gen_ift_segmenter_config.cc
@@ -62,7 +62,7 @@ int main(int argc, char** argv) {
   absl::SetProgramUsageMessage(
       "Generates a segmenter config to use with a font.\n"
       "\n"
-      "Usage: generate_segmenter_config --font=\"myfont.ttf\" [--quality=n] "
+      "Usage: gen_ift_segmenter_config --font=\"myfont.ttf\" [--quality=n] "
       "[--primary_script=Script_foo]\n");
   absl::SetStderrThreshold(absl::LogSeverityAtLeast::kInfo);
   absl::SetGlobalVLogLevel(absl::GetFlag(FLAGS_verbosity));

--- a/util/gen_ift_table_keyed_plan.cc
+++ b/util/gen_ift_table_keyed_plan.cc
@@ -82,7 +82,7 @@ int main(int argc, char** argv) {
   absl::SetProgramUsageMessage(
       "Generates a table keyed segmentation plan for a font.\n"
       "\n"
-      "Usage: generate_table_keyed_config --font=\"myfont.ttf\" <initial "
+      "Usage: gen_ift_table_keyed_plan --font=\"myfont.ttf\" <initial "
       "subset fil> <subset 1 file> [... <subset n file>]\n"
       "\n"
       "Where a subset file lists one codepoint per line in hexadecimal format: "
@@ -115,7 +115,7 @@ int main(int argc, char** argv) {
     sets.push_back(empty);
   } else if (args.size() <= 1) {
     std::cerr << "Usage:" << std::endl
-              << "generate_table_keyed_config <initial font subset file> "
+              << "gen_ift_table_keyed_plan <initial font subset file> "
                  "<table keyed subset 1 file> [... <table keyed subset file n>]"
               << std::endl
               << std::endl


### PR DESCRIPTION
```
closure_glyph_keyed_segmenter_util -> gen_ift_segmentation_plan
generate_segmenter_config          -> gen_ift_segmenter_config
generate_table_keyed_config        -> gen_ift_table_keyed_plan
```
Adds ift to all of the tool names, and use plan vs config correctly. Also changes some of the cli flag defaults to better reflect the typical use cases (eg. output segmentation plan by default)