### PR TITLE
Add DEP_GRAPH_ONLY condition analysis mode

### DIFF
--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -27,20 +27,15 @@ namespace ift::config {
 static constexpr uint32_t kMinimumGroupSize = 4;
 
 // Quality Table:
-// Quality | bigrams | find conditions | init brotli | non init brotli | init
-// font merge threshold | opt cut off | preprocess merging | preprocess
-// threshold 1       | No      | No              | 0           | 0 | 60% | 5% |
-// Yes                | 5% 2       | Yes     | No              | 0           | 0
-// | 55%                       | 4%          | Yes                | 4% 3       |
-// Yes     | Yes             | 0           | 0               | 50% | 3% | Yes |
-// 3% 4       | Yes     | Yes             | 0           | 9               | 45%
-// | 2%          | Yes                | 2% 5       | Yes     | Yes             |
-// 9           | 9               | 40%                       | 1%          | Yes
-// | 1% 6       | Yes     | Yes             | 9           | 11              |
-// 30%                       | 0.5%        | Yes                | 0.5% 7       |
-// Yes     | Yes             | 11          | 11              | 25% | 0.5% | Yes
-// | 0.05% 8       | Yes     | Yes             | 11          | 11              |
-// 25%                       | 0.5%        | No                 | na
+// Quality | bigrams | init font merging | init brotli | non init brotli | init font merge threshold | opt cut off | preprocess merging | preprocess threshold
+// 1       | No      | No                | 0           | 0               | na                        | 5%          | Yes                | 5%
+// 2       | Yes     | No                | 0           | 0               | na                        | 4%          | Yes                | 4%
+// 3       | Yes     | Yes               | 0           | 0               | 60%                       | 3%          | Yes                | 3%
+// 4       | Yes     | Yes               | 0           | 9               | 50%                       | 2%          | Yes                | 2%
+// 5       | Yes     | Yes               | 9           | 9               | 40%                       | 1%          | Yes                | 1%
+// 6       | Yes     | Yes               | 9           | 11              | 30%                       | 0.5%        | Yes                | 0.5%
+// 7       | Yes     | Yes               | 11          | 11              | 25%                       | 0.5%        | Yes                | 0.05%
+// 8       | Yes     | Yes               | 11          | 11              | 25%                       | 0.5%        | No                 | na
 enum Quality {
   MIN = 1,  // Alias for ONE
   ONE = 1,
@@ -535,6 +530,10 @@ static void ApplyQualityLevelTo(Quality quality, CostConfiguration& config) {
 
 static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
   if (merge_group.has_cost_config()) {
+    if (quality == ONE || quality == TWO) {
+      merge_group.mutable_cost_config()->clear_initial_font_merge_threshold();
+    }
+
     if (quality >= ONE && quality <= SEVEN) {
       merge_group.set_preprocess_merging_group_size(kMinimumGroupSize);
     } else {
@@ -571,21 +570,13 @@ static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
 
     if (merge_group.mutable_cost_config()->has_initial_font_merge_threshold()) {
       switch (quality) {
-        case ONE:
+        case THREE:
           merge_group.mutable_cost_config()
               ->set_initial_font_merge_probability_threshold(0.60);
           break;
-        case TWO:
-          merge_group.mutable_cost_config()
-              ->set_initial_font_merge_probability_threshold(0.55);
-          break;
-        case THREE:
-          merge_group.mutable_cost_config()
-              ->set_initial_font_merge_probability_threshold(0.50);
-          break;
         case FOUR:
           merge_group.mutable_cost_config()
-              ->set_initial_font_merge_probability_threshold(0.45);
+              ->set_initial_font_merge_probability_threshold(0.50);
           break;
         case FIVE:
           merge_group.mutable_cost_config()
@@ -609,11 +600,7 @@ static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
 static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
   config.set_preprocess_merging_group_size_for_ungrouped(kMinimumGroupSize);
 
-  if (quality == ONE || quality == TWO) {
-    config.set_unmapped_glyph_handling(MOVE_TO_INIT_FONT);
-  } else {
-    config.set_unmapped_glyph_handling(FIND_CONDITIONS);
-  }
+  config.set_unmapped_glyph_handling(MOVE_TO_INIT_FONT);
 
   switch (quality) {
     case ONE:
@@ -665,7 +652,7 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
   SegmenterConfig config;
   config.set_generate_table_keyed_segments(true);
   config.set_generate_feature_segments(true);
-  config.set_condition_analysis_mode(CLOSURE_AND_DEP_GRAPH);
+  config.set_condition_analysis_mode(DEP_GRAPH_ONLY);
 
   auto* base_plan = config.mutable_base_segmentation_plan();
   base_plan->set_jump_ahead(2);
@@ -683,7 +670,7 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
   if (cp_count <= 1000) {
     quality = MAX;
   } else if (cp_count <= 3000) {
-    quality_level = SIX;
+    quality = SIX;
   }
 
   if (quality_level.has_value() && quality_level.value() >= MIN &&

--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -26,6 +26,7 @@ namespace ift::config {
 
 static constexpr uint32_t kMinimumGroupSize = 4;
 
+// clang-format off
 // Quality Table:
 // Quality | bigrams | init font merging | init brotli | non init brotli | init font merge threshold | opt cut off | preprocess merging | preprocess threshold
 // 1       | No      | No                | 0           | 0               | na                        | 5%          | Yes                | 5%
@@ -36,6 +37,7 @@ static constexpr uint32_t kMinimumGroupSize = 4;
 // 6       | Yes     | Yes               | 9           | 11              | 30%                       | 0.5%        | Yes                | 0.5%
 // 7       | Yes     | Yes               | 11          | 11              | 25%                       | 0.5%        | Yes                | 0.05%
 // 8       | Yes     | Yes               | 11          | 11              | 25%                       | 0.5%        | No                 | na
+// clang-format on
 enum Quality {
   MIN = 1,  // Alias for ONE
   ONE = 1,

--- a/ift/config/auto_segmenter_config_test.cc
+++ b/ift/config/auto_segmenter_config_test.cc
@@ -91,7 +91,7 @@ TEST_F(AutoSegmenterConfigTest, Roboto_UnspecifiedPrimary) {
 
   std::string config_string;
   TextFormat::PrintToString(*config_or, &config_string);
-  ASSERT_EQ(config_string, R"(unmapped_glyph_handling: FIND_CONDITIONS
+  ASSERT_EQ(config_string, R"(unmapped_glyph_handling: MOVE_TO_INIT_FONT
 generate_table_keyed_segments: true
 brotli_quality: 11
 brotli_quality_for_initial_font_merging: 11
@@ -146,7 +146,7 @@ base_segmentation_plan {
   use_prefetch_lists: true
 }
 generate_feature_segments: true
-condition_analysis_mode: CLOSURE_AND_DEP_GRAPH
+condition_analysis_mode: DEP_GRAPH_ONLY
 )");
 }
 
@@ -290,7 +290,7 @@ TEST_F(AutoSegmenterConfigTest, QualityLevelForcing) {
       AutoSegmenterConfig::GenerateConfig(face_.get(), std::nullopt, 8);
   ASSERT_TRUE(config_or_8.ok()) << config_or_8.status();
   EXPECT_EQ(config_or_8->brotli_quality(), 11);
-  EXPECT_EQ(config_or_8->unmapped_glyph_handling(), FIND_CONDITIONS);
+  EXPECT_EQ(config_or_8->unmapped_glyph_handling(), MOVE_TO_INIT_FONT);
   EXPECT_EQ(config_or_8->base_cost_config().use_bigrams(), true);
   EXPECT_EQ(config_or_8->brotli_quality_for_initial_font_merging(), 11);
   EXPECT_EQ(config_or_8->base_cost_config().optimization_cutoff_fraction(),

--- a/ift/config/segmenter_config.proto
+++ b/ift/config/segmenter_config.proto
@@ -10,8 +10,8 @@ enum ConditionAnalysisMode {
   CLOSURE_ONLY = 0;
 
   // Attempts to analyze glyph conditions using a dependency
-  // graph where possible. When not possible it falls back
-  // to closure analysis. This is for many cases much faster
+  // graph where possible. When dep graph is expected not to be accurate
+  // it falls back to closure analysis. This is for many cases much faster
   // then pure closure based analysis. However, the dependency
   // graph approach is still experimental and may (rarely) produce
   // different results than the pure closure analysis approach.
@@ -30,6 +30,8 @@ enum ConditionAnalysisMode {
   // This is the fastest method and generally generates high quality
   // conditions, but may on occassion overestimate the conditions
   // for a glyph.
+  //
+  // This is currently the recommended analysis mode.
   DEP_GRAPH_ONLY = 3;
 }
 

--- a/ift/config/segmenter_config.proto
+++ b/ift/config/segmenter_config.proto
@@ -22,6 +22,15 @@ enum ConditionAnalysisMode {
   // Useful primarily for testing the accuracy of the dependency
   // graph approach.
   CLOSURE_AND_VALIDATE_DEP_GRAPH = 2;
+
+  // Analyze glyph conditions using dep graph only. Closure is
+  // only used at the very end to validate that founds conditions
+  // meet the glyph closure requirement.
+  //
+  // This is the fastest method and generally generates high quality
+  // conditions, but may on occassion overestimate the conditions
+  // for a glyph.
+  DEP_GRAPH_ONLY = 3;
 }
 
 // This messages provides the configuration details for util/gen_ift_segmentation_plan.cc

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -71,7 +71,8 @@ ActivationCondition ActivationCondition::or_segments(const SegmentSet& segments,
 }
 
 ActivationCondition ActivationCondition::composite_condition(
-    absl::Span<const SegmentSet> groups, patch_id_t activated, bool is_fallback) {
+    absl::Span<const SegmentSet> groups, patch_id_t activated,
+    bool is_fallback) {
   ActivationCondition conditions;
   conditions.activated_ = {activated};
   for (const auto& group : groups) {

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -71,13 +71,14 @@ ActivationCondition ActivationCondition::or_segments(const SegmentSet& segments,
 }
 
 ActivationCondition ActivationCondition::composite_condition(
-    absl::Span<const SegmentSet> groups, patch_id_t activated) {
+    absl::Span<const SegmentSet> groups, patch_id_t activated, bool is_fallback) {
   ActivationCondition conditions;
   conditions.activated_ = {activated};
   for (const auto& group : groups) {
     conditions.conditions_.push_back(group);
   }
 
+  conditions.is_fallback_ = is_fallback;
   return conditions;
 }
 

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -446,110 +446,81 @@ ActivationCondition::ActivationConditionsToPatchMapEntries(
 StatusOr<double> ActivationCondition::Probability(
     Span<const Segment> segments,
     const ProbabilityCalculator& calculator) const {
-  // This calculation makes the assumption that segments are all disjoint.
-  // Disjointess of the segment list is enforced in the initialization
-  // of segmentation context.
-
-  std::vector<const Segment*> conjunctive_segments;
-  bool is_conjunctive = conditions_.size() > 1;
-  for (const auto& segment_set : conditions_) {
-    if (is_conjunctive && segment_set.size() != 1) {
-      // Composite conditions (eg. (a or b) and (c or d)) may have repeated
-      // segments in each conjunctive group (eg. (a or b) and (a or d)) which
-      // requires special analysis to correctly determine probability. For our
-      // current use cases we don't need to support this.
-      return absl::UnimplementedError(
-          "Calculating probability of composite conditions is not "
-          "supported.");
-    }
-
-    if (is_conjunctive) {
-      conjunctive_segments.push_back(&segments[*segment_set.min()]);
-      continue;
-    }
-
-    if (segment_set.size() == 1) {
-      // If we're here the condition is disjunctive, which means that there is
-      // at most one condition group (which we are currently on) and since there
-      // is only one segment in the condition group we already know it's
-      // probability, just return it.
-      return segments[*segment_set.min()].Probability();
-    }
-
-    // For a group (s1 OR s2 OR ...), compute the union of their definitions.
-    std::vector<const Segment*> union_segments;
-    for (unsigned s_index : segment_set) {
-      const auto& s = segments[s_index];
-      union_segments.push_back(&s);
-    }
-
-    // TODO(garretrieger): The full probability bound should be utilized here.
-    return calculator.ComputeMergedProbability(union_segments).Average();
+  if (conditions_.empty()) {
+    return 1.0;
   }
 
-  return calculator.ComputeConjunctiveProbability(conjunctive_segments)
-      .Average();
+  std::vector<freq::ProbabilityBound> bounds;
+  bool is_conjunctive = conditions_.size() > 1;
+  for (const auto& segment_set : conditions_) {
+    freq::ProbabilityBound set_bound = freq::ProbabilityBound::Zero();
+    if (segment_set.empty()) {
+      return absl::InternalError("Unexpected empty disjunctive group.");
+    } else if (segment_set.size() > 1) {
+      // For a group (s1 OR s2 OR ...), compute the union of their definitions.
+      std::vector<const Segment*> union_segments;
+      for (unsigned s_index : segment_set) {
+        union_segments.push_back(&segments[s_index]);
+      }
+      set_bound = calculator.ComputeMergedProbability(union_segments);
+    } else {
+      set_bound = segments[*segment_set.min()].ProbabilityBound();
+    }
+
+    if (!is_conjunctive) {
+      return set_bound.Average();
+    }
+    bounds.push_back(set_bound);
+  }
+
+  return calculator.ComputeConjunctiveProbability(bounds).Average();
 }
 
 StatusOr<double> ActivationCondition::MergedProbability(
     Span<const Segment> segments, const SegmentSet& merged_segments,
     const Segment& merged_segment,
     const ProbabilityCalculator& calculator) const {
-  std::vector<const Segment*> conjunctive_segments;
-
-  bool is_conjunctive = conditions_.size() > 1;
-  for (const auto& segment_set : conditions_) {
-    if (is_conjunctive && segment_set.size() != 1) {
-      // Composite conditions (eg. (a or b) and (c or d)) may have repeated
-      // segments in each conjunctive group (eg. (a or b) and (a or d)) which
-      // requires special analysis to correctly determine probability. For our
-      // current use cases we don't need to support this.
-      return absl::UnimplementedError(
-          "Calculating probability of composite conditions is not "
-          "supported.");
-    }
-
-    if (is_conjunctive) {
-      segment_index_t s_index = *segment_set.min();
-      if (!merged_segments.contains(s_index)) {
-        conjunctive_segments.push_back(&segments[s_index]);
-      } else {
-        conjunctive_segments.push_back(&merged_segment);
-      }
-      continue;
-    }
-
-    if (segment_set.is_subset_of(merged_segments)) {
-      // Post merge the segment will be equal to merged_segment, so we can just
-      // use it's probability directly.
-      return merged_segment.Probability();
-    }
-
-    if (segment_set.size() == 1) {
-      return segments[*segment_set.min()].Probability();
-    }
-
-    // For a group (s1 OR s2 OR ...), compute the union of their definitions.
-    bool has_merged = false;
-    std::vector<const Segment*> union_segments;
-    for (unsigned s_index : segment_set) {
-      if (!has_merged && merged_segments.contains(s_index)) {
-        has_merged = true;
-      }
-      union_segments.push_back(&segments[s_index]);
-    }
-
-    if (has_merged) {
-      // the condition group intersects with the merged set so need to union
-      // in all of the merged segments to get the probability.
-      union_segments.push_back(&merged_segment);
-    }
-
-    return calculator.ComputeMergedProbability(union_segments).Average();
+  if (conditions_.empty()) {
+    return 1.0;
   }
 
-  return calculator.ComputeConjunctiveProbability(conjunctive_segments)
-      .Average();
+  std::vector<freq::ProbabilityBound> bounds;
+  bool is_conjunctive = conditions_.size() > 1;
+  for (const auto& segment_set : conditions_) {
+    freq::ProbabilityBound set_bound = freq::ProbabilityBound::Zero();
+
+    if (segment_set.empty()) {
+      return absl::InternalError("Unexpected empty disjunctive group.");
+    }
+
+    std::vector<const Segment*> union_segments;
+    if (segment_set.intersects(merged_segments)) {
+      // replace all segments in 'merged_segments' with 'merged_segment'.
+      union_segments.push_back(&merged_segment);
+      for (unsigned s : segment_set) {
+        if (!merged_segments.contains(s)) {
+          union_segments.push_back(&segments[s]);
+        }
+      }
+    } else {
+      for (unsigned s : segment_set) {
+        union_segments.push_back(&segments[s]);
+      }
+    }
+
+    if (union_segments.size() > 1) {
+      set_bound = calculator.ComputeMergedProbability(union_segments);
+    } else {
+      set_bound = union_segments[0]->ProbabilityBound();
+    }
+
+    if (!is_conjunctive) {
+      return set_bound.Average();
+    }
+    bounds.push_back(set_bound);
+  }
+
+  return calculator.ComputeConjunctiveProbability(bounds).Average();
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -54,7 +54,8 @@ class ActivationCondition {
    * (s1 OR ..) AND (si OR ...) AND ...
    */
   static ActivationCondition composite_condition(
-      absl::Span<const ift::common::SegmentSet> groups, patch_id_t activated, bool is_fallback = false);
+      absl::Span<const ift::common::SegmentSet> groups, patch_id_t activated,
+      bool is_fallback = false);
 
   // Returns a new activation condition that activates on (a && b)
   //

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -54,7 +54,7 @@ class ActivationCondition {
    * (s1 OR ..) AND (si OR ...) AND ...
    */
   static ActivationCondition composite_condition(
-      absl::Span<const ift::common::SegmentSet> groups, patch_id_t activated);
+      absl::Span<const ift::common::SegmentSet> groups, patch_id_t activated, bool is_fallback = false);
 
   // Returns a new activation condition that activates on (a && b)
   //

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -293,11 +293,10 @@ TEST(ActivationConditionTest, ActivationConditionProbabilities) {
                 segments, probability_calculator),
             0.77);
 
-  ASSERT_EQ(
-      *ActivationCondition::composite_condition({{1, 2}, {0, 1}}, 1)
-          .Probability(segments, probability_calculator),
-          // {1, 2} 0.66 * {0, 1} 0.77
-          0.66 * 0.77);
+  ASSERT_EQ(*ActivationCondition::composite_condition({{1, 2}, {0, 1}}, 1)
+                 .Probability(segments, probability_calculator),
+            // {1, 2} 0.66 * {0, 1} 0.77
+            0.66 * 0.77);
 }
 
 TEST(ActivationConditionTest, Probability_RejectsEmptySegmentSet) {
@@ -400,11 +399,10 @@ TEST(ActivationConditionTest, MergedProbability) {
               0.75 * 0.85 * 0.85, 1e-9);
 
   // Composite condition
-  EXPECT_NEAR(
-      *ActivationCondition::composite_condition({{0, 1}, {2}}, 1)
-           .MergedProbability(segments, {1, 2}, merged_segment,
-                              probability_calculator),
-      0.90 * 0.85, 1e-9);
+  EXPECT_NEAR(*ActivationCondition::composite_condition({{0, 1}, {2}}, 1)
+                   .MergedProbability(segments, {1, 2}, merged_segment,
+                                      probability_calculator),
+              0.90 * 0.85, 1e-9);
 }
 
 TEST(ActivationConditionTest, True) {

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -293,11 +293,44 @@ TEST(ActivationConditionTest, ActivationConditionProbabilities) {
                 segments, probability_calculator),
             0.77);
 
-  // Composite conditions aren't currently supported.
-  ASSERT_TRUE(absl::IsUnimplemented(
-      ActivationCondition::composite_condition({{1, 2}, {0, 1}}, 1)
-          .Probability(segments, probability_calculator)
-          .status()));
+  ASSERT_EQ(
+      *ActivationCondition::composite_condition({{1, 2}, {0, 1}}, 1)
+          .Probability(segments, probability_calculator),
+          // {1, 2} 0.66 * {0, 1} 0.77
+          0.66 * 0.77);
+}
+
+TEST(ActivationConditionTest, Probability_RejectsEmptySegmentSet) {
+  ActivationCondition invalid_condition =
+      ActivationCondition::composite_condition({{}, {1}}, 10);
+  MockProbabilityCalculator probability_calculator({});
+  std::vector<Segment> segments = {
+      Segment({'a'}, ProbabilityBound{0.75, 0.75}),
+      Segment({'b'}, ProbabilityBound{0.5, 0.5}),
+  };
+
+  EXPECT_FALSE(
+      invalid_condition.Probability(segments, probability_calculator).ok());
+
+  Segment merged_segment({'a'}, ProbabilityBound{0.5, 0.5});
+  EXPECT_FALSE(invalid_condition
+                   .MergedProbability(segments, {}, merged_segment,
+                                      probability_calculator)
+                   .ok());
+}
+
+TEST(ActivationConditionTest, Probability_EmptyCondition) {
+  ActivationCondition empty_condition = ActivationCondition::True(10);
+  MockProbabilityCalculator probability_calculator({});
+  std::vector<Segment> segments;
+
+  EXPECT_EQ(*empty_condition.Probability(segments, probability_calculator),
+            1.0);
+
+  Segment merged_segment({'a'}, ProbabilityBound{0.5, 0.5});
+  EXPECT_EQ(*empty_condition.MergedProbability(segments, {}, merged_segment,
+                                               probability_calculator),
+            1.0);
 }
 
 TEST(ActivationConditionTest, MergedProbability) {
@@ -366,11 +399,12 @@ TEST(ActivationConditionTest, MergedProbability) {
                                       probability_calculator),
               0.75 * 0.85 * 0.85, 1e-9);
 
-  EXPECT_TRUE(absl::IsUnimplemented(
-      ActivationCondition::composite_condition({{0, 1}, {2}}, 1)
-          .MergedProbability(segments, {1, 2}, merged_segment,
-                             probability_calculator)
-          .status()));
+  // Composite condition
+  EXPECT_NEAR(
+      *ActivationCondition::composite_condition({{0, 1}, {2}}, 1)
+           .MergedProbability(segments, {1, 2}, merged_segment,
+                              probability_calculator),
+      0.90 * 0.85, 1e-9);
 }
 
 TEST(ActivationConditionTest, True) {

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -200,20 +200,13 @@ Status ValidateIncrementalGroupings(hb_face_t* face,
 
   // Compute the glyph groupings/conditions from scratch to compare against the
   // incrementall produced ones.
-  for (segment_index_t segment_index = 0;
-       segment_index < context.SegmentationInfo().Segments().size();
-       segment_index++) {
-    TRY(non_incremental_context.ReprocessSegment(segment_index));
-  }
 
   // Transfer over information on combined patches
   for (const GlyphSet& group :
        TRY(context.glyph_groupings.CombinedPatches().NonIdentityGroups())) {
     TRYV(non_incremental_context.glyph_groupings.CombinePatches(group, {}));
   }
-
-  TRYV(non_incremental_context.GroupGlyphs(
-      context.SegmentationInfo().FullClosure(), {}));
+  TRYV(non_incremental_context.ReprocessAll());
 
   bool glyph_groupings_diffs_allowed = false;
   if (non_incremental_context.glyph_groupings.ConditionsAndGlyphs() !=
@@ -633,20 +626,7 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
       return ToFinalSegmentation(context, unmapped_glyph_handling_);
     }
 
-    InvalidationSet modified = std::move(*maybe_modified);
-    last_merged_segment_index = modified.base_segment;
-
-    GlyphSet analysis_modified_gids;
-    if (!context.InertSegments().contains(last_merged_segment_index)) {
-      VLOG(1) << "Re-analyzing segment " << last_merged_segment_index
-              << " due to merge.";
-      analysis_modified_gids =
-          TRY(context.ReprocessSegment(last_merged_segment_index));
-    }
-
-    modified.glyphs.union_set(analysis_modified_gids);
-
-    TRYV(context.GroupGlyphs(modified.glyphs, modified.segments));
+    TRYV(context.ReprocessChanged(std::move(*maybe_modified)));
   }
 
   return absl::InternalError("unreachable");

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -6,6 +6,8 @@
 #include "ift/common/font_data.h"
 #include "ift/common/font_helper.h"
 #include "ift/common/int_set.h"
+#include "ift/common/try.h"
+#include "ift/encoder/activation_condition.h"
 #include "ift/encoder/glyph_segmentation.h"
 #include "ift/encoder/merge_strategy.h"
 #include "ift/encoder/subset_definition.h"
@@ -14,6 +16,7 @@
 
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
 using ift::config::CLOSURE_ONLY;
+using ift::config::DEP_GRAPH_ONLY;
 using ift::config::FIND_CONDITIONS;
 using ift::config::MOVE_TO_INIT_FONT;
 using ift::config::PATCH;
@@ -44,6 +47,7 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
         segmenter_move_to_init_font(8, 8, MOVE_TO_INIT_FONT, CLOSURE_ONLY),
 #ifdef HB_DEPEND_API
         segmenter_dep_graph(8, 8, PATCH, CLOSURE_AND_VALIDATE_DEP_GRAPH),
+        segmenter_dep_graph_only(8, 8, PATCH, DEP_GRAPH_ONLY),
         segmenter_find_conditions_dep_graph(8, 8, FIND_CONDITIONS,
                                             CLOSURE_AND_VALIDATE_DEP_GRAPH),
         segmenter_move_to_init_font_dep_graph(8, 8, MOVE_TO_INIT_FONT,
@@ -76,15 +80,28 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
       hb_face_t* face, SubsetDefinition initial_segment,
       const std::vector<SubsetDefinition>& subset_definitions,
       std::optional<MergeStrategy> strategy = std::nullopt) const {
-    auto segmentation = segmenter.CodepointToGlyphSegments(
-        face, initial_segment, subset_definitions, strategy);
-    auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
-        face, initial_segment, subset_definitions, strategy);
+    auto segmentation = TRY(segmenter.CodepointToGlyphSegments(
+        face, initial_segment, subset_definitions, strategy));
+    auto dep_graph_segmentation = TRY(segmenter_dep_graph.CodepointToGlyphSegments(
+        face, initial_segment, subset_definitions, strategy));
+    auto dep_graph_only_segmentation =
+        TRY(segmenter_dep_graph_only.CodepointToGlyphSegments(
+            face, initial_segment, subset_definitions, strategy));
+
     if (segmentation != dep_graph_segmentation) {
       return absl::InternalError(
           "Basic segmenter: segmentation from dep graph is not equivalent to "
           "the non-dep graph version.");
     }
+    if (segmentation != dep_graph_only_segmentation) {
+      std::cerr << "Closure segmentation: " << segmentation.ToString() << std::endl;
+      std::cerr << "Dep graph only segmentation: " << dep_graph_only_segmentation.ToString() << std::endl;
+      return absl::InternalError(
+          "Basic segmenter: segmentation from dep graph only is not equivalent "
+          "to "
+          "the non-dep graph version.");
+    }
+
     return segmentation;
   }
 
@@ -92,15 +109,28 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
       hb_face_t* face, SubsetDefinition initial_segment,
       const std::vector<SubsetDefinition>& subset_definitions,
       btree_map<SegmentSet, MergeStrategy> merge_groups) const {
-    auto segmentation = segmenter.CodepointToGlyphSegments(
-        face, initial_segment, subset_definitions, merge_groups);
-    auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
-        face, initial_segment, subset_definitions, merge_groups);
+    auto segmentation = TRY(segmenter.CodepointToGlyphSegments(
+        face, initial_segment, subset_definitions, merge_groups));
+    auto dep_graph_segmentation = TRY(segmenter_dep_graph.CodepointToGlyphSegments(
+        face, initial_segment, subset_definitions, merge_groups));
+    auto dep_graph_only_segmentation =
+        TRY(segmenter_dep_graph_only.CodepointToGlyphSegments(
+            face, initial_segment, subset_definitions, merge_groups));
+
     if (segmentation != dep_graph_segmentation) {
       return absl::InternalError(
           "Basic segmenter: segmentation from dep graph is not equivalent to "
           "the non-dep graph version.");
     }
+    if (segmentation != dep_graph_only_segmentation) {
+      std::cerr << "Closure segmentation: " << segmentation.ToString() << std::endl;
+      std::cerr << "Dep graph only segmentation: " << dep_graph_only_segmentation.ToString() << std::endl;
+      return absl::InternalError(
+          "Basic segmenter: segmentation from dep graph only is not equivalent "
+          "to "
+          "the non-dep graph version.");
+    }
+
     return segmentation;
   }
 
@@ -142,12 +172,11 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
   hb_face_unique_ptr noto_nastaliq_urdu;
   hb_face_unique_ptr noto_sans_jp;
 
- private:
   ClosureGlyphSegmenter segmenter;
   ClosureGlyphSegmenter segmenter_find_conditions;
   ClosureGlyphSegmenter segmenter_move_to_init_font;
-
   ClosureGlyphSegmenter segmenter_dep_graph;
+  ClosureGlyphSegmenter segmenter_dep_graph_only;
   ClosureGlyphSegmenter segmenter_find_conditions_dep_graph;
   ClosureGlyphSegmenter segmenter_move_to_init_font_dep_graph;
 };
@@ -292,20 +321,36 @@ if ((s0 OR s1)) then p1
 
 TEST_F(ClosureGlyphSegmenterTest, SegmentationWithAdditionalConditionOverlap) {
   auto segmentation =
-      CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
+      segmenter.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
+  auto dep_graph_segmentation =
+      segmenter_dep_graph.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
+  auto dep_graph_only_segmentation =
+      segmenter_dep_graph_only.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_only_segmentation.ok()) << segmentation.status();
 
   std::vector<SubsetDefinition> expected_segments = {{'f'}, {'i'}, {'f', 'i'}};
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0, gid69 }
-p0: { gid444, gid446 }
-p1: { gid74 }
-p2: { gid77 }
-if ((s0 OR s2)) then p1
-if ((s1 OR s2)) then p2
-if ((s0 OR s1 OR s2)) then p0
+p0: { gid74 }
+p1: { gid77 }
+p2: { gid444, gid446 }
+if ((s0 OR s2)) then p0
+if ((s1 OR s2)) then p1
+if ((s0 OR s1 OR s2)) then p2
+)");
+  ASSERT_EQ(segmentation->ToString(), dep_graph_segmentation->ToString());
+  ASSERT_EQ(dep_graph_only_segmentation->ToString(),
+            R"(initial font: { gid0, gid69 }
+p0: { gid74 }
+p1: { gid77 }
+p2: { gid444, gid446 }
+if ((s0 OR s2)) then p0
+if ((s1 OR s2)) then p1
+if ((s0 OR s2) AND (s1 OR s2)) then p2
 )");
 }
 
@@ -487,19 +532,25 @@ TEST_F(ClosureGlyphSegmenterTest, MixedAndOr) {
             R"(initial font: { gid0, gid69 }
 p0: { gid37, gid74, gid640 }
 p1: { gid39, gid77, gid700 }
-p2: { gid444, gid446 }
-p3: { gid117 }
+p2: { gid117 }
+p3: { gid444, gid446 }
 if (s0) then p0
 if (s1) then p1
-if ((s0 OR s1)) then p3
-if (s0 AND s1) then p2
+if ((s0 OR s1)) then p2
+if (s0 AND s1) then p3
 )");
 }
 
 TEST_F(ClosureGlyphSegmenterTest, UnmappedGlyphs_FallbackSegment) {
-  auto segmentation = CodepointToGlyphSegments(
+  auto segmentation = segmenter.CodepointToGlyphSegments(
+      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
+  auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
+      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
+  auto dep_graph_only_segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
       noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_only_segmentation.ok()) << segmentation.status();
 
   ASSERT_EQ(segmentation->UnmappedGlyphs().size(), 12);
 
@@ -510,15 +561,38 @@ p1: { gid4, gid10, gid156 }
 p2: { gid5, gid6, gid11, gid157 }
 p3: { gid158 }
 p4: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid68, gid139, gid140, gid153, gid172 }
-p5: { gid47, gid64, gid73, gid74, gid75, gid76, gid77, gid83, gid111, gid149, gid174, gid190, gid191 }
-p6: { gid14, gid33, gid60, gid91, gid112, gid145, gid152 }
+p5: { gid14, gid33, gid60, gid91, gid112, gid145, gid152 }
+p6: { gid47, gid64, gid73, gid74, gid75, gid76, gid77, gid83, gid111, gid149, gid174, gid190, gid191 }
 if (s0) then p0
 if (s1) then p1
 if (s2) then p2
 if (s3) then p3
 if ((s0 OR s1)) then p4
-if ((s2 OR s3)) then p6
-if ((s0 OR s1 OR s2 OR s3)) then p5
+if ((s2 OR s3)) then p5
+if ((s0 OR s1 OR s2 OR s3)) then p6
+)");
+  ASSERT_EQ(segmentation->ToString(), dep_graph_segmentation->ToString());
+
+  ASSERT_EQ(dep_graph_only_segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid3, gid9, gid155 }
+p1: { gid4, gid10, gid156 }
+p2: { gid5, gid6, gid157 }
+p3: { gid158 }
+p4: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid64, gid68, gid77, gid139, gid140, gid153, gid172 }
+p5: { gid14, gid33, gid60, gid91, gid112, gid145, gid152, gid190, gid191 }
+p6: { gid174 }
+p7: { gid11 }
+p8: { gid47, gid73, gid74, gid75, gid76, gid83, gid111, gid149 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+if (s3) then p3
+if ((s0 OR s1)) then p4
+if ((s2 OR s3)) then p5
+if ((s0 OR s1 OR s2 OR s3)) then p6
+if ((s0 OR s1) AND s2) then p7
+if ((s0 OR s1) AND (s2 OR s3)) then p8
 )");
 }
 
@@ -539,16 +613,50 @@ p2: { gid4, gid10, gid156 }
 p3: { gid5, gid6, gid11, gid157 }
 p4: { gid158 }
 p5: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid68, gid139, gid140, gid153, gid172 }
-p6: { gid47, gid64, gid73, gid74, gid75, gid76, gid77, gid83, gid111, gid149, gid174, gid190, gid191 }
-p7: { gid14, gid33, gid60, gid91, gid112, gid145, gid152 }
+p6: { gid14, gid33, gid60, gid91, gid112, gid145, gid152 }
+p7: { gid47, gid64, gid73, gid74, gid75, gid76, gid77, gid83, gid111, gid149, gid174, gid190, gid191 }
 if (s0) then p0
 if (s1) then p1
 if (s2) then p2
 if (s3) then p3
 if (s4) then p4
 if ((s1 OR s2)) then p5
-if ((s3 OR s4)) then p7
-if ((s1 OR s2 OR s3 OR s4)) then p6
+if ((s3 OR s4)) then p6
+if ((s1 OR s2 OR s3 OR s4)) then p7
+)");
+}
+
+TEST_F(ClosureGlyphSegmenterTest, DepGraphOnly_FindConditions) {
+  auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
+      noto_nastaliq_urdu.get(), {},
+      {{0x20}, {0x62a}, {0x62b}, {0x62c}, {0x62d}});
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  ASSERT_TRUE(segmentation->UnmappedGlyphs().empty())
+      << segmentation->UnmappedGlyphs().ToString();
+
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid1 }
+p1: { gid3, gid9, gid155 }
+p2: { gid4, gid10, gid156 }
+p3: { gid5, gid6, gid157 }
+p4: { gid158 }
+p5: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid64, gid68, gid77, gid139, gid140, gid153, gid172 }
+p6: { gid14, gid33, gid60, gid91, gid112, gid145, gid152, gid190, gid191 }
+p7: { gid174 }
+p8: { gid11 }
+p9: { gid47, gid73, gid74, gid75, gid76, gid83, gid111, gid149 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+if (s3) then p3
+if (s4) then p4
+if ((s1 OR s2)) then p5
+if ((s3 OR s4)) then p6
+if ((s1 OR s2 OR s3 OR s4)) then p7
+if ((s1 OR s2) AND s3) then p8
+if ((s1 OR s2) AND (s3 OR s4)) then p9
 )");
 }
 
@@ -568,15 +676,15 @@ p1: { gid4, gid10, gid156 }
 p2: { gid5, gid6, gid11, gid157 }
 p3: { gid158 }
 p4: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid68, gid139, gid140, gid153, gid172 }
-p5: { gid47, gid64, gid73, gid74, gid75, gid76, gid77, gid83, gid111, gid149, gid174, gid190, gid191 }
-p6: { gid14, gid33, gid60, gid91, gid112, gid145, gid152 }
+p5: { gid14, gid33, gid60, gid91, gid112, gid145, gid152 }
+p6: { gid47, gid64, gid73, gid74, gid75, gid76, gid77, gid83, gid111, gid149, gid174, gid190, gid191 }
 if (s0) then p0
 if (s1) then p1
 if (s2) then p2
 if (s3) then p3
 if ((s0 OR s1)) then p4
-if ((s2 OR s3)) then p6
-if ((s0 OR s1 OR s2 OR s3)) then p5
+if ((s2 OR s3)) then p5
+if ((s0 OR s1 OR s2 OR s3)) then p6
 )");
 }
 
