### PR TITLE
Switch topological sort to SCC in condition extraction.

### DIFF
--- a/ift/dep_graph/dependency_graph.cc
+++ b/ift/dep_graph/dependency_graph.cc
@@ -39,9 +39,9 @@ using ift::encoder::SubsetDefinition;
 
 namespace ift::dep_graph {
 
-StatusOr<GlyphSet> GetContextSet(
-    hb_depend_t* depend, const ift::common::GlyphSet* full_closure,
-    hb_codepoint_t context_set_id) {
+StatusOr<GlyphSet> GetContextSet(hb_depend_t* depend,
+                                 const ift::common::GlyphSet* full_closure,
+                                 hb_codepoint_t context_set_id) {
   // the context set is actually a set of sets.
   hb_set_unique_ptr context_sets = make_hb_set();
   if (!hb_depend_get_set_from_index(depend, context_set_id,
@@ -82,7 +82,9 @@ class TraversalContext {
   hb_depend_t* depend = nullptr;
 
   // Only edges from these tables will be followed.
-  flat_hash_set<hb_tag_t> table_filter = {FontHelper::kCmap, FontHelper::kGlyf, FontHelper::kGSUB, FontHelper::kCOLR, FontHelper::kMATH, FontHelper::kCFF};
+  flat_hash_set<hb_tag_t> table_filter = {FontHelper::kCmap, FontHelper::kGlyf,
+                                          FontHelper::kGSUB, FontHelper::kCOLR,
+                                          FontHelper::kMATH, FontHelper::kCFF};
 
   // Only edges that originate from and end at glyphs from this filter will be
   // followed.
@@ -449,7 +451,8 @@ static Status DoTraversal(const PendingEdge& edge,
                           TraversalContext<CallbackT>& context) {
   context.callback.VisitPending(edge);
 
-  if (edge.table_tag == FontHelper::kGSUB && edge.required_feature.has_value()) {
+  if (edge.table_tag == FontHelper::kGSUB &&
+      edge.required_feature.has_value()) {
     if (edge.required_context_set_index.has_value()) {
       GlyphSet context_glyphs =
           TRY(GetContextSet(context.depend, context.full_closure,
@@ -524,17 +527,17 @@ absl::Status DependencyGraph::HandleOutgoingEdges(
   return absl::OkStatus();
 }
 
-StatusOr<std::vector<Node>> DependencyGraph::TopologicalSorting(
-  const flat_hash_set<hb_tag_t>& table_filter,
-  uint32_t node_type_filter
-) const {
-  struct TopoCallback {
+StatusOr<std::vector<std::vector<Node>>>
+DependencyGraph::StronglyConnectedComponents(
+    const flat_hash_set<hb_tag_t>& table_filter,
+    uint32_t node_type_filter) const {
+  struct Callback {
     std::vector<Node> edges;
-    void Visit(Node dest) {}
-    void Visit(Node dest, hb_tag_t) {}
-    void VisitGsub(Node dest, hb_tag_t) {}
-    void VisitContextual(Node dest, hb_tag_t, ift::common::GlyphSet) {}
-    void VisitPending(const PendingEdge& edge) { edges.push_back(edge.dest); }
+    void Visit(Node) {}
+    void Visit(Node, hb_tag_t) {}
+    void VisitGsub(Node, hb_tag_t) {}
+    void VisitContextual(Node, hb_tag_t, GlyphSet) {}
+    void VisitPending(const PendingEdge& pe) { edges.push_back(pe.dest); }
   };
 
   CodepointSet non_init_font_codepoints =
@@ -549,7 +552,7 @@ StatusOr<std::vector<Node>> DependencyGraph::TopologicalSorting(
 
   GlyphSet non_init_font_glyphs = segmentation_info_->NonInitFontGlyphs();
 
-  TraversalContext<TopoCallback> context;
+  TraversalContext<Callback> context;
   context.depend = dependency_graph_.get();
   context.full_closure = &segmentation_info_->FullClosure();
   context.enforce_context = false;
@@ -559,73 +562,124 @@ StatusOr<std::vector<Node>> DependencyGraph::TopologicalSorting(
   context.table_filter = table_filter;
   context.node_type_filter = node_type_filter;
 
-  // DFS topological sorting algorithm from:
-  // https://en.wikipedia.org/wiki/Topological_sorting
-  // Modified to use a stack instead of recursion.
-  flat_hash_set<Node> visited;
-  flat_hash_set<Node> visiting;
-  std::vector<Node> post_order;
-  std::vector<Node> dfs_stack;
-  auto process_node = [&](Node start_node) -> Status {
-    dfs_stack.push_back(start_node);
+  // Implementation based on
+  // https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm
+  // Modified to use stack instead of recursion.
+  struct Meta {
+    int64_t index = -1;
+    int64_t lowlink = -1;
+    bool on_stack = false;
+  };
+
+  flat_hash_map<Node, Meta> node_meta;
+  std::vector<Node> stack;
+
+  int64_t index = 0;
+  std::vector<std::vector<Node>> sccs;
+
+  struct DfsState {
+    Node node;
+    std::vector<Node> edges;
+  };
+
+  auto strongconnect = [&](Node start_node) -> Status {
+    std::vector<DfsState> dfs_stack = {{start_node, {}}};
+
     while (!dfs_stack.empty()) {
-      Node node = dfs_stack.back();
-      if (visited.contains(node)) {
-        dfs_stack.pop_back();
-        continue;
-      }
-      if (visiting.contains(node)) {
-        visiting.erase(node);
-        visited.insert(node);
-        post_order.push_back(node);
-        dfs_stack.pop_back();
-        continue;
+      Node v = dfs_stack.back().node;
+
+      std::vector<Node>& edges = dfs_stack.back().edges;
+      {
+        // Scope v_meta to where it's still valid
+        auto& v_meta = node_meta[v];
+        if (v_meta.index == -1) {
+          // first time time visiting this node, set up initial state.
+          v_meta.index = v_meta.lowlink = index++;
+          stack.push_back(v);
+          v_meta.on_stack = true;
+          context.callback.edges.clear();
+          TRYV(HandleOutgoingEdges(v, &context));
+          edges = std::move(context.callback.edges);
+        }
       }
 
-      visiting.insert(node);
-      context.callback.edges.clear();
-      TRYV(HandleOutgoingEdges(node, &context));
+      bool recursing = false;
+      while (!edges.empty()) {
+        Node w = edges.back();
+        edges.pop_back();
 
-      std::vector<Node> current_edges = std::move(context.callback.edges);
-      for (Node dest : current_edges) {
-        if (visiting.contains(dest)) {
-          return absl::InvalidArgumentError(
-              absl::StrCat("Cycle detected during topological sort in "
-                           "dependency graph involving node: ",
-                           dest.ToString()));
+        auto& w_meta = node_meta[w];
+        if (w_meta.index == -1) {
+          // recurse strongconnect()
+          dfs_stack.push_back({w, {}});
+          recursing = true;
+          break;
+        } else if (w_meta.on_stack) {
+          // Successor w is in stack and hence in the current SCC
+          auto& v_meta = node_meta[v];
+          v_meta.lowlink = std::min(v_meta.lowlink, w_meta.index);
         }
-        if (!visited.contains(dest)) {
-          dfs_stack.push_back(dest);
+      }
+
+      if (recursing) continue;
+
+      const auto& v_meta = node_meta.at(v);
+      // If v is a root node, pop the stack and generate an SCC
+      if (v_meta.lowlink == v_meta.index) {
+        std::vector<Node> scc;
+        while (true) {
+          Node node = stack.back();
+          stack.pop_back();
+          node_meta.at(node).on_stack = false;
+          scc.push_back(node);
+          if (node == v) break;
         }
+        sccs.push_back(std::move(scc));
+      }
+
+      dfs_stack.pop_back();
+      if (!dfs_stack.empty()) {
+        Node parent = dfs_stack.back().node;
+        auto& parent_meta = node_meta.at(parent);
+        parent_meta.lowlink = std::min(parent_meta.lowlink, v_meta.lowlink);
       }
     }
     return absl::OkStatus();
   };
 
-  /* ### Run process_node for every possible, non init font node. #### */
+  /* ### Run strongconnect for every possible, non init font node. #### */
   for (segment_index_t s : segmentation_info_->NonEmptySegments()) {
-    TRYV(process_node(Node::Segment(s)));
+    Node n = Node::Segment(s);
+    if (!node_meta.contains(n)) {
+      TRYV(strongconnect(n));
+    }
   }
 
   for (hb_codepoint_t u : non_init_font_codepoints) {
-    TRYV(process_node(Node::Unicode(u)));
+    Node n = Node::Unicode(u);
+    if (!node_meta.contains(n)) {
+      TRYV(strongconnect(n));
+    }
   }
 
   for (hb_tag_t tag : non_init_font_features) {
-    TRYV(process_node(Node::Feature(tag)));
+    Node n = Node::Feature(tag);
+    if (!node_meta.contains(n)) {
+      TRYV(strongconnect(n));
+    }
   }
 
   for (glyph_id_t gid : non_init_font_glyphs) {
-    TRYV(process_node(Node::Glyph(gid)));
+    Node n = Node::Glyph(gid);
+    if (!node_meta.contains(n)) {
+      TRYV(strongconnect(n));
+    }
   }
 
-  std::vector<Node> topo_order;
-  topo_order.reserve(post_order.size());
-  for (auto it = post_order.rbegin(); it != post_order.rend(); ++it) {
-    topo_order.push_back(*it);
-  }
-
-  return topo_order;
+  // Tarjan's returns SCCs in reverse topological order, reverse to get
+  // topological order.
+  std::reverse(sccs.begin(), sccs.end());
+  return sccs;
 }
 
 StatusOr<Traversal> DependencyGraph::TraverseGraph(
@@ -730,7 +784,8 @@ StatusOr<Traversal> DependencyGraph::ClosureTraversal(
   }
 
   /* ### Remaining Phases ### */
-  for (unsigned phase = 1; phase < DependencyGraph::kNumberOfClosurePhases; phase++) {
+  for (unsigned phase = 1; phase < DependencyGraph::kNumberOfClosurePhases;
+       phase++) {
     if (table_tags.contains(DependencyGraph::kClosurePhaseTable[phase])) {
       TRYV(ClosureSubTraversal(&base_context, phase, traversal_full));
     }
@@ -744,13 +799,15 @@ Status DependencyGraph::ClosureSubTraversal(
     Traversal& traversal_full) const {
   btree_set<Node> start_nodes;
 
-  if (DependencyGraph::kClosurePhaseStartNodes[phase_index] & Node::NodeType::GLYPH) {
+  if (DependencyGraph::kClosurePhaseStartNodes[phase_index] &
+      Node::NodeType::GLYPH) {
     for (glyph_id_t gid : traversal_full.ReachedGlyphs()) {
       start_nodes.insert(Node::Glyph(gid));
     }
   }
 
-  if (DependencyGraph::kClosurePhaseStartNodes[phase_index] & Node::NodeType::FEATURE) {
+  if (DependencyGraph::kClosurePhaseStartNodes[phase_index] &
+      Node::NodeType::FEATURE) {
     for (hb_tag_t feature : traversal_full.ReachedLayoutFeatures()) {
       start_nodes.insert(Node::Feature(feature));
     }
@@ -760,7 +817,8 @@ Status DependencyGraph::ClosureSubTraversal(
   context.SetReached(start_nodes);
   context.callback.SetStartNodes(start_nodes);
   context.table_filter = {DependencyGraph::kClosurePhaseTable[phase_index]};
-  context.node_type_filter = DependencyGraph::kClosurePhaseNodeFilter[phase_index];
+  context.node_type_filter =
+      DependencyGraph::kClosurePhaseNodeFilter[phase_index];
   traversal_full.Merge(TRY(TraverseGraph(&context)));
   return absl::OkStatus();
 }
@@ -1142,7 +1200,8 @@ DependencyGraph::ComputeFeatureEdges() const {
     while (hb_depend_get_glyph_entry(
         dependency_graph_.get(), gid, index++, &table_tag, &dest_gid,
         &layout_tag, &ligature_set, &context_set, nullptr /* flags */)) {
-      if (table_tag != FontHelper::kGSUB || layout_tag == HB_CODEPOINT_INVALID) {
+      if (table_tag != FontHelper::kGSUB ||
+          layout_tag == HB_CODEPOINT_INVALID) {
         continue;
       }
 
@@ -1179,7 +1238,7 @@ DependencyGraph::CollectIncomingEdges(
     void Visit(Node dest) {}
     void Visit(Node dest, hb_tag_t) {}
     void VisitGsub(Node, hb_tag_t) {}
-    void VisitContextual(Node, hb_tag_t, ift::common::GlyphSet) {}
+    void VisitContextual(Node, hb_tag_t, GlyphSet) {}
     void VisitPending(const PendingEdge& pe) {
       auto reqs = graph->ExtractRequirements(pe);
       had_error.Update(reqs.status());

--- a/ift/dep_graph/dependency_graph.h
+++ b/ift/dep_graph/dependency_graph.h
@@ -44,32 +44,29 @@ class DependencyGraph {
   // _populate_gids_to_retain() from
   // https://github.com/harfbuzz/harfbuzz/blob/main/src/hb-subset-plan.cc#L439
   static constexpr hb_tag_t kClosurePhaseTable[] = {
-    common::FontHelper::kCmap,
-    common::FontHelper::kGSUB,
-    common::FontHelper::kMATH,
-    common::FontHelper::kCOLR,
-    common::FontHelper::kGlyf,
-    common::FontHelper::kCFF,
+      common::FontHelper::kCmap, common::FontHelper::kGSUB,
+      common::FontHelper::kMATH, common::FontHelper::kCOLR,
+      common::FontHelper::kGlyf, common::FontHelper::kCFF,
   };
 
   static constexpr hb_tag_t kClosurePhaseNodeFilter[] = {
-    /* cmap */ 0xFFFFFFFF,
-    /* GSUB */ Node::NodeType::GLYPH,
-    /* MATH */ Node::NodeType::GLYPH,
-    /* COLR */ Node::NodeType::GLYPH,
-    /* glyf */ Node::NodeType::GLYPH,
-    /* CFF */ Node::NodeType::GLYPH,
+      /* cmap */ 0xFFFFFFFF,
+      /* GSUB */ Node::NodeType::GLYPH,
+      /* MATH */ Node::NodeType::GLYPH,
+      /* COLR */ Node::NodeType::GLYPH,
+      /* glyf */ Node::NodeType::GLYPH,
+      /* CFF */ Node::NodeType::GLYPH,
   };
 
   static constexpr hb_tag_t kClosurePhaseStartNodes[] = {
-    /* cmap */ Node::NodeType::SEGMENT,
-    // For GSUB we also need to consider reached features as starting nodes
-    // since those have outgoing GSUB edges.
-    /* GSUB */ Node::NodeType::GLYPH | Node::NodeType::FEATURE,
-    /* MATH */ Node::NodeType::GLYPH,
-    /* COLR */ Node::NodeType::GLYPH,
-    /* glyf */ Node::NodeType::GLYPH,
-    /* CFF */ Node::NodeType::GLYPH,
+      /* cmap */ Node::NodeType::SEGMENT,
+      // For GSUB we also need to consider reached features as starting nodes
+      // since those have outgoing GSUB edges.
+      /* GSUB */ Node::NodeType::GLYPH | Node::NodeType::FEATURE,
+      /* MATH */ Node::NodeType::GLYPH,
+      /* COLR */ Node::NodeType::GLYPH,
+      /* glyf */ Node::NodeType::GLYPH,
+      /* CFF */ Node::NodeType::GLYPH,
   };
 
   static absl::StatusOr<DependencyGraph> Create(
@@ -117,9 +114,12 @@ class DependencyGraph {
   absl::StatusOr<ift::common::GlyphSet> RequiredGlyphsFor(
       const PendingEdge& edge) const;
 
-  // Returns a topological sorting of the dependency graph's nodes, excluding
-  // any nodes that are in the init font.
-  absl::StatusOr<std::vector<Node>> TopologicalSorting(const absl::flat_hash_set<hb_tag_t>& table_filter, uint32_t node_type_filter) const;
+  // Returns the strongly connected components of the dependency graph's nodes,
+  // excluding any nodes that are in the init font. The components are returned
+  // in topological order.
+  absl::StatusOr<std::vector<std::vector<Node>>> StronglyConnectedComponents(
+      const absl::flat_hash_set<hb_tag_t>& table_filter,
+      uint32_t node_type_filter) const;
 
   // Computes the incoming edges for every node in the dependency graph, taking
   // into account all context requirements and implicit dependencies.
@@ -127,7 +127,8 @@ class DependencyGraph {
   // The return value is a map from each node to each unique edge requirement.
   // Edge requirements are represented as a CNF expression over other nodes.
   absl::StatusOr<absl::flat_hash_map<Node, absl::btree_set<EdgeConditonsCnf>>>
-  CollectIncomingEdges(const absl::flat_hash_set<hb_tag_t>& table_filter, uint32_t node_type_filter) const;
+  CollectIncomingEdges(const absl::flat_hash_set<hb_tag_t>& table_filter,
+                       uint32_t node_type_filter) const;
 
  private:
   DependencyGraph(

--- a/ift/dep_graph/dependency_graph_test.cc
+++ b/ift/dep_graph/dependency_graph_test.cc
@@ -436,6 +436,17 @@ TEST_F(DependencyGraphTest, RequiredGlyphsFor_Liga) {
   EXPECT_TRUE(found_fi);
 }
 
+static std::vector<Node> FlattenSccs(
+    const std::vector<std::vector<Node>>& sccs) {
+  std::vector<Node> out;
+  for (const auto& scc : sccs) {
+    for (Node n : scc) {
+      out.push_back(n);
+    }
+  }
+  return out;
+}
+
 static int GetIndex(const std::vector<Node>& topo_order, Node n) {
   for (int i = 0; i < (int)topo_order.size(); ++i) {
     if (topo_order[i] == n) return i;
@@ -443,7 +454,9 @@ static int GetIndex(const std::vector<Node>& topo_order, Node n) {
   return -1;
 }
 
-TEST_F(DependencyGraphTest, TopologicalSorting) {
+TEST_F(DependencyGraphTest, StronglyConnectedComponents_TopologicalSorting) {
+  // For dependency graphs that are DAG's strongly connected components is just
+  // a topological sort
   SubsetDefinition liga;
   liga.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
   Reconfigure({}, {
@@ -453,13 +466,10 @@ TEST_F(DependencyGraphTest, TopologicalSorting) {
                       {liga, ProbabilityBound::Zero()},
                   });
 
-  auto topo_order_or = graph.TopologicalSorting({
-    FontHelper::kCmap,
-    FontHelper::kGSUB,
-    FontHelper::kGlyf
-  }, 0xFFFFFFFF);
-  ASSERT_TRUE(topo_order_or.ok()) << topo_order_or.status();
-  const std::vector<Node>& topo_order = *topo_order_or;
+  auto sccs_or = graph.StronglyConnectedComponents(
+      {FontHelper::kCmap, FontHelper::kGSUB, FontHelper::kGlyf}, 0xFFFFFFFF);
+  ASSERT_TRUE(sccs_or.ok()) << sccs_or.status();
+  const std::vector<Node> topo_order = FlattenSccs(*sccs_or);
   glyph_id_t gid_a = *FontHelper::GetNominalGlyph(face.get(), 'a');
   glyph_id_t gid_f = *FontHelper::GetNominalGlyph(face.get(), 'f');
   glyph_id_t gid_i = *FontHelper::GetNominalGlyph(face.get(), 'i');
@@ -513,7 +523,7 @@ TEST_F(DependencyGraphTest, TopologicalSorting) {
   EXPECT_LT(liga_f, gffi);
 }
 
-TEST_F(DependencyGraphTest, TopologicalSorting_InitFontFilter) {
+TEST_F(DependencyGraphTest, StronglyConnectedComponents_TopologicalSorting_InitFontFilter) {
   SubsetDefinition liga;
   liga.feature_tags = {HB_TAG('l', 'i', 'g', 'a')};
   SubsetDefinition dlig;
@@ -525,13 +535,10 @@ TEST_F(DependencyGraphTest, TopologicalSorting_InitFontFilter) {
                   {dlig, ProbabilityBound::Zero()},
               });
 
-  auto topo_order_or = graph.TopologicalSorting({
-    FontHelper::kCmap,
-    FontHelper::kGSUB,
-    FontHelper::kGlyf
-  }, 0xFFFFFFFF);
-  ASSERT_TRUE(topo_order_or.ok()) << topo_order_or.status();
-  const std::vector<Node>& topo_order = *topo_order_or;
+  auto sccs_or = graph.StronglyConnectedComponents(
+      {FontHelper::kCmap, FontHelper::kGSUB, FontHelper::kGlyf}, 0xFFFFFFFF);
+  ASSERT_TRUE(sccs_or.ok()) << sccs_or.status();
+  const std::vector<Node> topo_order = FlattenSccs(*sccs_or);
 
   glyph_id_t gid_a = *FontHelper::GetNominalGlyph(face.get(), 'a');
 
@@ -543,7 +550,7 @@ TEST_F(DependencyGraphTest, TopologicalSorting_InitFontFilter) {
                                    Node::Feature(HB_TAG('d', 'l', 'i', 'g'))));
 }
 
-TEST_F(DependencyGraphTest, TopologicalSorting_InitFontFeatures) {
+TEST_F(DependencyGraphTest, StronglyConnectedComponents_TopologicalSorting_InitFontFeatures) {
   Reconfigure(WithDefaultFeatures({}),
               {
                   /* 0 */ {{'a'}, ProbabilityBound::Zero()},
@@ -554,13 +561,10 @@ TEST_F(DependencyGraphTest, TopologicalSorting_InitFontFeatures) {
                   /* 5 */ {{0xC1 /* Aacute */}, ProbabilityBound::Zero()},
               });
 
-  auto topo_order_or = graph.TopologicalSorting({
-    FontHelper::kCmap,
-    FontHelper::kGSUB,
-    FontHelper::kGlyf
-  }, 0xFFFFFFFF);
-  ASSERT_TRUE(topo_order_or.ok()) << topo_order_or.status();
-  const std::vector<Node>& topo_order = *topo_order_or;
+  auto sccs_or = graph.StronglyConnectedComponents(
+      {FontHelper::kCmap, FontHelper::kGSUB, FontHelper::kGlyf}, 0xFFFFFFFF);
+  ASSERT_TRUE(sccs_or.ok()) << sccs_or.status();
+  const std::vector<Node> topo_order = FlattenSccs(*sccs_or);
 
   // f
   int s1 = GetIndex(topo_order, Node::Segment(1));
@@ -575,7 +579,8 @@ TEST_F(DependencyGraphTest, TopologicalSorting_InitFontFeatures) {
   EXPECT_LT(gi, gffi);
 }
 
-TEST_F(DependencyGraphTest, TopologicalSorting_TableFilteringCycle) {
+TEST_F(DependencyGraphTest,
+       StronglyConnectedComponents_TableFilteringWithCycle) {
   SubsetDefinition ccmp;
   ccmp.feature_tags = {HB_TAG('c', 'c', 'm', 'p')};
   Reconfigure({},
@@ -585,21 +590,37 @@ TEST_F(DependencyGraphTest, TopologicalSorting_TableFilteringCycle) {
                   /* 2 */ {{ccmp}, ProbabilityBound::Zero()},
               });
 
-  // With both GSUB and glyf enabled, it should hit a cycle.
+  // With both GSUB and glyf enabled, it should find a cycle.
   // Cycle: AE -GSUB-> AEacute -glyf-> AE
-  auto topo_order_or = graph.TopologicalSorting(
+  auto sccs_or = graph.StronglyConnectedComponents(
       {FontHelper::kGSUB, FontHelper::kGlyf}, 0xFFFFFFFF);
-  EXPECT_FALSE(topo_order_or.ok());
-  EXPECT_EQ(topo_order_or.status().code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_THAT(topo_order_or.status().message(), HasSubstr("Cycle detected"));
+  ASSERT_TRUE(sccs_or.ok()) << sccs_or.status();
 
-  // With only GSUB, it should succeed.
-  topo_order_or = graph.TopologicalSorting({FontHelper::kGSUB}, 0xFFFFFFFF);
-  EXPECT_TRUE(topo_order_or.ok()) << topo_order_or.status();
+  uint32_t num_cycles = 0;
+  for (const auto& scc : *sccs_or) {
+    if (scc.size() > 1) {
+      EXPECT_THAT(scc, UnorderedElementsAre(
+        Node::Glyph(129 /* AE */),
+        Node::Glyph(811 /* AEacute */)
+      ));
+      num_cycles++;
+    }
+  }
+  EXPECT_EQ(num_cycles, 1);
 
-  // With only glyf, it should succeed.
-  topo_order_or = graph.TopologicalSorting({FontHelper::kGlyf}, 0xFFFFFFFF);
-  EXPECT_TRUE(topo_order_or.ok()) << topo_order_or.status();
+  // With only GSUB, there should be no cycles
+  sccs_or = graph.StronglyConnectedComponents({FontHelper::kGSUB}, 0xFFFFFFFF);
+  EXPECT_TRUE(sccs_or.ok()) << sccs_or.status();
+  for (const auto& scc : *sccs_or) {
+    EXPECT_EQ(scc.size(), 1);
+  }
+
+  // With only glyf, there should be no cycles
+  sccs_or = graph.StronglyConnectedComponents({FontHelper::kGlyf}, 0xFFFFFFFF);
+  EXPECT_TRUE(sccs_or.ok()) << sccs_or.status();
+  for (const auto& scc : *sccs_or) {
+    EXPECT_EQ(scc.size(), 1);
+  }
 }
 
 TEST_F(DependencyGraphTest, CollectIncomingEdges_TableFiltering) {
@@ -662,7 +683,8 @@ TEST_F(DependencyGraphTest, CollectIncomingEdges) {
                   /* 2 */ {liga, ProbabilityBound::Zero()},
               });
 
-  auto edges_or = graph.CollectIncomingEdges({FontHelper::kCmap, FontHelper::kGSUB}, 0xFFFFFFFF);
+  auto edges_or = graph.CollectIncomingEdges(
+      {FontHelper::kCmap, FontHelper::kGSUB}, 0xFFFFFFFF);
   ASSERT_TRUE(edges_or.ok()) << edges_or.status();
   const auto& edges = *edges_or;
 

--- a/ift/encoder/dependency_closure.cc
+++ b/ift/encoder/dependency_closure.cc
@@ -703,8 +703,8 @@ DependencyClosure::EdgeConditionsToActivationCondition(
 
     if (!group_condition.has_value()) {
       // If group_condition is empty that means it's FALSE, and since the group
-      // condition combines with AND with other sub-groups, the whole expression is
-      // also false.
+      // condition combines with AND with other sub-groups, the whole expression
+      // is also false.
       return std::nullopt;
     }
 
@@ -720,53 +720,73 @@ DependencyClosure::EdgeConditionsToActivationCondition(
 
 Status DependencyClosure::PropagateConditions(
     const flat_hash_map<Node, btree_set<EdgeConditonsCnf>>& incoming_edges,
-    const std::vector<Node>& topological_sort,
+    const std::vector<std::vector<Node>>& sccs,
     flat_hash_map<Node, ActivationCondition>& node_conditions) const {
-  for (Node n : topological_sort) {
-    auto it = incoming_edges.find(n);
-    if (it == incoming_edges.end()) {
-      // we only process nodes that have incoming edges for each phase.
-      continue;
-    }
+  for (const std::vector<Node>& scc : sccs) {
+    // strongly connect components have cycles so we need to iteratively
+    // propagate conditions through the cycle until they stop changing.
+    // Since conditions can only grow this is gauranteed to stop eventually.
+    bool changed = true;
+    while (changed) {
+      changed = false;
+      for (Node n : scc) {
+        auto it = incoming_edges.find(n);
+        if (it == incoming_edges.end()) {
+          // we only process nodes that have incoming edges within each phase.
+          continue;
+        }
 
-    auto node_conditions_it = node_conditions.find(n);
-    if (node_conditions_it != node_conditions.end() &&
-        node_conditions_it->second.IsAlwaysTrue()) {
-      // If node is always true, it's condition cannot change further.
-      continue;
-    }
+        auto node_conditions_it = node_conditions.find(n);
+        if (node_conditions_it != node_conditions.end() &&
+            node_conditions_it->second.IsAlwaysTrue()) {
+          // If node is always true, it's condition cannot change further.
+          continue;
+        }
 
-    std::optional<ActivationCondition> complete_condition;
+        std::optional<ActivationCondition> complete_condition;
 
-    for (const EdgeConditonsCnf& edge : it->second) {
-      std::optional<ActivationCondition> condition =
-          TRY(EdgeConditionsToActivationCondition(edge, node_conditions));
-      if (!condition.has_value()) {
-        // std::nullopt means the condition for this edge is false, since
-        // it combines with OR with other edges, we can just skip it.
-        continue;
+        for (const EdgeConditonsCnf& edge : it->second) {
+          std::optional<ActivationCondition> condition =
+              TRY(EdgeConditionsToActivationCondition(edge, node_conditions));
+          if (!condition.has_value()) {
+            // std::nullopt means the condition for this edge is false, since
+            // it combines with OR with other edges, we can just skip it.
+            continue;
+          }
+
+          if (complete_condition.has_value()) {
+            complete_condition =
+                ActivationCondition::Or(*complete_condition, *condition);
+          } else {
+            complete_condition = condition;
+          }
+        }
+
+        if (!complete_condition.has_value()) {
+          // If no condition has been found, the condition for this node in this
+          // phase is FALSE so don't add a entry into the node_conditions map.
+          continue;
+        }
+
+        auto it_existing = node_conditions.find(n);
+        if (it_existing == node_conditions.end()) {
+          node_conditions.insert({n, *complete_condition});
+          changed = true;
+        } else {
+          ActivationCondition combined =
+              ActivationCondition::Or(it_existing->second, *complete_condition);
+          if (combined != it_existing->second) {
+            it_existing->second = std::move(combined);
+            changed = true;
+          }
+        }
       }
 
-      if (complete_condition.has_value()) {
-        complete_condition =
-            ActivationCondition::Or(*complete_condition, *condition);
-      } else {
-        complete_condition = condition;
+      if (scc.size() == 1) {
+        // If the component has only one node we can assume the condition
+        // is already stabilized and shortcut a second check.
+        break;
       }
-    }
-
-    if (!complete_condition.has_value()) {
-      // If no condition has been found, the condition for this node in this phase
-      // is FALSE so don't add a entry into the node_conditions map.
-      continue;
-    }
-
-    auto it_existing = node_conditions.find(n);
-    if (it_existing == node_conditions.end()) {
-      node_conditions.insert({n, *complete_condition});
-    } else {
-      it_existing->second =
-          ActivationCondition::Or(it_existing->second, *complete_condition);
     }
   }
 
@@ -780,12 +800,15 @@ DependencyClosure::ExtractAllGlyphConditions() const {
   flat_hash_set<hb_tag_t> table_tags =
       ift::common::FontHelper::GetTags(original_face_.get());
 
-  for (uint32_t phase = 0; phase < DependencyGraph::kNumberOfClosurePhases; phase++) {
+  for (uint32_t phase = 0; phase < DependencyGraph::kNumberOfClosurePhases;
+       phase++) {
     hb_tag_t table = DependencyGraph::kClosurePhaseTable[phase];
     if (table_tags.contains(table)) {
-      auto topological_sort = TRY(graph_.TopologicalSorting({table}, DependencyGraph::kClosurePhaseNodeFilter[phase]));
-      auto incoming_edges = TRY(graph_.CollectIncomingEdges({table}, DependencyGraph::kClosurePhaseNodeFilter[phase]));
-      TRYV(PropagateConditions(incoming_edges, topological_sort, conditions));
+      auto sccs = TRY(graph_.StronglyConnectedComponents(
+          {table}, DependencyGraph::kClosurePhaseNodeFilter[phase]));
+      auto incoming_edges = TRY(graph_.CollectIncomingEdges(
+          {table}, DependencyGraph::kClosurePhaseNodeFilter[phase]));
+      TRYV(PropagateConditions(incoming_edges, sccs, conditions));
     }
   }
 

--- a/ift/encoder/dependency_closure.h
+++ b/ift/encoder/dependency_closure.h
@@ -136,7 +136,7 @@ class DependencyClosure {
       const absl::flat_hash_map<dep_graph::Node,
                                 absl::btree_set<dep_graph::EdgeConditonsCnf>>&
           incoming_edges,
-      const std::vector<dep_graph::Node>& topological_sort,
+      const std::vector<std::vector<dep_graph::Node>>& sccs,
       absl::flat_hash_map<dep_graph::Node, ActivationCondition>& conditions)
       const;
 #endif

--- a/ift/encoder/dependency_closure_test.cc
+++ b/ift/encoder/dependency_closure_test.cc
@@ -291,19 +291,19 @@ TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_PhaseIsolation) {
   EXPECT_EQ(conditions.at(652 /* Iacute */).ToString(), "if (s1) then p0");
 }
 
-TEST_F(DependencyClosureTest, DISABLED_ExtractAllGlyphConditions_FullFont) {
-  // TODO XXXXX currently disabled because we can't yet handle cycles.
-
+TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_FullFont) {
   CodepointSet unicodes = FontHelper::ToCodepointsSet(face.get());
   btree_set<hb_tag_t> features = FontHelper::GetFeatureTags(face.get());
 
   std::vector<Segment> segments;
   flat_hash_map<hb_codepoint_t, segment_index_t> cp_to_seg;
+  flat_hash_map<hb_tag_t, segment_index_t> layout_to_seg;
   for (hb_codepoint_t cp : unicodes) {
     cp_to_seg[cp] = segments.size();
     segments.push_back({{cp}, ProbabilityBound::Zero()});
   }
   for (hb_tag_t feature : features) {
+    layout_to_seg[feature] = segments.size();
     SubsetDefinition f;
     f.feature_tags.insert(feature);
     segments.push_back({f, ProbabilityBound::Zero()});
@@ -311,10 +311,30 @@ TEST_F(DependencyClosureTest, DISABLED_ExtractAllGlyphConditions_FullFont) {
 
   Reconfigure({}, segments);
 
-  auto r = dependency_closure->ExtractAllGlyphConditions();
-  ASSERT_TRUE(r.ok()) << r.status();
+  auto conditions = dependency_closure->ExtractAllGlyphConditions();
+  ASSERT_TRUE(conditions.ok()) << conditions.status();
 
-  // TODO XXXX check some cases
+  uint32_t parenleft = cp_to_seg.at('(');
+  uint32_t parenright = cp_to_seg.at(')');
+
+  EXPECT_EQ(conditions->at(12 /* parenleft */).ToString(),
+    // '(' is accesible from either '(' or ')' due to unicode mirroring.
+    absl::StrCat("if ((s", parenleft, " OR s", parenright,")) then p0"));
+
+  // small caps AE is accesible via numerous pathways and forms a complex
+  // composite condition (smcp, c2sc, and glyph component substitutions)
+  uint32_t AE = cp_to_seg.at(0xC6);
+  uint32_t ae = cp_to_seg.at(0xE6);
+  uint32_t AEacute = cp_to_seg.at(0x1FC);
+  uint32_t aeacute = cp_to_seg.at(0x1FD);
+  uint32_t smcp = layout_to_seg.at(HB_TAG('s', 'm', 'c', 'p'));
+  uint32_t c2sc = layout_to_seg.at(HB_TAG('c', '2', 's', 'c'));
+  EXPECT_EQ(conditions->at(627 /* small caps AE */).ToString(),
+  absl::StrCat(
+    "if ((s", AE, " OR s", ae," OR s", AEacute, " OR s", aeacute, ") ",
+    "AND (s", AE, " OR s", AEacute, " OR s", smcp, ") ",
+    "AND (s", ae," OR s", aeacute," OR s", c2sc,") ",
+    "AND (s", c2sc," OR s", smcp, ")) then p0"));
 }
 
 TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_PhaseCycle) {
@@ -336,7 +356,25 @@ TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_PhaseCycle) {
   const auto& conditions = *r;
 
   EXPECT_EQ("if (s0) then p0", conditions.at(129 /* AE */).ToString());
-  EXPECT_EQ("if (s0 AND s1 AND s2) then p0", conditions.at(117 /* acute */).ToString());
+  EXPECT_EQ("if (s0 AND s1 AND s2) then p0",
+            conditions.at(117 /* acute */).ToString());
+}
+
+TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_BidiCycle) {
+  Reconfigure(face.get(), WithDefaultFeatures(),
+              {
+                  /* 0 */ {{0x0029 /* ) */}, ProbabilityBound::Zero()},
+                  /* 1 */ {{0x0028 /* ( */}, ProbabilityBound::Zero()},
+              });
+
+  auto r = dependency_closure->ExtractAllGlyphConditions();
+  ASSERT_TRUE(r.ok()) << r.status();
+  const auto& conditions = *r;
+
+  // GID 11 is '(', GID 12 is ')' in Roboto
+  // Both should be reached if either segment is present due to the cycle.
+  EXPECT_EQ(conditions.at(12).ToString(), "if ((s0 OR s1)) then p0");
+  EXPECT_EQ(conditions.at(13).ToString(), "if ((s0 OR s1)) then p0");
 }
 
 TEST_F(DependencyClosureTest, Exclusive) {


### PR DESCRIPTION
Dependency graphs can have cycles within a closure phase (for example bidi mirror dependencies naturally form cycles). Since topological sorting can't handle cycles a different approach is needed.

In condition extraction topological sorting is swapped out with a strongly connected component finding algorithm (Tarjan's, ref: https://en.wikipedia.org/wiki/Tarjan%27s_strongly_connected_components_algorithm). This returns a topological sorting of strongly connected components. When the dependency graph is a DAG this gives the exact same behaviour as the prior topological sorting based implementation. To handle the cycles within a strongly connected component condition propagation has been modified to iteratively propagate conditions inside a component until they stabilize.

New high level algorithm:
- Generate a topological sorting of strongly connected components of the dep graph.
- Generate a list of incoming edge conditions for each node. Where a condition is a CNF boolean expression in terms of other nodes.
- Working in topological order for each component iteratively resolve node conditions by combining the incoming edge conditions on each node. Simplify the combined condition to CNF. Repeat until stable conditions are formed within the component.
- Repeat this process for each closure phase.