### PR TITLE
Optimize the bigram probability calculator

### DIFF
--- a/ift/freq/bigram_probability_calculator.cc
+++ b/ift/freq/bigram_probability_calculator.cc
@@ -17,40 +17,48 @@ BigramProbabilityCalculator::BigramProbabilityCalculator(
 
 ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
     const CodepointSet& codepoints, double best_lower) const {
+  unsigned n = codepoints.size();
+  std::vector<unsigned> cps;
+  std::vector<double> P;
+  std::vector<double> partial_totals;
+  cps.reserve(n);
+  P.reserve(n);
+  partial_totals.resize(n, 0.0);
+
   double unigram_total = 0.0;
-  double bigram_total = 0.0;
-  double max_partial_bigram_total = 0.0;
   double max_single_bound = 0.0;
+  for (unsigned cp : codepoints) {
+    double P_cp = frequencies_.ProbabilityFor(cp);
+    cps.push_back(cp);
+    P.push_back(P_cp);
+    unigram_total += P_cp;
+    max_single_bound = std::max(P_cp, max_single_bound);
+  }
+
+  if (max_single_bound >= 1.0) {
+    // Bounds can't be lower than [1, 1] stop checking.
+    return ProbabilityBound(1.0, 1.0);
+  }
+
+  double bigram_total = 0.0;
   double max_pair_bound = 0.0;
+  for (unsigned i = 0; i < n; i++) {
+    for (unsigned j = i + 1; j < n; j++) {
+      double Pij = frequencies_.ProbabilityFor(cps[i], cps[j], P[i], P[j]);
+      bigram_total += Pij;
+      partial_totals[i] += Pij;
+      partial_totals[j] += Pij;
 
-  for (auto it1 = codepoints.begin(); it1 != codepoints.end(); it1++) {
-    if (max_single_bound >= 1.0) {
-      // Bounds can't be lower than [1, 1] stop checking.
-      return ProbabilityBound(1.0, 1.0);
-    }
-
-    double partial_total = 0.0;
-    unsigned cp1 = *it1;
-    double P1 = frequencies_.ProbabilityFor(cp1);
-    unigram_total += P1;
-    max_single_bound = std::max(P1, max_single_bound);
-    for (auto it2 = codepoints.begin(); it2 != codepoints.end(); it2++) {
-      unsigned cp2 = *it2;
-      if (cp1 == cp2) {
-        continue;
-      }
-      double P12 = frequencies_.ProbabilityFor(cp1, cp2);
-      partial_total += P12;
-      if (cp1 < cp2) {
-        max_pair_bound = std::max(P1 + frequencies_.ProbabilityFor(cp2) - P12,
-                                  max_pair_bound);
-        if (max_pair_bound >= 1.0) {
-          // Bounds can't be lower than [1, 1] stop checking.
-          return ProbabilityBound(1.0, 1.0);
-        }
-        bigram_total += P12;
+      max_pair_bound = std::max(P[i] + P[j] - Pij, max_pair_bound);
+      if (max_pair_bound >= 1.0) {
+        // Bounds can't be lower than [1, 1] stop checking.
+        return ProbabilityBound(1.0, 1.0);
       }
     }
+  }
+
+  double max_partial_bigram_total = 0.0;
+  for (double partial_total : partial_totals) {
     max_partial_bigram_total =
         std::max(partial_total, max_partial_bigram_total);
   }

--- a/ift/freq/unicode_frequencies.cc
+++ b/ift/freq/unicode_frequencies.cc
@@ -41,25 +41,38 @@ void UnicodeFrequencies::Add(uint32_t cp1, uint32_t cp2, uint64_t count) {
 }
 
 double UnicodeFrequencies::ProbabilityFor(uint32_t cp) const {
-  return ProbabilityFor(cp, cp);
-}
-
-double UnicodeFrequencies::ProbabilityFor(uint32_t cp1, uint32_t cp2) const {
   if (max_count_ == 0) {
     return 0.0;
   }
+  auto it = probabilities_.find(ToKey(cp, cp));
+  if (it != probabilities_.end()) {
+    return it->second;
+  }
+  return unknown_probability;
+}
+
+double UnicodeFrequencies::ProbabilityFor(uint32_t cp1, uint32_t cp2) const {
+  return ProbabilityFor(cp1, cp2, ProbabilityFor(cp1), ProbabilityFor(cp2));
+}
+
+double UnicodeFrequencies::ProbabilityFor(uint32_t cp1, uint32_t cp2, double p1,
+                                          double p2) const {
+  if (max_count_ == 0) {
+    return 0.0;
+  }
+
+  if (cp1 == cp2) {
+    return p1;
+  }
+
   auto it = probabilities_.find(ToKey(cp1, cp2));
   if (it != probabilities_.end()) {
     return it->second;
   }
 
-  if (cp1 == cp2) {
-    return unknown_probability;
-  }
-
   // Since we don't have data  on P(cp1 n cp2), just assume the probabilities
   // for P(cp1) and P(cp2) are independent:
-  return ProbabilityFor(cp1, cp1) * ProbabilityFor(cp2, cp2);
+  return p1 * p2;
 }
 
 CodepointSet UnicodeFrequencies::CoveredCodepoints() const {

--- a/ift/freq/unicode_frequencies.h
+++ b/ift/freq/unicode_frequencies.h
@@ -33,6 +33,12 @@ class UnicodeFrequencies {
   // Returns the probability of codepoint pair (cp1, cp2) occurring.
   double ProbabilityFor(uint32_t cp1, uint32_t cp2) const;
 
+  // Returns the probability of codepoint pair (cp1, cp2) occurring.
+  // P1 and P2 are the pre-calculated unigram probabilities for cp1 and cp2
+  // respectively.
+  double ProbabilityFor(uint32_t cp1, uint32_t cp2, double p1,
+                        double p2) const;
+
   // Returns the probability of layout tag occurring.
   double ProbabilityForLayoutTag(hb_tag_t tag) const {
     // TODO(garretrieger): this is a temporary hack (just assumes all tags have


### PR DESCRIPTION
- Set iteration is slower then vector iteration so cache the set values.
- Process only (i < j) pairs.
- Specialized frequency lookup method to eliminate some redundant frequency map finds().