@@ -634,9 +742,16 @@ TEST_F(ClosureGlyphSegmenterTest, FullRoboto_WithFeaturesAndDepGraph) {
   smcp.feature_tags.insert(HB_TAG('s', 'm', 'c', 'p'));
   segments.push_back(smcp);
 
-  auto segmentation = CodepointToGlyphSegments(
+  auto segmentation = segmenter.CodepointToGlyphSegments(
+      roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
+  auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
+      roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
+  auto dep_graph_only_segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
       roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_only_segmentation.ok()) << segmentation.status();
+  ASSERT_EQ(segmentation, dep_graph_segmentation);
 }
 
 TEST_F(ClosureGlyphSegmenterTest, CostRequiresFrequencies) {
@@ -968,7 +1083,7 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
   // Basic no segment case.
   GlyphSegmentation segmentation1({'a', 'b', 'c'}, {}, {});
   auto sc =
-      GlyphSegmentation::GroupsToSegmentation({}, {}, {}, {}, segmentation1);
+      GlyphSegmentation::ConditionsToSegmentation({}, {}, segmentation1);
   ASSERT_TRUE(sc.ok()) << sc;
 
   ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY);
@@ -980,10 +1095,10 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
 
   // Add some patches
   GlyphSegmentation segmentation2({'a', 'b', 'c'}, {}, {});
-  sc = GlyphSegmentation::GroupsToSegmentation({}, {},
+  sc = GlyphSegmentation::ConditionsToSegmentation(
                                                {
-                                                   {0, {100, 101, 102}},
-                                                   {1, {103, 104, 105}},
+                                                   {ActivationCondition::exclusive_segment(0, 0), {100, 101, 102}},
+                                                   {ActivationCondition::exclusive_segment(1, 0), {103, 104, 105}},
                                                },
                                                {}, segmentation2);
   ASSERT_TRUE(sc.ok()) << sc;
@@ -1555,14 +1670,35 @@ TEST_F(ClosureGlyphSegmenterTest, ConjunctiveAdditionalConditions) {
   smcp.feature_tags.insert(HB_TAG('s', 'm', 'c', 'p'));
   smcp.feature_tags.insert(HB_TAG('c', '2', 's', 'c'));
 
-  auto segmentation = CodepointToGlyphSegments(roboto.get(), {0xE4},
-                                               {
-                                                   {0xD6},  // Ö
-                                                   {0xF6},  // ö
-                                                   smcp,
-                                               },
-                                               MergeStrategy::None());
+  // XXXX
+
+  auto segmentation = segmenter.CodepointToGlyphSegments(roboto.get(), {0xE4},
+                                                         {
+                                                             {0xD6},  // Ö
+                                                             {0xF6},  // ö
+                                                             smcp,
+                                                         },
+                                                         MergeStrategy::None());
+  auto dep_graph_segmentation =
+      segmenter_dep_graph.CodepointToGlyphSegments(roboto.get(), {0xE4},
+                                                   {
+                                                       {0xD6},  // Ö
+                                                       {0xF6},  // ö
+                                                       smcp,
+                                                   },
+                                                   MergeStrategy::None());
+  auto dep_graph_only_segmentation =
+      segmenter_dep_graph_only.CodepointToGlyphSegments(roboto.get(), {0xE4},
+                                                        {
+                                                            {0xD6},  // Ö
+                                                            {0xF6},  // ö
+                                                            smcp,
+                                                        },
+                                                        MergeStrategy::None());
+
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+  ASSERT_TRUE(dep_graph_segmentation.ok()) << dep_graph_segmentation.status();
+  ASSERT_TRUE(dep_graph_only_segmentation.ok()) << dep_graph_only_segmentation.status();
 
   // Note: gid839 is the small caps O dieresis, it's currently mapped with
   // condition 'if {smcp}', the true condition is 'if {smcp} AND {Ö or ö}'
@@ -1575,6 +1711,28 @@ p2: { gid477, gid563, gid822, gid839 }
 if (s0) then p0
 if (s1) then p1
 if (s2) then p2
+)");
+
+  ASSERT_EQ(dep_graph_segmentation->ToString(),
+            R"(initial font: { gid0, gid69, gid106, gid670 }
+p0: { gid51, gid660 }
+p1: { gid83, gid687 }
+p2: { gid477, gid563, gid822, gid839 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+)");
+
+  ASSERT_EQ(dep_graph_only_segmentation->ToString(),
+            R"(initial font: { gid0, gid69, gid106, gid670 }
+p0: { gid51, gid660 }
+p1: { gid83, gid687 }
+p2: { gid563, gid822 }
+p3: { gid477, gid839 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+if ((s0 OR s1) AND s2) then p3
 )");
 
   // Rerun segmentation with merging of Ö and ö allowed, should now get

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -54,6 +54,7 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
                                               CLOSURE_AND_VALIDATE_DEP_GRAPH)
 #else
         segmenter_dep_graph(8, 8, PATCH, CLOSURE_ONLY),
+        segmenter_dep_graph_only(8, 8, PATCH, CLOSURE_ONLY),
         segmenter_find_conditions_dep_graph(8, 8, FIND_CONDITIONS,
                                             CLOSURE_ONLY),
         segmenter_move_to_init_font_dep_graph(8, 8, MOVE_TO_INIT_FONT,
@@ -350,6 +351,8 @@ if ((s1 OR s2)) then p1
 if ((s0 OR s1 OR s2)) then p2
 )");
   ASSERT_EQ(segmentation->ToString(), dep_graph_segmentation->ToString());
+
+#ifdef HB_DEPEND_API
   ASSERT_EQ(dep_graph_only_segmentation->ToString(),
             R"(initial font: { gid0, gid69 }
 p0: { gid74 }
@@ -359,6 +362,7 @@ if ((s0 OR s2)) then p0
 if ((s1 OR s2)) then p1
 if ((s0 OR s2) AND (s1 OR s2)) then p2
 )");
+#endif
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SegmentationWithFeatures) {
@@ -581,6 +585,7 @@ if ((s0 OR s1 OR s2 OR s3)) then p6
 )");
   ASSERT_EQ(segmentation->ToString(), dep_graph_segmentation->ToString());
 
+#ifdef HB_DEPEND_API
   ASSERT_EQ(dep_graph_only_segmentation->ToString(),
             R"(initial font: { gid0 }
 p0: { gid3, gid9, gid155 }
@@ -602,6 +607,7 @@ if ((s0 OR s1 OR s2 OR s3)) then p6
 if ((s0 OR s1) AND s2) then p7
 if ((s0 OR s1) AND (s2 OR s3)) then p8
 )");
+#endif
 }
 
 TEST_F(ClosureGlyphSegmenterTest, UnmappedGlyphs_FindConditions) {
@@ -634,6 +640,7 @@ if ((s1 OR s2 OR s3 OR s4)) then p7
 )");
 }
 
