### PR TITLE
Implement general activation condition combination.

### DIFF
--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -1,5 +1,7 @@
 #include "ift/encoder/activation_condition.h"
 
+#include <algorithm>
+
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
 #include "absl/status/status.h"
@@ -69,6 +71,75 @@ ActivationCondition ActivationCondition::composite_condition(
   }
 
   return conditions;
+}
+
+static void Simplify(std::vector<SegmentSet>& conditions) {
+  if (conditions.size() <= 1) return;
+
+  // Conditions can be simplified by removing duplicate and/or subset sub-conditions.
+  // For example if one sub-condition is a subset of another ((s1) AND (s1 or s2)),
+  // then the larger sub-condition (s1 or s2) is not necessary and can be dropped.
+
+  // Sort by size to ensure that if A is a subset of B, then A comes before B.
+  std::sort(conditions.begin(), conditions.end(),
+            [](const SegmentSet& a, const SegmentSet& b) {
+              return a.size() < b.size();
+            });
+
+  std::vector<uint8_t> redundant(conditions.size(), 0);
+  for (size_t i = 0; i < conditions.size(); ++i) {
+    if (redundant[i]) continue;
+    for (size_t j = i + 1; j < conditions.size(); ++j) {
+      if (redundant[j]) continue;
+      if (conditions[i].is_subset_of(conditions[j])) {
+        redundant[j] = 1;
+      }
+    }
+  }
+
+  size_t write_index = 0;
+  for (size_t i = 0; i < conditions.size(); ++i) {
+    if (redundant[i]) {
+      continue;
+    }
+    if (write_index != i) {
+      conditions[write_index] = std::move(conditions[i]);
+    }
+    write_index++;
+  }
+  conditions.erase(conditions.begin() + write_index, conditions.end());
+
+  // Final sort to normalize the order of conditions.
+  std::sort(conditions.begin(), conditions.end());
+}
+
+ActivationCondition ActivationCondition::And(const ActivationCondition& a,
+                                             const ActivationCondition& b) {
+  ActivationCondition condition = a;
+  condition.conditions_.insert(condition.conditions_.end(),
+                               b.conditions().begin(), b.conditions().end());
+  Simplify(condition.conditions_);
+  condition.is_exclusive_ = false;
+  return condition;
+}
+
+ActivationCondition ActivationCondition::Or(const ActivationCondition& a,
+                                            const ActivationCondition& b) {
+  ActivationCondition condition = a;
+  condition.conditions_.clear();
+  condition.conditions_.reserve(a.conditions().size() * b.conditions().size());
+
+  for (const auto& a_group : a.conditions()) {
+    for (const auto& b_group : b.conditions()) {
+      SegmentSet combined_group = a_group;
+      combined_group.union_set(b_group);
+      condition.conditions_.push_back(std::move(combined_group));
+    }
+  }
+
+  Simplify(condition.conditions_);
+  condition.is_exclusive_ = false;
+  return condition;
 }
 
 std::string ActivationCondition::ToString() const {

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -51,6 +51,20 @@ class ActivationCondition {
   static ActivationCondition composite_condition(
       absl::Span<const ift::common::SegmentSet> groups, patch_id_t activated);
 
+  // Returns a new activation condition that activates on (a && b)
+  //
+  // The new condition uses the values for the other fields
+  // from condition a (eg. activated, encoding).
+  static ActivationCondition And(const ActivationCondition& a,
+                                 const ActivationCondition& b);
+
+  // Returns a new activation condition that activates on (a || b)
+  //
+  // The new condition uses the values for the other fields
+  // from condition a (eg. activated, encoding).
+  static ActivationCondition Or(const ActivationCondition& a,
+                                const ActivationCondition& b);
+
   /*
    * Converts a list of activation conditions into a list of condition entries
    * which are used by the encoder to specify conditions.

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -373,4 +373,62 @@ TEST(ActivationConditionTest, MergedProbability) {
           .status()));
 }
 
+TEST(ActivationConditionTest, And) {
+  auto a = ActivationCondition::or_segments({1, 2}, 10);
+  auto b = ActivationCondition::or_segments({3}, 11);
+
+  auto combined_ab = ActivationCondition::And(a, b);
+  EXPECT_EQ(combined_ab.ToString(), "if ((s1 OR s2) AND s3) then p10");
+  EXPECT_EQ(combined_ab.activated(), 10);
+  EXPECT_FALSE(combined_ab.IsExclusive());
+  EXPECT_FALSE(combined_ab.IsFallback());
+
+  auto combined_ba = ActivationCondition::And(b, a);
+  EXPECT_EQ(combined_ab.conditions(), combined_ba.conditions());
+  EXPECT_EQ(combined_ba.activated(), 11);
+}
+
+TEST(ActivationConditionTest, And_Simplification) {
+  auto a = ActivationCondition::or_segments({1, 2}, 10);
+  auto b = ActivationCondition::or_segments({1}, 10);
+
+  auto combined_ab = ActivationCondition::And(a, b);
+  EXPECT_EQ(combined_ab.ToString(), "if (s1) then p10");
+
+  // common elements but not subsets, no simplification
+  auto c = ActivationCondition::or_segments({1, 2}, 10);
+  auto d = ActivationCondition::or_segments({1, 3}, 10);
+  auto combined_cd = ActivationCondition::And(c, d);
+  EXPECT_EQ(combined_cd.ToString(), "if ((s1 OR s2) AND (s1 OR s3)) then p10");
+}
+
+TEST(ActivationConditionTest, Or) {
+  auto a = ActivationCondition::and_segments({1, 2}, 10);
+  auto b = ActivationCondition::and_segments({3, 4}, 11);
+
+  auto combined_ab = ActivationCondition::Or(a, b);
+  EXPECT_EQ(combined_ab.ToString(),
+            "if ((s1 OR s3) AND (s1 OR s4) AND (s2 OR s3) AND (s2 OR s4)) "
+            "then p10");
+  EXPECT_EQ(combined_ab.activated(), 10);
+  EXPECT_FALSE(combined_ab.IsExclusive());
+  EXPECT_FALSE(combined_ab.IsFallback());
+
+  auto combined_ba = ActivationCondition::Or(b, a);
+  EXPECT_EQ(combined_ba.activated(), 11);
+  EXPECT_EQ(combined_ab.conditions(), combined_ba.conditions());
+}
+
+TEST(ActivationConditionTest, Or_Simplification) {
+  auto a = ActivationCondition::and_segments({1, 2}, 10);
+  auto b = ActivationCondition::and_segments({2, 3}, 10);
+
+  auto combined_ab = ActivationCondition::Or(a, b);
+  EXPECT_EQ(combined_ab.ToString(), "if ((s1 OR s3) AND s2) then p10");
+  EXPECT_EQ(combined_ab.activated(), 10);
+
+  auto combined_ba = ActivationCondition::Or(b, a);
+  EXPECT_EQ(combined_ab.conditions(), combined_ba.conditions());
+}
+
 }  // namespace ift::encoder


### PR DESCRIPTION
Adds the ability to combine two arbitrary activation conditions via AND, or OR to produce a new activation condition which is also in CNF (Conjunctive Normal Form). Not currently used, but will be useful for some upcoming changes.