### PR TITLE
Remove SegmentInteractionGroup().

### DIFF
--- a/ift/dep_graph/dependency_graph.cc
+++ b/ift/dep_graph/dependency_graph.cc
@@ -435,8 +435,8 @@ StatusOr<bool> TraversalContext::CheckPending(hb_depend_t* depend_graph) {
   auto it = pending_edges_.begin();
   while (it != pending_edges_.end()) {
     const auto& pending = *it;
-    if (TRY(ConstraintsSatisfied(pending, reached_unicodes_,
-                                 reached_glyphs_, reached_features_))) {
+    if (TRY(ConstraintsSatisfied(pending, reached_unicodes_, reached_glyphs_,
+                                 reached_features_))) {
       // Edge contstraints are now satisfied, can traverse the edge.
       TRYV(DoTraversal(pending, *this));
       pending_edges_.erase(it);

--- a/ift/dep_graph/node.h
+++ b/ift/dep_graph/node.h
@@ -74,6 +74,7 @@ class Node {
   }
 
  private:
+  Node() = delete;
   Node(uint32_t id, NodeType type) : id_(id), type_(type) {}
   uint32_t id_;
   NodeType type_;

--- a/ift/dep_graph/traversal.h
+++ b/ift/dep_graph/traversal.h
@@ -1,7 +1,6 @@
 #ifndef IFT_DEP_GRAPH_TRAVERSAL_H_
 #define IFT_DEP_GRAPH_TRAVERSAL_H_
 
-#include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "ift/common/int_set.h"
@@ -24,12 +23,6 @@ class Traversal {
 
     for (const auto& [glyph, glyphs] : other.context_per_glyph_) {
       context_per_glyph_[glyph].union_set(glyphs);
-    }
-
-    for (const auto& [glyph, features] : other.context_features_per_glyph_) {
-      for (hb_tag_t f : features) {
-        context_features_per_glyph_[glyph].insert(f);
-      }
     }
 
     for (hb_tag_t f : other.reached_feature_tags_) {
@@ -70,9 +63,6 @@ class Traversal {
     Visit(dest);
     tables_.insert(HB_TAG('G', 'S', 'U', 'B'));
     context_feature_tags_.insert(feature);
-    if (dest.IsGlyph()) {
-      context_features_per_glyph_[dest.Id()].insert(feature);
-    }
   }
 
   void VisitContextual(Node dest, hb_tag_t feature,
@@ -100,10 +90,6 @@ class Traversal {
     return reached_feature_tags_;
   }
 
-  const absl::flat_hash_set<hb_tag_t>& ContextLayoutFeatures() const {
-    return context_feature_tags_;
-  }
-
   const ift::common::GlyphSet& ReachedGlyphs() const { return reached_glyphs_; }
 
   const ift::common::CodepointSet& ReachedCodepoints() const {
@@ -116,11 +102,6 @@ class Traversal {
   const absl::flat_hash_map<encoder::glyph_id_t, ift::common::GlyphSet>&
   ContextPerGlyph() const {
     return context_per_glyph_;
-  }
-
-  const absl::flat_hash_map<encoder::glyph_id_t, absl::btree_set<hb_tag_t>>&
-  ContextFeaturesPerGlyph() const {
-    return context_features_per_glyph_;
   }
 
   // Returns true if at least one traversed edge has some sort of extra
@@ -137,9 +118,6 @@ class Traversal {
   ift::common::GlyphSet context_glyphs_;
   absl::flat_hash_map<encoder::glyph_id_t, ift::common::GlyphSet>
       context_per_glyph_;
-
-  absl::flat_hash_map<encoder::glyph_id_t, absl::btree_set<hb_tag_t>>
-      context_features_per_glyph_;
 
   absl::flat_hash_set<hb_tag_t> reached_feature_tags_;
   absl::flat_hash_set<hb_tag_t> context_feature_tags_;

--- a/ift/encoder/dependency_closure.cc
+++ b/ift/encoder/dependency_closure.cc
@@ -93,7 +93,6 @@ Status DependencyClosure::SegmentsChanged(bool init_font_change,
   // closure, we need to record the context glyphs from these as they are
   // potential interaction points.
   init_font_context_glyphs_.clear();
-  init_font_context_features_.clear();
   init_font_features_ = TRY(graph_.InitFontFeatureSet());
   Traversal init_font_traversal = TRY(graph_.ClosureTraversal(
       {Node::InitFont()}, &segmentation_info_->FullClosure(),
@@ -102,20 +101,6 @@ Status DependencyClosure::SegmentsChanged(bool init_font_change,
     if (segmentation_info_->NonInitFontGlyphs().contains(g)) {
       context_glyphs_.union_set(context);
       init_font_context_glyphs_.union_set(context);
-    }
-  }
-
-  for (const auto& [g, context_features] :
-       init_font_traversal.ContextFeaturesPerGlyph()) {
-    if (!segmentation_info_->NonInitFontGlyphs().contains(g)) {
-      continue;
-    }
-
-    for (hb_tag_t f : context_features) {
-      if (graph_.FullFeatureSet().contains(f) &&
-          !init_font_features_.contains(f)) {
-        init_font_context_features_.insert(f);
-      }
     }
   }
 
@@ -446,175 +431,121 @@ DependencyClosure::ConjunctiveConditionEdges(
 }
 
 StatusOr<SegmentSet> DependencyClosure::SegmentsThatInteractWith(
-    const GlyphSet& glyphs) {
+    const SubsetDefinition& def) const {
+  flat_hash_set<Node> nodes;
+  for (hb_codepoint_t u : def.codepoints) {
+    nodes.insert(Node::Unicode(u));
+  }
+  for (glyph_id_t g : def.gids) {
+    nodes.insert(Node::Glyph(g));
+  }
+  for (hb_tag_t f : def.feature_tags) {
+    nodes.insert(Node::Feature(f));
+  }
+  return SegmentsThatInteractWith(nodes);
+}
+
+StatusOr<SegmentSet> DependencyClosure::SegmentsThatInteractWith(
+    const GlyphSet& glyphs) const {
+  flat_hash_set<Node> nodes;
+  for (glyph_id_t gid : glyphs) {
+    nodes.insert(Node::Glyph(gid));
+  }
+  return SegmentsThatInteractWith(nodes);
+}
+
+StatusOr<SegmentSet> DependencyClosure::SegmentsThatInteractWith(
+    const absl::flat_hash_set<dep_graph::Node> nodes) const {
   // TODO(garretrieger): we can narrow the set by considering context glyphs per
   // activated glyph instead of just the whole set of context glyphs.
 
+  flat_hash_set<Node> visited;
   SegmentSet visited_segments;
   GlyphSet visited_glyphs;
-  btree_set<hb_tag_t> visited_features;
 
-  GlyphSet to_check = glyphs;
-  btree_set<hb_tag_t> features_to_check;
+  btree_set<Node> to_check;
+  to_check.insert(nodes.begin(), nodes.end());
+
+  // Expand to_check to include anything down stream of the input
+  // node set.
+  auto traversal =
+      TRY(graph_.ClosureTraversal(to_check, nullptr, nullptr, false));
+  for (glyph_id_t g : traversal.ReachedGlyphs()) {
+    to_check.insert(Node::Glyph(g));
+  }
+  for (hb_codepoint_t u : traversal.ReachedCodepoints()) {
+    to_check.insert(Node::Unicode(u));
+  }
+  for (hb_tag_t f : traversal.ReachedLayoutFeatures()) {
+    to_check.insert(Node::Feature(f));
+  }
 
   bool init_font_context_added = false;
 
-  while (!to_check.empty() || !features_to_check.empty()) {
-    if (!to_check.empty()) {
-      glyph_id_t gid = *to_check.min();
-      to_check.erase(gid);
-      visited_glyphs.insert(gid);
-
-      // gid may be reachable from the init font.
-      if (!init_font_context_added &&
-          init_font_reachable_glyphs_.contains(gid)) {
-        ReachabilityInitFontAddToCheck(visited_glyphs, visited_features,
-                                       to_check, features_to_check);
-        init_font_context_added = true;
-      }
-
-      // now check if any segments can reach it.
-      auto segments = unconstrained_reachability_.SegmentsForGlyph(gid);
-      if (segments.empty()) {
-        continue;
-      }
-
-      TRYV(ReachabilitySegmentsAddToCheck(
-          segments, visited_segments,
-          visited_glyphs, visited_features, to_check, features_to_check));
-
-    } else if (!features_to_check.empty()) {
-      hb_tag_t feature = *features_to_check.begin();
-      features_to_check.erase(feature);
-      visited_features.insert(feature);
-
-      // now check if any segments can reach it.
-      auto segments = unconstrained_reachability_.SegmentsForFeature(feature);
-      if (segments.empty()) {
-        continue;
-      }
-
-      TRYV(ReachabilitySegmentsAddToCheck(
-          segments,
-          visited_segments, visited_glyphs, visited_features, to_check,
-          features_to_check));
+  while (!to_check.empty()) {
+    Node next = *to_check.begin();
+    to_check.erase(next);
+    visited.insert(next);
+    if (next.IsGlyph()) {
+      visited_glyphs.insert(next.Id());
     }
+
+    // node may be reachable from the init font.
+    if (!init_font_context_added && next.IsGlyph() &&
+        init_font_reachable_glyphs_.contains(next.Id())) {
+      ReachabilityInitFontAddToCheck(visited_glyphs, to_check);
+      init_font_context_added = true;
+    }
+
+    // now check if any segments can reach it.
+    SegmentSet segments;
+    if (next.IsGlyph()) {
+      segments = unconstrained_reachability_.SegmentsForGlyph(next.Id());
+    } else if (next.IsUnicode()) {
+      segments = unconstrained_reachability_.SegmentsForCodepoint(next.Id());
+    } else if (next.IsFeature()) {
+      segments = unconstrained_reachability_.SegmentsForFeature(next.Id());
+    } else {
+      // ignored node type.
+      continue;
+    }
+
+    if (segments.empty()) {
+      continue;
+    }
+
+    TRYV(ReachabilitySegmentsAddToCheck(segments, visited_glyphs,
+                                        visited_segments, to_check));
   }
 
   return visited_segments;
 }
 
-StatusOr<SegmentSet> DependencyClosure::SegmentInteractionGroup(
-    const SegmentSet& segments) {
-  SegmentSet to_check = segments;
-  SegmentSet visited;
-
-  SegmentSet init_font_group = InitFontConnections();
-  if (segments.intersects(init_font_group)) {
-    to_check.union_set(init_font_group);
-  }
-
-  while (!to_check.empty()) {
-    segment_index_t next = *to_check.begin();
-    to_check.erase(next);
-    visited.insert(next);
-
-    SegmentSet connected = ConnectedSegments(next);
-    connected.subtract(visited);
-    to_check.union_set(connected);
-  }
-
-  return visited;
-}
-
-SegmentSet DependencyClosure::ConnectedSegments(segment_index_t s) {
-  // TODO(garretrieger): similar to what we do in SegmentsThatInteractWith we
-  // should keep a glyph and features visited sets (we'll need one for context
-  // and one for reachable) to avoid unnecessary checks.
-  // TODO(garretrieger): a narrower set of connections should be possible if we
-  // use context per glyph instead of the full context glyph sets.
-  SegmentSet connected;
-
-  for (glyph_id_t gid : unconstrained_reachability_.GlyphsForSegment(s)) {
-    connected.union_set(context_reachability_.SegmentsForGlyph(gid));
-    connected.union_set(unconstrained_reachability_.SegmentsForGlyph(gid));
-  }
-
-  for (glyph_id_t gid : context_reachability_.GlyphsForSegment(s)) {
-    connected.union_set(unconstrained_reachability_.SegmentsForGlyph(gid));
-  }
-
-  for (hb_tag_t tag : unconstrained_reachability_.FeaturesForSegment(s)) {
-    connected.union_set(context_reachability_.SegmentsForFeature(tag));
-    connected.union_set(unconstrained_reachability_.SegmentsForFeature(tag));
-  }
-
-  for (hb_tag_t tag : context_reachability_.FeaturesForSegment(s)) {
-    connected.union_set(unconstrained_reachability_.SegmentsForFeature(tag));
-  }
-
-  return connected;
-}
-
-SegmentSet DependencyClosure::InitFontConnections() {
-  SegmentSet connected;
-
-  for (glyph_id_t gid : init_font_reachable_glyphs_) {
-    connected.union_set(context_reachability_.SegmentsForGlyph(gid));
-    connected.union_set(unconstrained_reachability_.SegmentsForGlyph(gid));
-  }
-
-  for (glyph_id_t gid : init_font_context_glyphs_) {
-    connected.union_set(unconstrained_reachability_.SegmentsForGlyph(gid));
-  }
-
-  for (hb_tag_t tag : init_font_features_) {
-    connected.union_set(context_reachability_.SegmentsForFeature(tag));
-    connected.union_set(unconstrained_reachability_.SegmentsForFeature(tag));
-  }
-
-  for (hb_tag_t tag : init_font_context_features_) {
-    connected.union_set(unconstrained_reachability_.SegmentsForFeature(tag));
-  }
-
-  return connected;
-}
-
 void DependencyClosure::ReachabilityInitFontAddToCheck(
-    GlyphSet& visited_glyphs, btree_set<hb_tag_t>& visited_features,
-    GlyphSet& to_check, btree_set<hb_tag_t>& features_to_check) const {
+    const GlyphSet& visited_glyphs, btree_set<Node>& to_check) const {
   GlyphSet additional = init_font_context_glyphs_;
   additional.subtract(visited_glyphs);
-  to_check.union_set(additional);
-
-  for (hb_tag_t f : init_font_context_features_) {
-    if (!visited_features.contains(f)) {
-      features_to_check.insert(f);
-    }
+  for (glyph_id_t gid : additional) {
+    to_check.insert(Node::Glyph(gid));
   }
 }
 
 Status DependencyClosure::ReachabilitySegmentsAddToCheck(
-    const SegmentSet& segments, SegmentSet& visited_segments,
-    GlyphSet& visited_glyphs, btree_set<hb_tag_t>& visited_features,
-    GlyphSet& to_check, btree_set<hb_tag_t>& features_to_check) const {
+    const SegmentSet& segments, const GlyphSet& visited_glyphs,
+    SegmentSet& visited_segments, btree_set<Node>& to_check) const {
   for (segment_index_t s : segments) {
     if (visited_segments.contains(s)) {
       continue;
     }
 
     visited_segments.insert(s);
-    // TODO XXXXX can this utilize the unconstrained/context index?
-    auto traversal = TRY(graph_.ClosureTraversal({s}, false));
 
-    GlyphSet additional = traversal.ContextGlyphs();
+    GlyphSet additional = context_reachability_.GlyphsForSegment(s);
+
     additional.subtract(visited_glyphs);
-    to_check.union_set(additional);
 
-    for (hb_tag_t feature : traversal.ContextLayoutFeatures()) {
-      if (!visited_features.contains(feature)) {
-        features_to_check.insert(feature);
-      }
+    for (glyph_id_t gid : additional) {
+      to_check.insert(Node::Glyph(gid));
     }
   }
   return absl::OkStatus();
@@ -689,10 +620,6 @@ Status DependencyClosure::UpdateReachabilityIndex(segment_index_t s) {
 
   for (glyph_id_t g : traversal.ContextGlyphs()) {
     context_reachability_.AddGlyph(s, g);
-  }
-
-  for (hb_tag_t f : traversal.ContextLayoutFeatures()) {
-    context_reachability_.AddFeature(s, f);
   }
 
   return absl::OkStatus();

--- a/ift/encoder/dependency_closure.h
+++ b/ift/encoder/dependency_closure.h
@@ -11,12 +11,14 @@
 #include "ift/common/int_set.h"
 #include "ift/common/try.h"
 #include "ift/encoder/reachability_index.h"
+#include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
 
 #ifdef HB_DEPEND_API
 #include "ift/dep_graph/dependency_graph.h"
 #include "ift/dep_graph/pending_edge.h"
 #include "ift/dep_graph/traversal.h"
+#include "ift/dep_graph/node.h"
 #endif
 
 namespace ift::encoder {
@@ -90,16 +92,23 @@ class DependencyClosure {
   absl::Status SegmentsChanged(bool init_font_changed,
                                const ift::common::SegmentSet& segments);
 
-  // Finds the complete set of segments that may have some interaction on the
-  // presence of glyphs in the glyph closure.
+  // The collection of SegmentsThatInteractWith(...) methods are used to
+  // locate segments that have interactions with unicodes/features/glyphs.
+  //
+  // Interaction is defined as: given a node n, a segment interacts with
+  // n if the segment can influence the presence in the glyph
+  // closure of n or any things that depend on n (directly or indirectly).
   //
   // Utilizes the dependency graph to make the determination, so it's possible
   // that the result may be overestimated.
   absl::StatusOr<ift::common::SegmentSet> SegmentsThatInteractWith(
-      const ift::common::GlyphSet& glyphs);
-
-  absl::StatusOr<ift::common::SegmentSet> SegmentInteractionGroup(
-      const ift::common::SegmentSet& segments);
+      const common::GlyphSet& glyphs) const;
+  absl::StatusOr<ift::common::SegmentSet> SegmentsThatInteractWith(
+      const SubsetDefinition& def) const;
+#ifdef HB_DEPEND_API
+  absl::StatusOr<ift::common::SegmentSet> SegmentsThatInteractWith(
+      const absl::flat_hash_set<dep_graph::Node> nodes) const;
+#endif
 
   uint64_t AccurateResults() const { return accurate_results_; }
   uint64_t InaccurateResults() const { return inaccurate_results_; }
@@ -151,20 +160,14 @@ class DependencyClosure {
       hb_face_t* face);
 
   void ReachabilityInitFontAddToCheck(
-      ift::common::GlyphSet& visited_glyphs,
-      absl::btree_set<hb_tag_t>& visited_features,
-      ift::common::GlyphSet& to_check,
-      absl::btree_set<hb_tag_t>& features_to_check) const;
+      const common::GlyphSet& visited_glyphs,
+      absl::btree_set<dep_graph::Node>& to_check) const;
+
   absl::Status ReachabilitySegmentsAddToCheck(
       const ift::common::SegmentSet& segments,
+      const common::GlyphSet& visited_glyphs,
       ift::common::SegmentSet& visited_segments,
-      ift::common::GlyphSet& visited_glyphs,
-      absl::btree_set<hb_tag_t>& visited_features,
-      ift::common::GlyphSet& to_check,
-      absl::btree_set<hb_tag_t>& features_to_check) const;
-
-  ift::common::SegmentSet ConnectedSegments(segment_index_t s);
-  ift::common::SegmentSet InitFontConnections();
+      absl::btree_set<dep_graph::Node>& to_check) const;
 
   absl::Status UpdateReachabilityIndex(ift::common::SegmentSet segments);
   absl::Status UpdateReachabilityIndex(segment_index_t segment);
@@ -177,7 +180,6 @@ class DependencyClosure {
   ift::common::GlyphSet init_font_reachable_glyphs_;
   ift::common::GlyphSet init_font_context_glyphs_;
   absl::flat_hash_set<hb_tag_t> init_font_features_;
-  absl::flat_hash_set<hb_tag_t> init_font_context_features_;
 
   // Reachability indexes: these indexes are used to quickly locate segments
   // reachable from glyph and features (and in reverse as well).

--- a/ift/encoder/dependency_closure_disabled.cc
+++ b/ift/encoder/dependency_closure_disabled.cc
@@ -25,14 +25,14 @@ StatusOr<DependencyClosure::AnalysisAccuracy> DependencyClosure::AnalyzeSegment(
 }
 
 StatusOr<SegmentSet> DependencyClosure::SegmentsThatInteractWith(
-    const GlyphSet& glyphs) {
+    const GlyphSet& glyphs) const {
   return absl::UnimplementedError(
       "Depdency graph functionality was disabled during compilation and is "
       "unvailable");
 }
 
-StatusOr<SegmentSet> DependencyClosure::SegmentInteractionGroup(
-    const SegmentSet& segments) {
+StatusOr<SegmentSet> DependencyClosure::SegmentsThatInteractWith(
+      const SubsetDefinition& def) const {
   return absl::UnimplementedError(
       "Depdency graph functionality was disabled during compilation and is "
       "unvailable");

--- a/ift/encoder/dependency_closure_test.cc
+++ b/ift/encoder/dependency_closure_test.cc
@@ -8,6 +8,7 @@
 #include "ift/common/font_helper.h"
 #include "ift/common/int_set.h"
 #include "ift/config/common.pb.h"
+#include "ift/dep_graph/node.h"
 #include "ift/encoder/glyph_closure_cache.h"
 #include "ift/encoder/init_subset_defaults.h"
 #include "ift/encoder/requested_segmentation_information.h"
@@ -23,7 +24,9 @@ using ift::common::CodepointSet;
 using ift::common::FontData;
 using ift::common::GlyphSet;
 using ift::common::hb_face_unique_ptr;
+using ift::common::make_hb_font;
 using ift::common::SegmentSet;
+using ift::dep_graph::Node;
 using ift::freq::ProbabilityBound;
 
 namespace ift::encoder {
@@ -568,6 +571,59 @@ TEST_F(DependencyClosureTest, SegmentsChanged) {
   ASSERT_TRUE(s.ok()) << s;
 }
 
+TEST_F(DependencyClosureTest, SegmentsThatInteractWith_Nodes) {
+  SubsetDefinition aalt;
+  aalt.feature_tags.insert(HB_TAG('a', 'a', 'l', 't'));
+  SubsetDefinition jp78;
+  jp78.feature_tags.insert(HB_TAG('j', 'p', '7', '8'));
+  Reconfigure(noto_sans_jp_vf.get(), {},
+              {
+                  /* 0 */ {{0x6717}, ProbabilityBound::Zero()},
+                  /* 1 */ {{0x7891}, ProbabilityBound::Zero()},
+                  /* 2 */ {{0x798f}, ProbabilityBound::Zero()},
+                  /* 3 */ {{0x6406}, ProbabilityBound::Zero()},
+                  /* 4 */ {{0xe0100}, ProbabilityBound::Zero()},
+                  /* 5 */ {{0xfe00}, ProbabilityBound::Zero()},
+                  /* 6 */ {aalt, ProbabilityBound::Zero()},
+                  /* 7 */ {jp78, ProbabilityBound::Zero()},
+              });
+
+  auto s =
+      dependency_closure->SegmentsThatInteractWith({Node::Unicode(0x6717)});
+  ASSERT_TRUE(s.ok()) << s.status();
+  ASSERT_EQ(*s, (SegmentSet{0, 4, 5}));
+
+  s = dependency_closure->SegmentsThatInteractWith(
+      {Node::Glyph(6 /* U+6717 UVS alt */)});
+  ASSERT_TRUE(s.ok()) << s.status();
+  ASSERT_EQ(*s, (SegmentSet{0, 4, 5}));
+
+  s = dependency_closure->SegmentsThatInteractWith(
+      {Node::Unicode(0x798f), Node::Feature(HB_TAG('j', 'p', '7', '8'))});
+  ASSERT_TRUE(s.ok()) << s.status();
+  ASSERT_EQ(*s, (SegmentSet{2, 5, 7}));
+}
+
+TEST_F(DependencyClosureTest, SegmentsThatInteractWith_SubsetDef) {
+  SubsetDefinition aalt;
+  aalt.feature_tags.insert(HB_TAG('a', 'a', 'l', 't'));
+
+  Reconfigure(noto_sans_jp_vf.get(), {},
+              {
+                  /* 0 */ {{0x6406}, ProbabilityBound::Zero()},
+                  /* 1 */ {{0x640f}, ProbabilityBound::Zero()},
+                  /* 2 */ {aalt, ProbabilityBound::Zero()},
+              });
+
+  SubsetDefinition query_def;
+  query_def.codepoints = {0x6406};
+  query_def.feature_tags = {HB_TAG('a', 'a', 'l', 't')};
+
+  auto s = dependency_closure->SegmentsThatInteractWith(query_def);
+  ASSERT_TRUE(s.ok()) << s.status();
+  ASSERT_EQ(*s, (SegmentSet{0, 2}));
+}
+
 TEST_F(DependencyClosureTest, SegmentsThatInteractWith) {
   Reconfigure(WithDefaultFeatures(), {
                                          {{'a'}, ProbabilityBound::Zero()},
@@ -576,23 +632,23 @@ TEST_F(DependencyClosureTest, SegmentsThatInteractWith) {
                                          {{'i'}, ProbabilityBound::Zero()},
                                      });
 
-  auto s = dependency_closure->SegmentsThatInteractWith({69 /* a */});
+  auto s = dependency_closure->SegmentsThatInteractWith(GlyphSet{69 /* a */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{0}));
 
-  s = dependency_closure->SegmentsThatInteractWith({70 /* b */});
+  s = dependency_closure->SegmentsThatInteractWith(GlyphSet{70 /* b */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{1}));
 
-  s = dependency_closure->SegmentsThatInteractWith({69, 70});
+  s = dependency_closure->SegmentsThatInteractWith(GlyphSet{69, 70});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{0, 1}));
 
-  s = dependency_closure->SegmentsThatInteractWith({74 /* f */});
+  s = dependency_closure->SegmentsThatInteractWith(GlyphSet{74 /* f */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{2}));
 
-  s = dependency_closure->SegmentsThatInteractWith({444});
+  s = dependency_closure->SegmentsThatInteractWith(GlyphSet{444});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{2, 3}));
 }
@@ -609,7 +665,8 @@ TEST_F(DependencyClosureTest, SegmentsThatInteractWith_Context) {
   ASSERT_EQ(segmentation_info->FullClosure(),
             (GlyphSet{0, 77, 85, 92, 141, 168, 609}));
 
-  auto s = dependency_closure->SegmentsThatInteractWith({609 /* dotlessi */});
+  auto s = dependency_closure->SegmentsThatInteractWith(
+      GlyphSet{609 /* dotlessi */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{2, 3}));
 }
@@ -628,7 +685,8 @@ TEST_F(DependencyClosureTest, SegmentsThatInteractWith_FeaturesInContext) {
   ASSERT_EQ(segmentation_info->FullClosure(),
             (GlyphSet{0, 77, 85, 92, 141, 168, 609}));
 
-  auto s = dependency_closure->SegmentsThatInteractWith({609 /* dotlessi */});
+  auto s = dependency_closure->SegmentsThatInteractWith(
+      GlyphSet{609 /* dotlessi */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{2, 3, 4}));
 }
@@ -644,7 +702,8 @@ TEST_F(DependencyClosureTest, SegmentsThatInteractWith_InitFontContext) {
   ASSERT_EQ(segmentation_info->FullClosure(),
             (GlyphSet{0, 77, 85, 92, 141, 168, 609}));
 
-  auto s = dependency_closure->SegmentsThatInteractWith({609 /* dotlessi */});
+  auto s = dependency_closure->SegmentsThatInteractWith(
+      GlyphSet{609 /* dotlessi */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{2}));
 }
@@ -663,91 +722,38 @@ TEST_F(DependencyClosureTest,
   ASSERT_EQ(segmentation_info->FullClosure(),
             (GlyphSet{0, 77, 85, 92, 141, 168, 609}));
 
-  auto s = dependency_closure->SegmentsThatInteractWith({609 /* dotlessi */});
+  auto s = dependency_closure->SegmentsThatInteractWith(
+      GlyphSet{609 /* dotlessi */});
   ASSERT_TRUE(s.ok()) << s.status();
   ASSERT_EQ(*s, (SegmentSet{2, 3}));
 }
 
-TEST_F(DependencyClosureTest, SegmentInteractionGroup) {
-  SubsetDefinition ccmp;
-  ccmp.feature_tags = {HB_TAG('c', 'c', 'm', 'p')};
-  SubsetDefinition liga;
-  liga.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
-  Reconfigure(liga,
-              {
-                  /* 0 */ {{'f'}, ProbabilityBound::Zero()},
-                  /* 1 */ {{'x'}, ProbabilityBound::Zero()},
-                  /* 2 */ {{'q'}, ProbabilityBound::Zero()},
-                  /* 3 */ {{'i'}, ProbabilityBound::Zero()},
-                  /* 4 */ {{0x300 /* gravecomb */}, ProbabilityBound::Zero()},
-                  /* 5 */ {{ccmp}, ProbabilityBound::Zero()},
-              });
-
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({1}), (SegmentSet{1}));
-
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({1, 2}),
-            (SegmentSet{1, 2}));
-
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({0}),
-            (SegmentSet{0, 3, 4, 5}));
-
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({3, 5}),
-            (SegmentSet{0, 3, 4, 5}));
-
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({1, 3, 5}),
-            (SegmentSet{0, 1, 3, 4, 5}));
-}
-
-TEST_F(DependencyClosureTest, SegmentInteractionGroup_WithInitFont) {
-  SubsetDefinition ccmp;
-  ccmp.feature_tags = {HB_TAG('c', 'c', 'm', 'p')};
-  SubsetDefinition liga{'i'};
-  liga.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
-  Reconfigure(liga,
-              {
-                  /* 0 */ {{'f'}, ProbabilityBound::Zero()},
-                  /* 1 */ {{'x'}, ProbabilityBound::Zero()},
-                  /* 2 */ {{'q'}, ProbabilityBound::Zero()},
-                  /* 3 */ {{0x300 /* gravecomb */}, ProbabilityBound::Zero()},
-                  /* 4 */ {{ccmp}, ProbabilityBound::Zero()},
-              });
-
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({1}), (SegmentSet{1}));
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({0}),
-            (SegmentSet{0, 3, 4}));
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({3}),
-            (SegmentSet{0, 3, 4}));
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({4}),
-            (SegmentSet{0, 3, 4}));
-}
-
-TEST_F(DependencyClosureTest, DISABLED_SegmentInteractionGroup_LayoutFeatures) {
-  // TODO(garretrieger): Currently failing, will need to be fixed.
+TEST_F(DependencyClosureTest, SegmentsThatInteractWith_LayoutFeatures) {
   SubsetDefinition aalt;
   aalt.feature_tags.insert(HB_TAG('a', 'a', 'l', 't'));
   SubsetDefinition jp78;
   jp78.feature_tags.insert(HB_TAG('j', 'p', '7', '8'));
-  Reconfigure(noto_sans_jp_vf.get(), {}, {
-    /* 0 */ {{0x6406}, ProbabilityBound::Zero()},
-    /* 1 */ {{0x640f}, ProbabilityBound::Zero()},
-    /* 2 */ {aalt, ProbabilityBound::Zero()},
-    /* 3 */ {jp78, ProbabilityBound::Zero()},
-  });
+  Reconfigure(noto_sans_jp_vf.get(), {},
+              {
+                  /* 0 */ {{0x6406}, ProbabilityBound::Zero()},
+                  /* 1 */ {{0x640f}, ProbabilityBound::Zero()},
+                  /* 2 */ {aalt, ProbabilityBound::Zero()},
+                  /* 3 */ {jp78, ProbabilityBound::Zero()},
+              });
 
-  auto s = dependency_closure->SegmentsThatInteractWith({1 /* U+6406 */});
+  auto s =
+      dependency_closure->SegmentsThatInteractWith(GlyphSet{1 /* U+6406 */});
   ASSERT_TRUE(s.ok()) << s.status();
-  ASSERT_EQ(*s, (SegmentSet{0, 2, 3}));
+  // g1 is only mapped from cmap, so only segment s0 interacts with it.
+  ASSERT_EQ(*s, (SegmentSet{0}));
 
-  s = dependency_closure->SegmentsThatInteractWith({9 /* single sub of U+6406 */});
+  s = dependency_closure->SegmentsThatInteractWith(
+      GlyphSet{9 /* single sub of U+6406 */});
   ASSERT_TRUE(s.ok()) << s.status();
+  // The key result here is that for s1 isn't considered to be in the
+  // interaction group despite both interacting with s2 and s3 (likewise for
+  // s0).
   ASSERT_EQ(*s, (SegmentSet{0, 2, 3}));
-
-  // The key result here is that for s0, s1 isn't considered to be in the interaction
-  // group despite both interacting with s2 and s3 (likewise for s0).
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({0}), (SegmentSet{0, 2, 3}));
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({1}), (SegmentSet{1, 2, 3}));
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({2}), (SegmentSet{0, 1, 2, 3}));
-  ASSERT_EQ(*dependency_closure->SegmentInteractionGroup({3}), (SegmentSet{0, 1, 2, 3}));
 }
 
 TEST_F(DependencyClosureTest, InitFontFeatureConjunction) {

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -9,6 +9,7 @@
 #include "ift/encoder/glyph_condition_set.h"
 #include "ift/encoder/glyph_segmentation.h"
 #include "ift/encoder/init_subset_defaults.h"
+#include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
 
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
@@ -112,9 +113,14 @@ Status SegmentationContext::ReassignInitSubset(SubsetDefinition new_def) {
   SegmentSet segments_with_changed_defs;
   uint32_t s_index = 0;
   for (auto& s : segmentation_info_->Segments()) {
-    // TODO XXXXX this also needs to handle features?
     if (s.Definition().codepoints.intersects(new_def.codepoints)) {
       segments_with_changed_defs.insert(s_index);
+    }
+    for (hb_tag_t f : s.Definition().feature_tags) {
+      if (new_def.feature_tags.contains(f)) {
+        segments_with_changed_defs.insert(s_index);
+        break;
+      }
     }
     s_index++;
   }
@@ -125,11 +131,12 @@ Status SegmentationContext::ReassignInitSubset(SubsetDefinition new_def) {
         0, segmentation_info_->Segments().size() - 1);
   }
   if (dependency_closure_.has_value()) {
+    SubsetDefinition new_def_delta = new_def;
+    new_def_delta.Subtract(SegmentationInfo().InitFontSegment());
     // If dep graph is enabled we can use it to narrow the set of segments that
     // need reprocessing.
     segments_to_reprocess =
-        TRY((*dependency_closure_)
-                ->SegmentInteractionGroup(segments_with_changed_defs));
+        TRY((*dependency_closure_)->SegmentsThatInteractWith(new_def_delta));
   }
 
   TRYV(segmentation_info_->ReassignInitSubset(*glyph_closure_cache, new_def));


### PR DESCRIPTION
What an interaction group is was poorly defined, SegmentsThatInteractWith() can be utilized instead which has a much more clear definition.

SegmentsThatInteractWith() is extended to work with nodes instead of just glyphs, this allows SegmentationContext to replace it's usage of SegmentInteractionGroup().

Lastly, this also cleans up special casing around features which is no longer needed now that feature conjunction has edges present on both sides in the graph.