+#ifdef HB_DEPEND_API
 TEST_F(ClosureGlyphSegmenterTest, DepGraphOnly_FindConditions) {
   auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
       noto_nastaliq_urdu.get(), {},
@@ -667,6 +674,7 @@ if ((s1 OR s2) AND s3) then p8
 if ((s1 OR s2) AND (s3 OR s4)) then p9
 )");
 }
+#endif
 
 TEST_F(ClosureGlyphSegmenterTest, UnmappedGlyphs_FindConditions_IsFallback) {
   // Here the found conditions are equal to the fallback segment, this ensures
@@ -1678,8 +1686,6 @@ TEST_F(ClosureGlyphSegmenterTest, ConjunctiveAdditionalConditions) {
   smcp.feature_tags.insert(HB_TAG('s', 'm', 'c', 'p'));
   smcp.feature_tags.insert(HB_TAG('c', '2', 's', 'c'));
 
-  // XXXX
-
   auto segmentation = segmenter.CodepointToGlyphSegments(roboto.get(), {0xE4},
                                                          {
                                                              {0xD6},  // Ö
@@ -1732,6 +1738,7 @@ if (s1) then p1
 if (s2) then p2
 )");
 
+#ifdef HB_DEPEND_API
   ASSERT_EQ(dep_graph_only_segmentation->ToString(),
             R"(initial font: { gid0, gid69, gid106, gid670 }
 p0: { gid51, gid660 }
@@ -1743,6 +1750,7 @@ if (s1) then p1
 if (s2) then p2
 if ((s0 OR s1) AND s2) then p3
 )");
+#endif
 
   // Rerun segmentation with merging of Ö and ö allowed, should now get
   // the true condition.

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -82,8 +82,9 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
       std::optional<MergeStrategy> strategy = std::nullopt) const {
     auto segmentation = TRY(segmenter.CodepointToGlyphSegments(
         face, initial_segment, subset_definitions, strategy));
-    auto dep_graph_segmentation = TRY(segmenter_dep_graph.CodepointToGlyphSegments(
-        face, initial_segment, subset_definitions, strategy));
+    auto dep_graph_segmentation =
+        TRY(segmenter_dep_graph.CodepointToGlyphSegments(
+            face, initial_segment, subset_definitions, strategy));
     auto dep_graph_only_segmentation =
         TRY(segmenter_dep_graph_only.CodepointToGlyphSegments(
             face, initial_segment, subset_definitions, strategy));
@@ -94,8 +95,10 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
           "the non-dep graph version.");
     }
     if (segmentation != dep_graph_only_segmentation) {
-      std::cerr << "Closure segmentation: " << segmentation.ToString() << std::endl;
-      std::cerr << "Dep graph only segmentation: " << dep_graph_only_segmentation.ToString() << std::endl;
+      std::cerr << "Closure segmentation: " << segmentation.ToString()
+                << std::endl;
+      std::cerr << "Dep graph only segmentation: "
+                << dep_graph_only_segmentation.ToString() << std::endl;
       return absl::InternalError(
           "Basic segmenter: segmentation from dep graph only is not equivalent "
           "to "
@@ -111,8 +114,9 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
       btree_map<SegmentSet, MergeStrategy> merge_groups) const {
     auto segmentation = TRY(segmenter.CodepointToGlyphSegments(
         face, initial_segment, subset_definitions, merge_groups));
-    auto dep_graph_segmentation = TRY(segmenter_dep_graph.CodepointToGlyphSegments(
-        face, initial_segment, subset_definitions, merge_groups));
+    auto dep_graph_segmentation =
+        TRY(segmenter_dep_graph.CodepointToGlyphSegments(
+            face, initial_segment, subset_definitions, merge_groups));
     auto dep_graph_only_segmentation =
         TRY(segmenter_dep_graph_only.CodepointToGlyphSegments(
             face, initial_segment, subset_definitions, merge_groups));
@@ -123,8 +127,10 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
           "the non-dep graph version.");
     }
     if (segmentation != dep_graph_only_segmentation) {
-      std::cerr << "Closure segmentation: " << segmentation.ToString() << std::endl;
-      std::cerr << "Dep graph only segmentation: " << dep_graph_only_segmentation.ToString() << std::endl;
+      std::cerr << "Closure segmentation: " << segmentation.ToString()
+                << std::endl;
+      std::cerr << "Dep graph only segmentation: "
+                << dep_graph_only_segmentation.ToString() << std::endl;
       return absl::InternalError(
           "Basic segmenter: segmentation from dep graph only is not equivalent "
           "to "
@@ -320,12 +326,13 @@ if ((s0 OR s1)) then p1
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SegmentationWithAdditionalConditionOverlap) {
-  auto segmentation =
-      segmenter.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
-  auto dep_graph_segmentation =
-      segmenter_dep_graph.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
+  auto segmentation = segmenter.CodepointToGlyphSegments(
+      roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
+  auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
+      roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
   auto dep_graph_only_segmentation =
-      segmenter_dep_graph_only.CodepointToGlyphSegments(roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
+      segmenter_dep_graph_only.CodepointToGlyphSegments(
+          roboto.get(), {'a'}, {{'f'}, {'i'}, {'f', 'i'}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_only_segmentation.ok()) << segmentation.status();
@@ -546,8 +553,9 @@ TEST_F(ClosureGlyphSegmenterTest, UnmappedGlyphs_FallbackSegment) {
       noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
   auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
       noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
-  auto dep_graph_only_segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
-      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
+  auto dep_graph_only_segmentation =
+      segmenter_dep_graph_only.CodepointToGlyphSegments(
+          noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_only_segmentation.ok()) << segmentation.status();
@@ -746,8 +754,9 @@ TEST_F(ClosureGlyphSegmenterTest, FullRoboto_WithFeaturesAndDepGraph) {
       roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
   auto dep_graph_segmentation = segmenter_dep_graph.CodepointToGlyphSegments(
       roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
-  auto dep_graph_only_segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
-      roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
+  auto dep_graph_only_segmentation =
+      segmenter_dep_graph_only.CodepointToGlyphSegments(
+          roboto.get(), {}, segments, MergeStrategy::Heuristic(4000, 12000));
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_only_segmentation.ok()) << segmentation.status();
@@ -1082,8 +1091,7 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
 
   // Basic no segment case.
   GlyphSegmentation segmentation1({'a', 'b', 'c'}, {}, {});
-  auto sc =
-      GlyphSegmentation::ConditionsToSegmentation({}, {}, segmentation1);
+  auto sc = GlyphSegmentation::ConditionsToSegmentation({}, {}, segmentation1);
   ASSERT_TRUE(sc.ok()) << sc;
 
   ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY);
@@ -1096,11 +1104,11 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
   // Add some patches
   GlyphSegmentation segmentation2({'a', 'b', 'c'}, {}, {});
   sc = GlyphSegmentation::ConditionsToSegmentation(
-                                               {
-                                                   {ActivationCondition::exclusive_segment(0, 0), {100, 101, 102}},
-                                                   {ActivationCondition::exclusive_segment(1, 0), {103, 104, 105}},
-                                               },
-                                               {}, segmentation2);
+      {
+          {ActivationCondition::exclusive_segment(0, 0), {100, 101, 102}},
+          {ActivationCondition::exclusive_segment(1, 0), {103, 104, 105}},
+      },
+      {}, segmentation2);
   ASSERT_TRUE(sc.ok()) << sc;
 
   std::vector<SubsetDefinition> segments{
@@ -1698,7 +1706,8 @@ TEST_F(ClosureGlyphSegmenterTest, ConjunctiveAdditionalConditions) {
 
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
   ASSERT_TRUE(dep_graph_segmentation.ok()) << dep_graph_segmentation.status();
-  ASSERT_TRUE(dep_graph_only_segmentation.ok()) << dep_graph_only_segmentation.status();
+  ASSERT_TRUE(dep_graph_only_segmentation.ok())
+      << dep_graph_only_segmentation.status();
 
   // Note: gid839 is the small caps O dieresis, it's currently mapped with
   // condition 'if {smcp}', the true condition is 'if {smcp} AND {Ö or ö}'

--- a/ift/encoder/dependency_closure.cc
+++ b/ift/encoder/dependency_closure.cc
@@ -135,6 +135,19 @@ void DependencyClosure::UpdateNodeConditionsCache(
   }
 }
 
+// TODO XXXXX add unit test.
+GlyphSet DependencyClosure::SegmentsToAffectedGlyphs(
+    const SegmentSet& segments) const {
+  auto nodes = SegmentsToAffectedNodeConditions(segments);
+  GlyphSet out;
+  for (auto node : nodes) {
+    if (node.IsGlyph()) {
+      out.insert(node.Id());
+    }
+  }
+  return out;
+}
+
 flat_hash_set<Node> DependencyClosure::SegmentsToAffectedNodeConditions(
     const SegmentSet& segments) const {
   flat_hash_set<Node> nodes;

--- a/ift/encoder/dependency_closure.cc
+++ b/ift/encoder/dependency_closure.cc
@@ -135,7 +135,6 @@ void DependencyClosure::UpdateNodeConditionsCache(
   }
 }
 
-// TODO XXXXX add unit test.
 GlyphSet DependencyClosure::SegmentsToAffectedGlyphs(
     const SegmentSet& segments) const {
   auto nodes = SegmentsToAffectedNodeConditions(segments);

--- a/ift/encoder/dependency_closure.h
+++ b/ift/encoder/dependency_closure.h
@@ -96,6 +96,9 @@ class DependencyClosure {
 
   common::GlyphSet SegmentsToAffectedGlyphs(
       const common::SegmentSet& segments) const;
+
+  absl::flat_hash_set<dep_graph::Node> SegmentsToAffectedNodeConditions(
+      const common::SegmentSet& segments) const;
 #endif
 
   // This structure caches information derived from the segmentation info
@@ -181,8 +184,6 @@ class DependencyClosure {
   absl::Status InitNodeConditionsCache();
   void UpdateNodeConditionsCache(segment_index_t base_segment,
                                  const common::SegmentSet& segments);
-  absl::flat_hash_set<dep_graph::Node> SegmentsToAffectedNodeConditions(
-      const common::SegmentSet& segments) const;
 
   const RequestedSegmentationInformation* segmentation_info_;
   ift::common::hb_face_unique_ptr original_face_;

--- a/ift/encoder/dependency_closure.h
+++ b/ift/encoder/dependency_closure.h
@@ -93,6 +93,9 @@ class DependencyClosure {
   AllGlyphConditions() const {
     return glyph_condition_cache_;
   }
+
+  common::GlyphSet SegmentsToAffectedGlyphs(
+      const common::SegmentSet& segments) const;
 #endif
 
   // This structure caches information derived from the segmentation info

--- a/ift/encoder/dependency_closure_test.cc
+++ b/ift/encoder/dependency_closure_test.cc
@@ -21,6 +21,7 @@ using ift::config::PATCH;
 
 using absl::btree_set;
 using absl::flat_hash_map;
+using absl::flat_hash_set;
 using absl::Status;
 using ift::common::CodepointSet;
 using ift::common::FontData;
@@ -1002,6 +1003,39 @@ TEST_F(DependencyClosureTest, InitFontFeatureConjunction) {
 
   s = CompareAnalysis({0, 1});
   ASSERT_TRUE(s.ok()) << s;
+}
+
+TEST_F(DependencyClosureTest, SegmentsToAffected) {
+  Reconfigure(WithDefaultFeatures(),
+              {
+                  /* 0 */ {{'a'}, ProbabilityBound::Zero()},
+                  /* 1 */ {{'f'}, ProbabilityBound::Zero()},
+                  /* 2 */ {{'i'}, ProbabilityBound::Zero()},
+                  /* 3 */ {{'q'}, ProbabilityBound::Zero()},
+                  /* 4 */ {{'A'}, ProbabilityBound::Zero()},
+                  /* 5 */ {{0xC1 /* Aacute */}, ProbabilityBound::Zero()},
+              });
+
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({0}), (GlyphSet{69 /* a */}));
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({1}),
+            (GlyphSet{74 /* f */, 444 /* fi */, 446 /* ffi */}));
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({2}),
+            (GlyphSet{77 /* i */, 444 /* fi */, 446 /* ffi */}));
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({4}), (GlyphSet{37 /* A */}));
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({5}),
+            (GlyphSet{37 /* A */, 117 /* acute */, 640 /* Aacute */}));
+
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({1, 2}),
+            (GlyphSet{74, 77, 444, 446}));
+
+  auto nodes = dependency_closure->SegmentsToAffectedNodeConditions({1});
+  EXPECT_EQ(nodes, (flat_hash_set<Node>{
+    Node::Segment(1),
+    Node::Unicode('f'),
+    Node::Glyph(74),
+    Node::Glyph(444),
+    Node::Glyph(446)
+  }));
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/glyph_closure_cache.cc
+++ b/ift/encoder/glyph_closure_cache.cc
@@ -190,8 +190,13 @@ StatusOr<SubsetDefinition> GlyphClosureCache::ExpandClosure(
   while (changed) {
     GlyphSet closure_gids = TRY(GlyphClosure(expanded));
 
-    CodepointSet closure_unicodes =
-        FontHelper::GidsToUnicodes(Face(), closure_gids);
+    CodepointSet closure_unicodes;
+    for (glyph_id_t gid : closure_gids) {
+      auto unicode = gid_to_unicode_.find(gid);
+      if (unicode != gid_to_unicode_.end()) {
+        closure_unicodes.union_set(unicode->second);
+      }
+    }
 
     changed = false;
     if (!closure_gids.is_subset_of(expanded.gids)) {

--- a/ift/encoder/glyph_closure_cache.h
+++ b/ift/encoder/glyph_closure_cache.h
@@ -21,7 +21,8 @@ class GlyphClosureCache {
       : preprocessed_face_(
             ift::common::make_hb_face(hb_subset_preprocess(face))),
         original_face_(ift::common::make_hb_face(hb_face_reference(face))),
-        gid_to_unicode_(common::FontHelper::GidToUnicodeMap(preprocessed_face_.get())) {}
+        gid_to_unicode_(
+            common::FontHelper::GidToUnicodeMap(preprocessed_face_.get())) {}
 
   absl::StatusOr<ift::common::GlyphSet> GlyphClosure(
       const SubsetDefinition& segment);

--- a/ift/encoder/glyph_closure_cache.h
+++ b/ift/encoder/glyph_closure_cache.h
@@ -4,6 +4,7 @@
 #include "absl/status/status.h"
 #include "hb-subset.h"
 #include "ift/common/font_data.h"
+#include "ift/common/font_helper.h"
 #include "ift/common/int_set.h"
 #include "ift/encoder/subset_definition.h"
 
@@ -19,7 +20,8 @@ class GlyphClosureCache {
   GlyphClosureCache(hb_face_t* face)
       : preprocessed_face_(
             ift::common::make_hb_face(hb_subset_preprocess(face))),
-        original_face_(ift::common::make_hb_face(hb_face_reference(face))) {}
+        original_face_(ift::common::make_hb_face(hb_face_reference(face))),
+        gid_to_unicode_(common::FontHelper::GidToUnicodeMap(preprocessed_face_.get())) {}
 
   absl::StatusOr<ift::common::GlyphSet> GlyphClosure(
       const SubsetDefinition& segment);
@@ -63,6 +65,7 @@ class GlyphClosureCache {
       glyph_closure_cache_;
   uint64_t glyph_closure_cache_hit_ = 0;
   uint64_t glyph_closure_cache_miss_ = 0;
+  absl::flat_hash_map<uint32_t, common::CodepointSet> gid_to_unicode_;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/glyph_condition_set.h
+++ b/ift/encoder/glyph_condition_set.h
@@ -89,6 +89,14 @@ class GlyphConditionSet {
     segment_to_gid_conditions_[segment].insert(gid);
   }
 
+  void SetCondition(glyph_id_t gid, ActivationCondition condition) {
+    common::SegmentSet segments = condition.TriggeringSegments();
+    gid_conditions_[gid].condition_ = std::move(condition);
+    for (segment_index_t s : segments) {
+      segment_to_gid_conditions_[s].insert(gid);
+    }
+  }
+
   // Returns the set of glyphs that have 'segment' in their conditions.
   const ift::common::GlyphSet& GlyphsWithSegment(
       segment_index_t segment) const {

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -144,14 +144,24 @@ StatusOr<GlyphSegmentation> GlyphGroupings::ToGlyphSegmentation(
   // The fallback patch isn't stored in ConditionAndGlyphs() so add it in
   // manually.
   SegmentSet fallback_segments;
+  auto conditions_with_fallback = ConditionsAndGlyphs();
   if (!unmapped_glyphs_.empty()) {
     fallback_segments = segmentation_info.NonEmptySegments();
-    or_glyph_groups[fallback_segments].union_set(unmapped_glyphs_);
+
+    ActivationCondition non_fallback_cond = ActivationCondition::or_segments(fallback_segments, 0, false);
+    ActivationCondition fallback_cond = ActivationCondition::or_segments(fallback_segments, 0, true);
+
+    if (conditions_with_fallback.contains(non_fallback_cond)) {
+      // If an equivalent non-fallback condition exists merge it with the fallback one.
+      conditions_with_fallback[fallback_cond].union_set(conditions_with_fallback[non_fallback_cond]);
+      conditions_with_fallback.erase(non_fallback_cond);
+    }
+
+    conditions_with_fallback[fallback_cond].union_set(unmapped_glyphs_);
   }
 
-  TRYV(GlyphSegmentation::GroupsToSegmentation(
-      and_glyph_groups, or_glyph_groups, exclusive_glyph_groups,
-      fallback_segments, segmentation));
+  TRYV(GlyphSegmentation::ConditionsToSegmentation(
+      conditions_with_fallback, fallback_segments, segmentation));
 
   return segmentation;
 }
@@ -161,7 +171,7 @@ Status GlyphGroupings::GroupGlyphs(
     const GlyphConditionSet& glyph_condition_set,
     GlyphClosureCache& closure_cache,
     std::optional<DependencyClosure*> dependency_closure, GlyphSet glyphs,
-    const SegmentSet& modified_segments) {
+    const SegmentSet& modified_segments, bool additional_conditions_check) {
   const auto& initial_closure = segmentation_info.InitFontGlyphs();
   SegmentSet inscope_fallback_segments;
 
@@ -241,6 +251,13 @@ Status GlyphGroupings::GroupGlyphs(
   // used.
   for (const auto& or_group : modified_or_groups) {
     auto& glyphs = or_glyph_groups_[or_group];
+    ActivationCondition condition =
+        ActivationCondition::or_segments(or_group, 0);
+
+    if (!additional_conditions_check) {
+      TRYV(AddConditionAndGlyphs(condition, glyphs));
+      continue;
+    }
 
     SegmentSet all_other_segment_ids;
     if (!segmentation_info.Segments().empty()) {
@@ -262,8 +279,6 @@ Status GlyphGroupings::GroupGlyphs(
       }
     }
 
-    ActivationCondition condition =
-        ActivationCondition::or_segments(or_group, 0);
     if (glyphs.empty()) {
       // Group has been emptied out, so it's no longer needed.
       or_glyph_groups_.erase(or_group);

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -148,12 +148,16 @@ StatusOr<GlyphSegmentation> GlyphGroupings::ToGlyphSegmentation(
   if (!unmapped_glyphs_.empty()) {
     fallback_segments = segmentation_info.NonEmptySegments();
 
-    ActivationCondition non_fallback_cond = ActivationCondition::or_segments(fallback_segments, 0, false);
-    ActivationCondition fallback_cond = ActivationCondition::or_segments(fallback_segments, 0, true);
+    ActivationCondition non_fallback_cond =
+        ActivationCondition::or_segments(fallback_segments, 0, false);
+    ActivationCondition fallback_cond =
+        ActivationCondition::or_segments(fallback_segments, 0, true);
 
     if (conditions_with_fallback.contains(non_fallback_cond)) {
-      // If an equivalent non-fallback condition exists merge it with the fallback one.
-      conditions_with_fallback[fallback_cond].union_set(conditions_with_fallback[non_fallback_cond]);
+      // If an equivalent non-fallback condition exists merge it with the
+      // fallback one.
+      conditions_with_fallback[fallback_cond].union_set(
+          conditions_with_fallback[non_fallback_cond]);
       conditions_with_fallback.erase(non_fallback_cond);
     }
 

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -134,7 +134,8 @@ class GlyphGroupings {
       GlyphClosureCache& closure_cache,
       std::optional<DependencyClosure*> dependency_closure,
       ift::common::GlyphSet glyphs,
-      const ift::common::SegmentSet& modified_segments);
+      const ift::common::SegmentSet& modified_segments,
+      bool additional_conditions_check = true);
 
   // Converts this grouping into a finalized GlyphSegmentation.
   absl::StatusOr<GlyphSegmentation> ToGlyphSegmentation(

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -10,6 +10,7 @@
 #include "absl/status/statusor.h"
 #include "ift/common/font_helper.h"
 #include "ift/common/int_set.h"
+#include "ift/encoder/activation_condition.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
@@ -37,50 +38,32 @@ using ift::proto::PatchMap;
 
 namespace ift::encoder {
 
-Status GlyphSegmentation::GroupsToSegmentation(
-    const btree_map<SegmentSet, GlyphSet>& and_glyph_groups,
-    const btree_map<SegmentSet, GlyphSet>& or_glyph_groups,
-    const btree_map<segment_index_t, GlyphSet>& exclusive_glyph_groups,
-    const SegmentSet& fallback_group, GlyphSegmentation& segmentation) {
+Status GlyphSegmentation::ConditionsToSegmentation(const btree_map<ActivationCondition, GlyphSet>& conditions,
+    const SegmentSet& fallback_group,
+    GlyphSegmentation& segmentation) {
+
   patch_id_t next_id = 0;
   segmentation.patches_.clear();
   segmentation.conditions_.clear();
 
-  // Map segments into patch ids
-  for (const auto& [segment, glyphs] : exclusive_glyph_groups) {
-    segmentation.patches_.insert(std::pair(next_id, glyphs));
-    segmentation.conditions_.insert(
-        ActivationCondition::exclusive_segment(segment, next_id++));
-  }
+  for (const auto& [condition, glyphs] : conditions) {
 
-  for (const auto& [and_segments, glyphs] : and_glyph_groups) {
-    segmentation.patches_.insert(std::pair(next_id, glyphs));
-    segmentation.conditions_.insert(
-        ActivationCondition::and_segments(and_segments, next_id));
-
-    next_id++;
-  }
-
-  for (const auto& [or_segments, glyphs] : or_glyph_groups) {
     if (glyphs.empty()) {
-      // Some or_segments have all of their glyphs removed by the additional
+      // Some conditions have all of their glyphs removed by the additional
       // conditions check, don't create a patch for these.
       continue;
     }
 
-    if (or_segments.size() == 1) {
-      return absl::InternalError(
-          StrCat("Unexpected or_segment with only one segment: s",
-                 *or_segments.begin()));
-    }
-
-    bool is_fallback =
-        !fallback_group.empty() && (or_segments == fallback_group);
     segmentation.patches_.insert(std::pair(next_id, glyphs));
-    segmentation.conditions_.insert(
-        ActivationCondition::or_segments(or_segments, next_id, is_fallback));
 
-    next_id++;
+    if (condition.IsExclusive()) {
+      segmentation.conditions_.insert(
+        ActivationCondition::exclusive_segment(*condition.TriggeringSegments().begin(), next_id++));
+    } else {
+      bool is_fallback =
+        !fallback_group.empty() && condition.IsPurelyConjunctive() && (condition.TriggeringSegments() == fallback_group);
+      segmentation.conditions_.insert(ActivationCondition::composite_condition(condition.conditions(), next_id++, is_fallback));
+    }
   }
 
   return absl::OkStatus();

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -59,7 +59,7 @@ Status GlyphSegmentation::ConditionsToSegmentation(
           *condition.TriggeringSegments().begin(), next_id++));
     } else {
       bool is_fallback = !fallback_group.empty() &&
-                         condition.IsPurelyConjunctive() &&
+                         condition.IsPurelyDisjunctive() &&
                          (condition.TriggeringSegments() == fallback_group);
       segmentation.conditions_.insert(ActivationCondition::composite_condition(
           condition.conditions(), next_id++, is_fallback));

--- a/ift/encoder/glyph_segmentation.cc
+++ b/ift/encoder/glyph_segmentation.cc
@@ -38,16 +38,14 @@ using ift::proto::PatchMap;
 
 namespace ift::encoder {
 
-Status GlyphSegmentation::ConditionsToSegmentation(const btree_map<ActivationCondition, GlyphSet>& conditions,
-    const SegmentSet& fallback_group,
-    GlyphSegmentation& segmentation) {
-
+Status GlyphSegmentation::ConditionsToSegmentation(
+    const btree_map<ActivationCondition, GlyphSet>& conditions,
+    const SegmentSet& fallback_group, GlyphSegmentation& segmentation) {
   patch_id_t next_id = 0;
   segmentation.patches_.clear();
   segmentation.conditions_.clear();
 
   for (const auto& [condition, glyphs] : conditions) {
-
     if (glyphs.empty()) {
       // Some conditions have all of their glyphs removed by the additional
       // conditions check, don't create a patch for these.
@@ -57,12 +55,14 @@ Status GlyphSegmentation::ConditionsToSegmentation(const btree_map<ActivationCon
     segmentation.patches_.insert(std::pair(next_id, glyphs));
 
     if (condition.IsExclusive()) {
-      segmentation.conditions_.insert(
-        ActivationCondition::exclusive_segment(*condition.TriggeringSegments().begin(), next_id++));
+      segmentation.conditions_.insert(ActivationCondition::exclusive_segment(
+          *condition.TriggeringSegments().begin(), next_id++));
     } else {
-      bool is_fallback =
-        !fallback_group.empty() && condition.IsPurelyConjunctive() && (condition.TriggeringSegments() == fallback_group);
-      segmentation.conditions_.insert(ActivationCondition::composite_condition(condition.conditions(), next_id++, is_fallback));
+      bool is_fallback = !fallback_group.empty() &&
+                         condition.IsPurelyConjunctive() &&
+                         (condition.TriggeringSegments() == fallback_group);
+      segmentation.conditions_.insert(ActivationCondition::composite_condition(
+          condition.conditions(), next_id++, is_fallback));
     }
   }
 

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -105,15 +105,9 @@ class GlyphSegmentation {
 
   ift::config::SegmentationPlan ToSegmentationPlanProto() const;
 
-  static absl::Status GroupsToSegmentation(
-      const absl::btree_map<ift::common::SegmentSet, ift::common::GlyphSet>&
-          and_glyph_groups,
-      const absl::btree_map<ift::common::SegmentSet, ift::common::GlyphSet>&
-          or_glyph_groups,
-      const absl::btree_map<segment_index_t, ift::common::GlyphSet>&
-          exclusive_glyph_groups,
-      const ift::common::SegmentSet& fallback_group,
-      GlyphSegmentation& segmentation);
+  static absl::Status ConditionsToSegmentation(const absl::btree_map<ActivationCondition, common::GlyphSet>& conditions,
+    const common::SegmentSet& fallback_group,
+    GlyphSegmentation& segmentation);
 
   void CopySegments(const std::vector<SubsetDefinition>& segments);
 

--- a/ift/encoder/glyph_segmentation.h
+++ b/ift/encoder/glyph_segmentation.h
@@ -105,9 +105,10 @@ class GlyphSegmentation {
 
   ift::config::SegmentationPlan ToSegmentationPlanProto() const;
 
-  static absl::Status ConditionsToSegmentation(const absl::btree_map<ActivationCondition, common::GlyphSet>& conditions,
-    const common::SegmentSet& fallback_group,
-    GlyphSegmentation& segmentation);
+  static absl::Status ConditionsToSegmentation(
+      const absl::btree_map<ActivationCondition, common::GlyphSet>& conditions,
+      const common::SegmentSet& fallback_group,
+      GlyphSegmentation& segmentation);
 
   void CopySegments(const std::vector<SubsetDefinition>& segments);
 

--- a/ift/encoder/glyph_segmentation_test.cc
+++ b/ift/encoder/glyph_segmentation_test.cc
@@ -325,14 +325,14 @@ glyph_patches {
 glyph_patches {
   key: 2
   value {
-    values: 444
-    values: 446
+    values: 117
   }
 }
 glyph_patches {
   key: 3
   value {
-    values: 117
+    values: 444
+    values: 446
   }
 }
 glyph_patch_conditions {
@@ -352,7 +352,7 @@ glyph_patch_conditions {
     values: 0
     values: 1
   }
-  activated_patch: 3
+  activated_patch: 2
 }
 glyph_patch_conditions {
   required_segments {
@@ -361,7 +361,7 @@ glyph_patch_conditions {
   required_segments {
     values: 1
   }
-  activated_patch: 2
+  activated_patch: 3
 }
 initial_codepoints {
   values: 97

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -57,6 +57,31 @@ Status SegmentationContext::ValidateSegmentation(
   return absl::OkStatus();
 }
 
+Status SegmentationContext::ReprocessChanged(InvalidationSet modified) {
+  segment_index_t last_merged_segment_index = modified.base_segment;
+  GlyphSet analysis_modified_gids;
+  if (!InertSegments().contains(last_merged_segment_index)) {
+    VLOG(1) << "Re-analyzing segment " << last_merged_segment_index
+            << " due to merge.";
+    analysis_modified_gids =
+        TRY(ReprocessSegment(last_merged_segment_index));
+  }
+
+  modified.glyphs.union_set(analysis_modified_gids);
+
+  return GroupGlyphs(modified.glyphs, modified.segments);
+}
+
+Status SegmentationContext::ReprocessAll() {
+  for (segment_index_t segment_index = 0;
+       segment_index < SegmentationInfo().Segments().size();
+       segment_index++) {
+    TRY(ReprocessSegment(segment_index));
+  }
+
+  return GroupGlyphs(SegmentationInfo().NonInitFontGlyphs(), {});
+}
+
 StatusOr<GlyphSet> SegmentationContext::ReprocessSegment(
     segment_index_t segment_index) {
   if (segmentation_info_->Segments()[segment_index].Definition().Empty()) {
@@ -269,13 +294,7 @@ SegmentationContext::InitializeSegmentationContext(
   // ### Generate the initial conditions and groupings by processing all
   // segments and glyphs. ###
   VLOG(0) << "Forming initial segmentation plan.";
-  for (segment_index_t segment_index = 0;
-       segment_index < context.SegmentationInfo().Segments().size();
-       segment_index++) {
-    TRY(context.ReprocessSegment(segment_index));
-  }
-
-  TRYV(context.GroupGlyphs(context.SegmentationInfo().NonInitFontGlyphs(), {}));
+  TRYV(context.ReprocessAll());
 
   return context;
 }

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -5,6 +5,7 @@
 #include "absl/status/status.h"
 #include "ift/common/int_set.h"
 #include "ift/common/try.h"
+#include "ift/encoder/activation_condition.h"
 #include "ift/encoder/dependency_closure.h"
 #include "ift/encoder/glyph_condition_set.h"
 #include "ift/encoder/glyph_segmentation.h"
@@ -15,6 +16,7 @@
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
 using ift::config::CLOSURE_ONLY;
 using ift::config::ConditionAnalysisMode;
+using ift::config::DEP_GRAPH_ONLY;
 using ift::config::UnmappedGlyphHandling;
 
 using absl::Status;
@@ -54,29 +56,59 @@ Status SegmentationContext::ValidateSegmentation(
         missing.ToString());
   }
 
+  for (const auto& condition : segmentation.Conditions()) {
+    auto it = segmentation.GidSegments().find(condition.activated());
+    if (it == segmentation.GidSegments().end()) {
+      return absl::FailedPreconditionError(absl::StrCat("Patch ", condition.activated(), " does not have glyphs specified"));
+    }
+
+    const auto& glyphs = it->second;
+    for (const auto& sub_group : condition.conditions()) {
+      if (TRY(glyph_closure_cache->HasAdditionalConditions(&SegmentationInfo(), sub_group, glyphs))) {
+        return absl::FailedPreconditionError(
+          absl::StrCat("Found a condition which does not satisfy the glyph closure requirement: ",
+          condition.ToString(), " ", glyphs.ToString(), ", sub group ", sub_group.ToString(), " failed the check."
+          ));
+      }
+    }
+  }
+
   return absl::OkStatus();
 }
 
 Status SegmentationContext::ReprocessChanged(InvalidationSet modified) {
   segment_index_t last_merged_segment_index = modified.base_segment;
-  GlyphSet analysis_modified_gids;
-  if (!InertSegments().contains(last_merged_segment_index)) {
-    VLOG(1) << "Re-analyzing segment " << last_merged_segment_index
-            << " due to merge.";
-    analysis_modified_gids =
-        TRY(ReprocessSegment(last_merged_segment_index));
-  }
 
-  modified.glyphs.union_set(analysis_modified_gids);
+  if (condition_analysis_mode_ != DEP_GRAPH_ONLY) {
+    if (!InertSegments().contains(last_merged_segment_index)) {
+      VLOG(1) << "Re-analyzing segment " << last_merged_segment_index
+              << " due to merge.";
+      GlyphSet analysis_modified_gids =
+          TRY(ReprocessSegment(last_merged_segment_index));
+      modified.glyphs.union_set(analysis_modified_gids);
+    }
+  } else {
+    modified.glyphs.union_set(
+        (*dependency_closure_)
+            ->SegmentsToAffectedGlyphs({modified.base_segment}));
+    TransferDependencyGraphGlyphConditions(modified.glyphs);
+  }
 
   return GroupGlyphs(modified.glyphs, modified.segments);
 }
 
 Status SegmentationContext::ReprocessAll() {
-  for (segment_index_t segment_index = 0;
-       segment_index < SegmentationInfo().Segments().size();
-       segment_index++) {
-    TRY(ReprocessSegment(segment_index));
+  if (condition_analysis_mode_ != DEP_GRAPH_ONLY) {
+    for (segment_index_t segment_index = 0;
+         segment_index < SegmentationInfo().Segments().size();
+         segment_index++) {
+      TRY(ReprocessSegment(segment_index));
+    }
+  } else {
+    // Pull conditions directly out of the dep graph instead of running closure
+    // processing.
+    TransferDependencyGraphGlyphConditions(
+        segmentation_info_->NonInitFontGlyphs());
   }
 
   return GroupGlyphs(SegmentationInfo().NonInitFontGlyphs(), {});
@@ -179,8 +211,16 @@ Status SegmentationContext::ReassignInitSubset(SubsetDefinition new_def) {
   inert_segments_.subtract(segments_to_reprocess);
 
   // Then reprocess segments:
-  for (segment_index_t segment_index : segments_to_reprocess) {
-    TRY(ReprocessSegment(segment_index));
+  if (condition_analysis_mode_ != DEP_GRAPH_ONLY) {
+    for (segment_index_t segment_index : segments_to_reprocess) {
+      TRY(ReprocessSegment(segment_index));
+    }
+  } else {
+    GlyphSet gids;
+    for (segment_index_t s : segments_to_reprocess) {
+      gids.union_set((*dependency_closure_)->SegmentsToAffectedGlyphs({s}));
+    }
+    TransferDependencyGraphGlyphConditions(gids);
   }
 
   // the groupings can be incrementally recomputed by looking at what conditions
@@ -297,6 +337,19 @@ SegmentationContext::InitializeSegmentationContext(
   TRYV(context.ReprocessAll());
 
   return context;
+}
+
+void SegmentationContext::TransferDependencyGraphGlyphConditions(
+    const GlyphSet& gids) {
+  const auto& conditions = (*dependency_closure_)->AllGlyphConditions();
+  for (glyph_id_t g : gids) {
+    ActivationCondition condition = conditions.at(g);
+    if (condition.IsUnitary()) {
+      condition = ActivationCondition::exclusive_segment(
+          *condition.TriggeringSegments().begin(), 0);
+    }
+    glyph_condition_set.SetCondition(g, condition);
+  }
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -91,10 +91,14 @@ Status SegmentationContext::ReprocessChanged(InvalidationSet modified) {
       modified.glyphs.union_set(analysis_modified_gids);
     }
   } else {
+#ifndef HB_DEPEND_API
+    return absl::InternalError("DEP_GRAPH_ONLY mode requires dependency graph support.");
+#else
     modified.glyphs.union_set(
         (*dependency_closure_)
             ->SegmentsToAffectedGlyphs({modified.base_segment}));
     TransferDependencyGraphGlyphConditions(modified.glyphs);
+#endif
   }
 
   return GroupGlyphs(modified.glyphs, modified.segments);
@@ -108,10 +112,14 @@ Status SegmentationContext::ReprocessAll() {
       TRY(ReprocessSegment(segment_index));
     }
   } else {
+#ifndef HB_DEPEND_API
+    return absl::InternalError("DEP_GRAPH_ONLY mode requires dependency graph support.");
+#else
     // Pull conditions directly out of the dep graph instead of running closure
     // processing.
     TransferDependencyGraphGlyphConditions(
         segmentation_info_->NonInitFontGlyphs());
+#endif
   }
 
   return GroupGlyphs(SegmentationInfo().NonInitFontGlyphs(), {});
@@ -219,11 +227,15 @@ Status SegmentationContext::ReassignInitSubset(SubsetDefinition new_def) {
       TRY(ReprocessSegment(segment_index));
     }
   } else {
+#ifndef HB_DEPEND_API
+    return absl::InternalError("DEP_GRAPH_ONLY mode requires dependency graph support.");
+#else
     GlyphSet gids;
     for (segment_index_t s : segments_to_reprocess) {
       gids.union_set((*dependency_closure_)->SegmentsToAffectedGlyphs({s}));
     }
     TransferDependencyGraphGlyphConditions(gids);
+#endif
   }
 
   // the groupings can be incrementally recomputed by looking at what conditions
@@ -344,6 +356,7 @@ SegmentationContext::InitializeSegmentationContext(
 
 void SegmentationContext::TransferDependencyGraphGlyphConditions(
     const GlyphSet& gids) {
+#ifdef HB_DEPEND_API
   const auto& conditions = (*dependency_closure_)->AllGlyphConditions();
   for (glyph_id_t g : gids) {
     ActivationCondition condition = conditions.at(g);
@@ -353,6 +366,7 @@ void SegmentationContext::TransferDependencyGraphGlyphConditions(
     }
     glyph_condition_set.SetCondition(g, condition);
   }
+#endif
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -59,16 +59,19 @@ Status SegmentationContext::ValidateSegmentation(
   for (const auto& condition : segmentation.Conditions()) {
     auto it = segmentation.GidSegments().find(condition.activated());
     if (it == segmentation.GidSegments().end()) {
-      return absl::FailedPreconditionError(absl::StrCat("Patch ", condition.activated(), " does not have glyphs specified"));
+      return absl::FailedPreconditionError(absl::StrCat(
+          "Patch ", condition.activated(), " does not have glyphs specified"));
     }
 
     const auto& glyphs = it->second;
     for (const auto& sub_group : condition.conditions()) {
-      if (TRY(glyph_closure_cache->HasAdditionalConditions(&SegmentationInfo(), sub_group, glyphs))) {
-        return absl::FailedPreconditionError(
-          absl::StrCat("Found a condition which does not satisfy the glyph closure requirement: ",
-          condition.ToString(), " ", glyphs.ToString(), ", sub group ", sub_group.ToString(), " failed the check."
-          ));
+      if (TRY(glyph_closure_cache->HasAdditionalConditions(
+              &SegmentationInfo(), sub_group, glyphs))) {
+        return absl::FailedPreconditionError(absl::StrCat(
+            "Found a condition which does not satisfy the glyph closure "
+            "requirement: ",
+            condition.ToString(), " ", glyphs.ToString(), ", sub group ",
+            sub_group.ToString(), " failed the check."));
       }
     }
   }

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -69,7 +69,8 @@ class SegmentationContext {
 
     if ((condition_analysis_mode == ift::config::CLOSURE_AND_DEP_GRAPH) ||
         (condition_analysis_mode ==
-         ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH)) {
+         ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH) ||
+        (condition_analysis_mode == ift::config::DEP_GRAPH_ONLY)) {
       context.dependency_closure_ = TRY(DependencyClosure::Create(
           context.segmentation_info_.get(), context.original_face.get()));
     }
@@ -239,10 +240,13 @@ class SegmentationContext {
     if (dependency_closure_.has_value()) {
       maybe_dep_closure = (*dependency_closure_).get();
     }
-    return glyph_groupings.GroupGlyphs(*segmentation_info_, glyph_condition_set,
-                                       *glyph_closure_cache, maybe_dep_closure,
-                                       glyphs, modified_segments);
+    return glyph_groupings.GroupGlyphs(
+        *segmentation_info_, glyph_condition_set, *glyph_closure_cache,
+        maybe_dep_closure, glyphs, modified_segments,
+        condition_analysis_mode_ != config::DEP_GRAPH_ONLY);
   }
+
+  void TransferDependencyGraphGlyphConditions(const common::GlyphSet& gids);
 
   // Generates updated glyph conditions and glyph groupings for segment_index
   // which has the provided set of codepoints.

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -18,6 +18,7 @@
 #include "ift/encoder/glyph_condition_set.h"
 #include "ift/encoder/glyph_groupings.h"
 #include "ift/encoder/glyph_segmentation.h"
+#include "ift/encoder/invalidation_set.h"
 #include "ift/encoder/patch_size_cache.h"
 #include "ift/encoder/requested_segmentation_information.h"
 #include "ift/encoder/segment.h"
@@ -210,6 +211,16 @@ class SegmentationContext {
    */
   absl::Status ReassignInitSubset(SubsetDefinition new_def);
 
+  // Regenerates glyphs conditions and groupings for the set of things specified
+  // in invalidation.
+  //
+  // Note: InvalidateGlyphInformationForMerge must be called first to clear out
+  // any old information.
+  absl::Status ReprocessChanged(InvalidationSet modified);
+
+  // Regenerates glyphs conditions and groupings for all segments.
+  absl::Status ReprocessAll();
+
   // Performs a closure analysis on codepoints and returns the associated
   // and, or, and exclusive glyph sets.
   absl::Status AnalyzeSegment(const ift::common::SegmentSet& segment_ids,
@@ -217,11 +228,7 @@ class SegmentationContext {
                               ift::common::GlyphSet& or_gids,
                               ift::common::GlyphSet& exclusive_gids);
 
-  // Generates updated glyph conditions and glyph groupings for segment_index
-  // which has the provided set of codepoints.
-  absl::StatusOr<ift::common::GlyphSet> ReprocessSegment(
-      segment_index_t segment_index);
-
+ private:
   // Update the glyph groups for 'glyphs'.
   //
   // The glyph condition set must be up to date and fully computed prior to
@@ -237,7 +244,11 @@ class SegmentationContext {
                                        glyphs, modified_segments);
   }
 
- private:
+  // Generates updated glyph conditions and glyph groupings for segment_index
+  // which has the provided set of codepoints.
+  absl::StatusOr<ift::common::GlyphSet> ReprocessSegment(
+      segment_index_t segment_index);
+
   /*
    * Ensures that the produce segmentation is:
    * - Disjoint (no duplicated glyphs) and doesn't overlap what's in the initial

--- a/ift/freq/bigram_probability_calculator.cc
+++ b/ift/freq/bigram_probability_calculator.cc
@@ -144,7 +144,7 @@ ProbabilityBound BigramProbabilityCalculator::ComputeMergedProbability(
 }
 
 ProbabilityBound BigramProbabilityCalculator::ComputeConjunctiveProbability(
-    const std::vector<const Segment*>& segments) const {
+    const std::vector<ProbabilityBound>& bounds) const {
   // Here we don't have access to pair probabilities between the segments so we
   // use a bound that relies only on the individual probabilities:
   //
@@ -154,14 +154,13 @@ ProbabilityBound BigramProbabilityCalculator::ComputeConjunctiveProbability(
   // min for the lower bound calc and the segment max for the upper bound calc.
   double sum = 0.0;
   double min_of_maxes = 1.0;
-  for (const Segment* s : segments) {
-    const auto& bound = s->ProbabilityBound();
+  for (const auto& bound : bounds) {
     sum += bound.Min();
     if (bound.Max() < min_of_maxes) {
       min_of_maxes = bound.Max();
     }
   }
-  double min_prob = sum - (double)segments.size() + 1.0;
+  double min_prob = sum - (double)bounds.size() + 1.0;
   return ProbabilityBound(std::max(0.0, min_prob), min_of_maxes);
 }
 

--- a/ift/freq/bigram_probability_calculator.h
+++ b/ift/freq/bigram_probability_calculator.h
@@ -25,7 +25,7 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
       const std::vector<const ift::encoder::Segment*>& segments) const override;
 
   ProbabilityBound ComputeConjunctiveProbability(
-      const std::vector<const ift::encoder::Segment*>& segments) const override;
+      const std::vector<ProbabilityBound>& bounds) const override;
 
  private:
   ProbabilityBound BigramProbabilityBound(

--- a/ift/freq/bigram_probability_calculator_test.cc
+++ b/ift/freq/bigram_probability_calculator_test.cc
@@ -135,16 +135,16 @@ TEST(BigramProbabilityCalculatorTest, ComputeConjunctiveProbability) {
   UnicodeFrequencies freqs;
   BigramProbabilityCalculator calculator(std::move(freqs));
 
-  Segment s1(SubsetDefinition({1}), ProbabilityBound(0.8, 0.9));
-  Segment s2(SubsetDefinition({2}), ProbabilityBound(0.7, 0.8));
+  ProbabilityBound b1(0.8, 0.9);
+  ProbabilityBound b2(0.7, 0.8);
 
-  std::vector<const Segment*> segments = {&s1, &s2};
+  std::vector<ProbabilityBound> bounds = {b1, b2};
 
   // sum(min) = 0.8 + 0.7 = 1.5
   // n = 2
   // min = 1.5 - 2 + 1 = 0.5
   // max = min(0.9, 0.8) = 0.8
-  ProbabilityBound result = calculator.ComputeConjunctiveProbability(segments);
+  ProbabilityBound result = calculator.ComputeConjunctiveProbability(bounds);
   ASSERT_DOUBLE_EQ(result.Min(), 0.5);
   ASSERT_DOUBLE_EQ(result.Max(), 0.8);
 }
@@ -153,17 +153,17 @@ TEST(BigramProbabilityCalculatorTest, ComputeConjunctiveProbability_Clamped) {
   UnicodeFrequencies freqs;
   BigramProbabilityCalculator calculator(std::move(freqs));
 
-  Segment s1(SubsetDefinition({1}), ProbabilityBound(0.1, 0.2));
-  Segment s2(SubsetDefinition({2}), ProbabilityBound(0.3, 0.4));
-  Segment s3(SubsetDefinition({3}), ProbabilityBound(0.5, 0.6));
+  ProbabilityBound b1(0.1, 0.2);
+  ProbabilityBound b2(0.3, 0.4);
+  ProbabilityBound b3(0.5, 0.6);
 
-  std::vector<const Segment*> segments = {&s1, &s2, &s3};
+  std::vector<ProbabilityBound> bounds = {b1, b2, b3};
 
   // sum(min) = 0.1 + 0.3 + 0.5 = 0.9
   // n = 3
   // min = max(0.0, 0.9 - 3 + 1) = 0.0
   // max = min(0.2, 0.4, 0.6) = 0.2
-  ProbabilityBound result = calculator.ComputeConjunctiveProbability(segments);
+  ProbabilityBound result = calculator.ComputeConjunctiveProbability(bounds);
   ASSERT_DOUBLE_EQ(result.Min(), 0.0);
   ASSERT_DOUBLE_EQ(result.Max(), 0.2);
 }
@@ -173,15 +173,15 @@ TEST(BigramProbabilityCalculatorTest,
   UnicodeFrequencies freqs;
   BigramProbabilityCalculator calculator(std::move(freqs));
 
-  Segment s1(SubsetDefinition({1}), ProbabilityBound(0.1, 0.2));
+  ProbabilityBound b1(0.1, 0.2);
 
-  std::vector<const Segment*> segments = {&s1};
+  std::vector<ProbabilityBound> bounds = {b1};
 
   // sum(min) = 0.1
   // n = 1
   // min = 0.1 - 1 + 1 = 0.1
   // max = 0.2
-  ProbabilityBound result = calculator.ComputeConjunctiveProbability(segments);
+  ProbabilityBound result = calculator.ComputeConjunctiveProbability(bounds);
   ASSERT_DOUBLE_EQ(result.Min(), 0.1);
   ASSERT_DOUBLE_EQ(result.Max(), 0.2);
 }
@@ -190,13 +190,13 @@ TEST(BigramProbabilityCalculatorTest, ComputeConjunctiveProbabilityNoSegments) {
   UnicodeFrequencies freqs;
   BigramProbabilityCalculator calculator(std::move(freqs));
 
-  std::vector<const Segment*> segments;
+  std::vector<ProbabilityBound> bounds;
 
   // sum(min) = 0
   // n = 0
   // min = 0 - 0 + 1 = 1.0
   // max = 1.0
-  ProbabilityBound result = calculator.ComputeConjunctiveProbability(segments);
+  ProbabilityBound result = calculator.ComputeConjunctiveProbability(bounds);
   ASSERT_DOUBLE_EQ(result.Min(), 1.0);
   ASSERT_DOUBLE_EQ(result.Max(), 1.0);
 }

--- a/ift/freq/mock_probability_calculator.h
+++ b/ift/freq/mock_probability_calculator.h
@@ -35,11 +35,10 @@ class MockProbabilityCalculator : public ProbabilityCalculator {
   }
 
   ProbabilityBound ComputeConjunctiveProbability(
-      const std::vector<const ift::encoder::Segment*>& segments)
-      const override {
+      const std::vector<ProbabilityBound>& bounds) const override {
     double probability = 1.0;
-    for (const auto* segment : segments) {
-      probability *= segment->Probability();
+    for (const auto& bound : bounds) {
+      probability *= bound.Average();
     }
     return {probability, probability};
   }

--- a/ift/freq/noop_probability_calculator.h
+++ b/ift/freq/noop_probability_calculator.h
@@ -23,8 +23,7 @@ class NoopProbabilityCalculator : public ProbabilityCalculator {
   }
 
   ProbabilityBound ComputeConjunctiveProbability(
-      const std::vector<const ift::encoder::Segment*>& segments)
-      const override {
+      const std::vector<ProbabilityBound>& bounds) const override {
     return {0.0, 0.0};
   }
 };

--- a/ift/freq/probability_calculator.h
+++ b/ift/freq/probability_calculator.h
@@ -30,7 +30,7 @@ class ProbabilityCalculator {
   // May use previously computed probability information in the segments
   // to speed up the computation.
   virtual ProbabilityBound ComputeConjunctiveProbability(
-      const std::vector<const ift::encoder::Segment*>& segments) const = 0;
+      const std::vector<ProbabilityBound>& bounds) const = 0;
 };
 
 }  // namespace ift::freq

--- a/ift/freq/unigram_probability_calculator.cc
+++ b/ift/freq/unigram_probability_calculator.cc
@@ -40,10 +40,10 @@ ProbabilityBound UnigramProbabilityCalculator::ComputeMergedProbability(
 }
 
 ProbabilityBound UnigramProbabilityCalculator::ComputeConjunctiveProbability(
-    const std::vector<const Segment*>& segments) const {
+    const std::vector<ProbabilityBound>& bounds) const {
   double probability = 1.0;
-  for (const auto* segment : segments) {
-    probability *= segment->Probability();
+  for (const auto& bound : bounds) {
+    probability *= bound.Average();
   }
   return {probability, probability};
 }

--- a/ift/freq/unigram_probability_calculator.h
+++ b/ift/freq/unigram_probability_calculator.h
@@ -21,7 +21,7 @@ class UnigramProbabilityCalculator : public ProbabilityCalculator {
       const std::vector<const ift::encoder::Segment*>& segments) const override;
 
   ProbabilityBound ComputeConjunctiveProbability(
-      const std::vector<const ift::encoder::Segment*>& segments) const override;
+      const std::vector<ProbabilityBound>& bounds) const override;
 
  private:
   UnicodeFrequencies frequencies_;

--- a/ift/freq/unigram_probability_calculator_test.cc
+++ b/ift/freq/unigram_probability_calculator_test.cc
@@ -82,7 +82,8 @@ TEST(UnigramProbabilityCalculatorTest, ComputeConjunctiveProbability) {
   EXPECT_DOUBLE_EQ(bound.Min(), 0.5 * 0.7);
   EXPECT_DOUBLE_EQ(bound.Max(), 0.5 * 0.7);
 
-  bounds = {s1.ProbabilityBound(), s3.ProbabilityBound(), s2.ProbabilityBound()};
+  bounds = {s1.ProbabilityBound(), s3.ProbabilityBound(),
+            s2.ProbabilityBound()};
   bound = calculator.ComputeConjunctiveProbability(bounds);
   EXPECT_DOUBLE_EQ(bound.Min(), 0.5 * 0.7 * 0.2);
   EXPECT_DOUBLE_EQ(bound.Max(), 0.5 * 0.7 * 0.2);

--- a/ift/freq/unigram_probability_calculator_test.cc
+++ b/ift/freq/unigram_probability_calculator_test.cc
@@ -72,23 +72,23 @@ TEST(UnigramProbabilityCalculatorTest, ComputeConjunctiveProbability) {
 
   UnigramProbabilityCalculator calculator(std::move(frequencies));
 
-  std::vector<const Segment *> segments{&s2};
-  ProbabilityBound bound = calculator.ComputeConjunctiveProbability(segments);
+  std::vector<ProbabilityBound> bounds{s2.ProbabilityBound()};
+  ProbabilityBound bound = calculator.ComputeConjunctiveProbability(bounds);
   EXPECT_DOUBLE_EQ(bound.Min(), 0.2);
   EXPECT_DOUBLE_EQ(bound.Max(), 0.2);
 
-  segments = {&s1, &s3};
-  bound = calculator.ComputeConjunctiveProbability(segments);
+  bounds = {s1.ProbabilityBound(), s3.ProbabilityBound()};
+  bound = calculator.ComputeConjunctiveProbability(bounds);
   EXPECT_DOUBLE_EQ(bound.Min(), 0.5 * 0.7);
   EXPECT_DOUBLE_EQ(bound.Max(), 0.5 * 0.7);
 
-  segments = {&s1, &s3, &s2};
-  bound = calculator.ComputeConjunctiveProbability(segments);
+  bounds = {s1.ProbabilityBound(), s3.ProbabilityBound(), s2.ProbabilityBound()};
+  bound = calculator.ComputeConjunctiveProbability(bounds);
   EXPECT_DOUBLE_EQ(bound.Min(), 0.5 * 0.7 * 0.2);
   EXPECT_DOUBLE_EQ(bound.Max(), 0.5 * 0.7 * 0.2);
 
-  segments = {};
-  bound = calculator.ComputeConjunctiveProbability(segments);
+  bounds = {};
+  bound = calculator.ComputeConjunctiveProbability(bounds);
   EXPECT_DOUBLE_EQ(bound.Min(), 1.0);
   EXPECT_DOUBLE_EQ(bound.Max(), 1.0);
 }


### PR DESCRIPTION
In this mode full conditions for all glyphs are extracted directly from the dependency graph. Subset closure is only used at the very end of segmentation to verify that the closure requirement is satisfied.

Notably this allows detections of composite conditions (like: (a or b) and (c or d)) which the other condition analysis modes cannot do. As a result this approach never results in unmapped glyphs (which are glyphs that are always loaded).

This should typically improve encoding times and segmentation quality vs the other modes. As a result I've made it the default for auto config. The quality level settings have been adjusted since there is no need for FIND_CONDITIONS to be utilized (due to no unmapped glyphs). Instead at the lowest two quality levels init font merging is disabled.

Example of quality and time improvements for Roboto:

```
CLOSURE_AND_DEP_GRAPH
total_cost_across_groups = 252777
total segmentation time = 7m34.576s

DEP_GRAPH_ONLY
total_cost_across_groups = 210858
total segmentation time = 4m17.402s
```