### PR TITLE
Rework Patch Map Entry List compilation

### DIFF
--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -122,6 +122,8 @@ cc_library(
     srcs = [
         "activation_condition.cc",
         "glyph_segmentation.cc",
+        "entry_graph.h",
+        "entry_graph.cc",
     ],
     hdrs = [
         "activation_condition.h",
@@ -365,6 +367,21 @@ cc_test(
     deps = [
         ":segmentation_context",
         "//ift/common",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
+    name = "entry_graph_test",
+    size = "small",
+    srcs = [
+        "entry_graph_test.cc",
+    ],
+    deps = [
+        ":common",
+        ":activation_condition",
+        "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/container:flat_hash_set",
         "@googletest//:gtest_main",
     ],
 )

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -29,6 +29,7 @@ using ift::common::SegmentSet;
 using ift::freq::ProbabilityCalculator;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
+using ift::proto::GLYPH_KEYED;
 
 namespace ift::encoder {
 
@@ -285,14 +286,27 @@ StatusOr<std::vector<PatchMap::Entry>>
 ActivationCondition::ActivationConditionsToPatchMapEntries(
     Span<const ActivationCondition> conditions,
     const flat_hash_map<segment_index_t, SubsetDefinition>& segments) {
+
+  // Set whichever encoding occurs the most to be the default
+  PatchEncoding default_encoding = GLYPH_KEYED;
+  uint32_t max_count = 0;
+  flat_hash_map<PatchEncoding, uint32_t> encoding_count;
+  for (const auto& c : conditions) {
+    auto& count = encoding_count[c.Encoding()];
+    count++;
+    if (count > max_count) {
+      max_count = count;
+      default_encoding = c.Encoding();
+    }
+  }
+
   std::vector<PatchMap::Entry> entries;
   if (conditions.empty()) {
     return entries;
   }
 
   EntryGraph graph = TRY(EntryGraph::Create(conditions, segments));
-  return graph.ToPatchMapEntries(
-      PatchEncoding::GLYPH_KEYED);  // TODO XXXXX choose an appropriate default.
+  return graph.ToPatchMapEntries(default_encoding);
 }
 
 StatusOr<double> ActivationCondition::Probability(

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -8,6 +8,8 @@
 #include "absl/status/statusor.h"
 #include "absl/strings/str_cat.h"
 #include "ift/common/int_set.h"
+#include "ift/common/try.h"
+#include "ift/encoder/entry_graph.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
 #include "ift/proto/patch_encoding.h"
@@ -29,6 +31,8 @@ using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
 
 namespace ift::encoder {
+
+static void Simplify(std::vector<SegmentSet>& conditions);
 
 ActivationCondition ActivationCondition::True(patch_id_t activated) {
   ActivationCondition condition;
@@ -78,6 +82,8 @@ ActivationCondition ActivationCondition::composite_condition(
   for (const auto& group : groups) {
     conditions.conditions_.push_back(group);
   }
+
+  Simplify(conditions.conditions_);
 
   conditions.is_fallback_ = is_fallback;
   return conditions;
@@ -275,24 +281,6 @@ ActivationConditionProto ActivationCondition::ToConfigProto() const {
   return proto;
 }
 
-void MakeIgnored(PatchMap::Entry& entry, patch_id_t& last_patch_id) {
-  entry.ignored = true;
-  // patch id for ignored entries doesn't matter, use last + 1 to minimize
-  // encoding size.
-  entry.patch_indices.clear();
-  entry.patch_indices.push_back(++last_patch_id);
-}
-
-patch_id_t MapTo(PatchMap::Entry& entry, patch_id_t new_patch_id,
-                 Span<const patch_id_t> prefetches) {
-  entry.ignored = false;
-  entry.patch_indices.clear();
-  entry.patch_indices.push_back(new_patch_id);
-  entry.patch_indices.insert(entry.patch_indices.end(), prefetches.begin(),
-                             prefetches.end());
-  return entry.patch_indices.back();
-}
-
 StatusOr<std::vector<PatchMap::Entry>>
 ActivationCondition::ActivationConditionsToPatchMapEntries(
     Span<const ActivationCondition> conditions,
@@ -302,146 +290,9 @@ ActivationCondition::ActivationConditionsToPatchMapEntries(
     return entries;
   }
 
-  // The conditions list describes what the patch map should do, here
-  // we need to convert that into an equivalent list of encoder condition
-  // entries.
-  //
-  // To minimize encoded size we can reuse set definitions in later entries
-  // via the copy indices mechanism. The conditions are evaluated in three
-  // phases to successively build up a set of common entries which can be reused
-  // by later ones.
-  //
-  // Tracks the list of conditions which have not yet been placed in a map
-  // entry.
-  btree_set<ActivationCondition> remaining_conditions;
-  remaining_conditions.insert(conditions.begin(), conditions.end());
-
-  // Phase 1 generate the base entries, there should be one for each
-  // unique glyph segment that is referenced in at least one condition.
-  // the conditions will refer back to these base entries via copy indices
-  //
-  // Each base entry can be used to map one condition as well.
-  flat_hash_map<uint32_t, uint32_t> segment_id_to_entry_index;
-  uint32_t next_entry_index = 0;
-  patch_id_t last_patch_id = 0;
-  for (auto condition = remaining_conditions.begin();
-       condition != remaining_conditions.end();) {
-    bool remove = false;
-    for (const auto& group : condition->conditions()) {
-      for (uint32_t segment_id : group) {
-        if (segment_id_to_entry_index.contains(segment_id)) {
-          continue;
-        }
-
-        auto original = segments.find(segment_id);
-        if (original == segments.end()) {
-          return absl::InvalidArgumentError(
-              StrCat("Codepoint segment ", segment_id, " not found."));
-        }
-        const auto& original_def = original->second;
-
-        std::vector<PatchMap::Entry> sub_entries =
-            // Activated patch ID will be assigned after this step, so just use
-            // empty array as a place holder
-            original_def.ToEntries(condition->encoding_, last_patch_id,
-                                   entries.size(), {});
-        auto& sub_entry = sub_entries.back();
-
-        last_patch_id = sub_entry.patch_indices.back();
-        if (condition->IsUnitary()) {
-          // this condition can use this entry to map itself. Update the entries
-          // mapped patch id.
-          last_patch_id =
-              MapTo(sub_entry, condition->activated(), condition->prefetches());
-          remove = true;
-        }
-
-        entries.insert(entries.end(), sub_entries.begin(), sub_entries.end());
-        next_entry_index = entries.size();
-        segment_id_to_entry_index[segment_id] = next_entry_index - 1;
-      }
-    }
-
-    if (remove) {
-      condition = remaining_conditions.erase(condition);
-    } else {
-      ++condition;
-    }
-  }
-
-  // Phase 2 generate entries for all groups of patches reusing the base entries
-  // written in phase one. When writing an entry if the triggering group is the
-  // only one in the condition then that condition can utilize the entry (just
-  // like in Phase 1).
-  flat_hash_map<IntSet, uint32_t> segment_group_to_entry_index;
-  for (auto condition = remaining_conditions.begin();
-       condition != remaining_conditions.end();) {
-    bool remove = false;
-
-    for (const auto& group : condition->conditions()) {
-      if (group.size() <= 1 || segment_group_to_entry_index.contains(group)) {
-        // don't handle groups of size one, those will just reference the base
-        // entry directly.
-        continue;
-      }
-
-      PatchMap::Entry entry;
-      entry.encoding = condition->encoding_;
-      entry.coverage.conjunctive = false;  // ... OR ...
-
-      for (uint32_t segment_id : group) {
-        auto entry_index = segment_id_to_entry_index.find(segment_id);
-        if (entry_index == segment_id_to_entry_index.end()) {
-          return absl::InternalError(
-              StrCat("entry for segment_id = ", segment_id,
-                     " was not previously created."));
-        }
-        entry.coverage.child_indices.insert(entry_index->second);
-      }
-
-      if (condition->conditions().size() == 1) {
-        last_patch_id =
-            MapTo(entry, condition->activated(), condition->prefetches());
-        remove = true;
-      } else {
-        MakeIgnored(entry, last_patch_id);
-      }
-
-      entries.push_back(entry);
-      segment_group_to_entry_index[group] = next_entry_index++;
-    }
-
-    if (remove) {
-      condition = remaining_conditions.erase(condition);
-    } else {
-      ++condition;
-    }
-  }
-
-  // Phase 3 for any remaining conditions create the actual entries utilizing
-  // the groups (phase 2) and base entries (phase 1) as needed
-  for (auto condition = remaining_conditions.begin();
-       condition != remaining_conditions.end(); condition++) {
-    PatchMap::Entry entry;
-    entry.encoding = condition->encoding_;
-    entry.coverage.conjunctive = true;  // ... AND ...
-
-    for (const auto& group : condition->conditions()) {
-      if (group.size() == 1) {
-        entry.coverage.child_indices.insert(
-            segment_id_to_entry_index[*group.begin()]);
-        continue;
-      }
-
-      entry.coverage.child_indices.insert(segment_group_to_entry_index[group]);
-    }
-
-    last_patch_id =
-        MapTo(entry, condition->activated(), condition->prefetches());
-    entries.push_back(entry);
-  }
-
-  return entries;
+  EntryGraph graph = TRY(EntryGraph::Create(conditions, segments));
+  return graph.ToPatchMapEntries(
+      PatchEncoding::GLYPH_KEYED);  // TODO XXXXX choose an appropriate default.
 }
 
 StatusOr<double> ActivationCondition::Probability(

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -108,6 +108,8 @@ class ActivationCondition {
     return out;
   }
 
+  proto::PatchEncoding Encoding() const { return encoding_; }
+
   // Returns true if any of the condition groups intersects with 'segments'.
   bool Intersects(const common::SegmentSet& segments) const;
 

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -35,42 +35,42 @@ TEST(ActivationConditionTest, ActivationConditionsToEncoderConditions) {
 
   std::vector<PatchMap::Entry> expected;
 
-  // entry[0] {{2}} -> 2,
+  // entry[0] {{4}} ignored
+  {
+    PatchMap::Entry condition({'g'}, 1, PatchEncoding::GLYPH_KEYED);
+    condition.ignored = true;
+    expected.push_back(condition);
+  }
+
+  // entry[1] {{2}} -> 2,
   expected.push_back(
       PatchMap::Entry({'c'}, 2, proto::PatchEncoding::GLYPH_KEYED));
 
-  // entry[1] {{3}} -> 4
+  // entry[2] {{1}} ignored
+  {
+    PatchMap::Entry condition({'a', 'b'}, 3, PatchEncoding::GLYPH_KEYED);
+    condition.ignored = true;
+    expected.push_back(condition);
+  }
+
+  // entry[3] {{3}} -> 4
   expected.push_back(
       PatchMap::Entry({'d', 'e', 'f'}, 4, proto::PatchEncoding::GLYPH_KEYED));
 
-  // entry[2] {{1}} ignored
-  {
-    PatchMap::Entry condition({'a', 'b'}, 5, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
-  }
-
-  // entry[3] {{4}} ignored
-  {
-    PatchMap::Entry condition({'g'}, 6, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
-  }
-
-  // entry[4] {{1 OR 3}} -> 5
+  // entry[4] {{2 OR 4}} ignored
   {
     PatchMap::Entry condition;
-    condition.coverage.child_indices = {2, 1};
+    condition.coverage.child_indices = {0, 1};  // entry[0], entry[1]
     condition.patch_indices.push_back(5);
+    condition.ignored = true;
     expected.push_back(condition);
   }
 
-  // entry[5] {{2 OR 4}} ignored
+  // entry[5] {{1 OR 3}} -> 5
   {
     PatchMap::Entry condition;
-    condition.coverage.child_indices = {0, 3};  // entry[0], entry[3]
-    condition.patch_indices.push_back(6);
-    condition.ignored = true;
+    condition.coverage.child_indices = {2, 3};
+    condition.patch_indices.push_back(5);
     expected.push_back(condition);
   }
 
@@ -115,11 +115,25 @@ TEST(ActivationConditionTest,
 
   std::vector<PatchMap::Entry> expected;
 
-  // entry[0] {{2}} -> 2,
+  // entry[0] {{4}} ignored
+  {
+    PatchMap::Entry condition({'g'}, 1, PatchEncoding::GLYPH_KEYED);
+    condition.ignored = true;
+    expected.push_back(condition);
+  }
+
+  // entry[1] {{2}} -> 2,
   expected.push_back(
       PatchMap::Entry({'c'}, 2, proto::PatchEncoding::GLYPH_KEYED));
 
-  // entry[1] {{3}} -> 4
+  // entry[2] {{1}} ignored
+  {
+    PatchMap::Entry condition({'a', 'b'}, 3, PatchEncoding::GLYPH_KEYED);
+    condition.ignored = true;
+    expected.push_back(condition);
+  }
+
+  // entry[2] {{3}} -> 4
   {
     PatchMap::Entry condition({'d', 'e', 'f'}, 4,
                               proto::PatchEncoding::TABLE_KEYED_FULL);
@@ -128,16 +142,11 @@ TEST(ActivationConditionTest,
     expected.push_back(condition);
   }
 
-  // entry[2] {{1}} ignored
+  // entry[3] {{2 OR 4}} ignored
   {
-    PatchMap::Entry condition({'a', 'b'}, 13, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
-  }
-
-  // entry[3] {{4}} ignored
-  {
-    PatchMap::Entry condition({'g'}, 14, PatchEncoding::GLYPH_KEYED);
+    PatchMap::Entry condition;
+    condition.coverage.child_indices = {0, 1};  // entry[0], entry[1]
+    condition.patch_indices.push_back(13);
     condition.ignored = true;
     expected.push_back(condition);
   }
@@ -145,17 +154,8 @@ TEST(ActivationConditionTest,
   // entry[4] {{1 OR 3}} -> 5
   {
     PatchMap::Entry condition;
-    condition.coverage.child_indices = {2, 1};
+    condition.coverage.child_indices = {2, 3};
     condition.patch_indices.push_back(5);
-    expected.push_back(condition);
-  }
-
-  // entry[5] {{2 OR 4}} ignored
-  {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {0, 3};  // entry[0], entry[3]
-    condition.patch_indices.push_back(6);
-    condition.ignored = true;
     expected.push_back(condition);
   }
 
@@ -193,10 +193,10 @@ TEST(ActivationConditionTest,
 
   std::vector<PatchMap::Entry> expected;
 
-  // entry[0] {{smcp}} -> 1,
+  // entry[0] {{dlig}} -> 1,
   {
     PatchMap::Entry condition;
-    condition.coverage.features = {HB_TAG('s', 'm', 'c', 'p')};
+    condition.coverage.features = {HB_TAG('d', 'l', 'i', 'g')};
     condition.ignored = true;
     condition.patch_indices = {1};
     condition.encoding = PatchEncoding::GLYPH_KEYED;
@@ -213,20 +213,20 @@ TEST(ActivationConditionTest,
     expected.push_back(condition);
   }
 
-  // entry[2] {{dlig}} -> 3,
+  // entry[3] {e0 OR e1} -> 3,
   {
     PatchMap::Entry condition;
-    condition.coverage.features = {HB_TAG('d', 'l', 'i', 'g')};
+    condition.coverage.child_indices = {0, 1};
     condition.ignored = true;
     condition.patch_indices = {3};
     condition.encoding = PatchEncoding::GLYPH_KEYED;
     expected.push_back(condition);
   }
 
-  // entry[3] {e1 OR e2} -> 4,
+  // entry[4] {{smcp}} -> 4,
   {
     PatchMap::Entry condition;
-    condition.coverage.child_indices = {1, 2};
+    condition.coverage.features = {HB_TAG('s', 'm', 'c', 'p')};
     condition.ignored = true;
     condition.patch_indices = {4};
     condition.encoding = PatchEncoding::GLYPH_KEYED;
@@ -236,7 +236,7 @@ TEST(ActivationConditionTest,
   // entry[2] s1 AND s2 -> 5,
   {
     PatchMap::Entry condition;
-    condition.coverage.child_indices = {0, 3};
+    condition.coverage.child_indices = {3, 4};
     condition.patch_indices = {5};
     condition.coverage.conjunctive = true;
     condition.encoding = PatchEncoding::GLYPH_KEYED;

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -317,7 +317,6 @@ StatusOr<uint32_t> EntryGraph::CreateNode() {
   }
   uint32_t node_id = nodes.size();
   nodes.push_back({
-      .id = node_id,
       .and_codepoints = {},
       .and_features = {},
       .child_mode = NONE,

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -218,26 +218,48 @@ StatusOr<uint32_t> EntryGraph::AddMapping(
     return node_id;
   }
 
-  // TODO XXXX handle case with more then 127 child ids
   if (normalized.IsPurelyDisjunctive()) {
     const auto& or_segments = *normalized.conditions().begin();
     nodes[node_id].child_mode = OR;
+    std::vector<uint32_t> children;
     for (const auto& s : or_segments) {
-      uint32_t child_id = TRY(
-          AddMapping(ActivationCondition::exclusive_segment(s, 0), segments));
-      nodes[node_id].children_ids.insert(child_id);
+      children.push_back(TRY(
+          AddMapping(ActivationCondition::exclusive_segment(s, 0), segments)));
     }
+    TRYV(AddChildrenToNode(node_id, OR, children));
     return node_id;
   }
 
   nodes[node_id].child_mode = AND;
+  std::vector<uint32_t> children;
   for (const auto& or_segments : normalized.conditions()) {
-    uint32_t child_id = TRY(
-        AddMapping(ActivationCondition::or_segments(or_segments, 0), segments));
-    nodes[node_id].children_ids.insert(child_id);
+    children.push_back(TRY(
+        AddMapping(ActivationCondition::or_segments(or_segments, 0), segments)));
   }
+  TRYV(AddChildrenToNode(node_id, AND, children));
 
   return node_id;
+}
+
+absl::Status EntryGraph::AddChildrenToNode(uint32_t node_id, ChildMode mode,
+                                             Span<const uint32_t> children_ids) {
+  while (children_ids.size() > 127) {
+    for (size_t i = 0; i < 126; ++i) {
+      nodes[node_id].children_ids.insert(children_ids[i]);
+    }
+    uint32_t next_node_id = TRY(CreateNode());
+    nodes[next_node_id].child_mode = mode;
+    incoming_edge_count[next_node_id]++;
+    nodes[node_id].children_ids.insert(next_node_id);
+
+    node_id = next_node_id;
+    children_ids = children_ids.subspan(126);
+  }
+
+  for (uint32_t child_id : children_ids) {
+    nodes[node_id].children_ids.insert(child_id);
+  }
+  return absl::OkStatus();
 }
 
 StatusOr<uint32_t> EntryGraph::AddCodepointsOnly(

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -1,0 +1,317 @@
+#include "ift/encoder/entry_graph.h"
+
+#include <algorithm>
+#include <cstdint>
+
+#include "absl/strings/str_cat.h"
+#include "ift/common/axis_range.h"
+#include "ift/common/try.h"
+#include "ift/encoder/activation_condition.h"
+#include "ift/proto/patch_encoding.h"
+#include "ift/proto/patch_map.h"
+
+using absl::btree_map;
+using absl::btree_set;
+using absl::flat_hash_map;
+using absl::flat_hash_set;
+using absl::Span;
+using absl::StatusOr;
+using ift::common::AxisRange;
+using ift::proto::PatchEncoding;
+using ift::proto::PatchMap;
+
+namespace ift::encoder {
+
+static ActivationCondition Normalize(const ActivationCondition& condition) {
+  // Remove patches, and other settings not relevant to the graph. Internally
+  // composite condition will simplify and normalize as well.
+  return ActivationCondition::composite_condition(condition.conditions(), 0);
+}
+
+StatusOr<EntryGraph> EntryGraph::Create(
+    Span<const ActivationCondition> conditions,
+    const flat_hash_map<segment_index_t, SubsetDefinition>& segments) {
+  EntryGraph graph;
+  for (const auto& condition : conditions) {
+    uint32_t _ = TRY(graph.AddMapping(condition, segments));
+    ActivationCondition normalized = Normalize(condition);
+
+    std::vector<uint32_t> patches = {condition.activated()};
+    patches.insert(patches.end(), condition.prefetches().begin(),
+                   condition.prefetches().end());
+    auto [it1, did_insert_1] =
+        graph.patch_mappings.insert({normalized, patches});
+    if (!did_insert_1) {
+      return absl::InternalError("Conflicting patch mappings.");
+    }
+    auto [it2, did_insert_2] =
+        graph.patch_encodings.insert({normalized, condition.Encoding()});
+    if (!did_insert_2) {
+      return absl::InternalError("Conflicting patch mappings.");
+    }
+  }
+
+  return graph;
+}
+
+StatusOr<std::vector<PatchMap::Entry>> EntryGraph::ToPatchMapEntries(
+    proto::PatchEncoding default_encoding) const {
+  std::vector<PatchMap::Entry> entries;
+  entries.reserve(nodes.size());
+
+  flat_hash_map<uint32_t, uint32_t> node_id_to_entry_index;
+  flat_hash_map<uint32_t, ActivationCondition> node_to_condition;
+
+  for (const auto& [condition, patches] : patch_mappings) {
+    auto it = condition_to_node_id.find(condition);
+    if (it != condition_to_node_id.end()) {
+      node_to_condition.insert({it->second, condition});
+    } else {
+      return absl::InternalError("Unexpected missing node.");
+    }
+  }
+
+  uint32_t last_patch_id = 0;
+  std::vector<uint32_t> sorted_nodes = TRY(TopologicalSort());
+  std::reverse(sorted_nodes.begin(), sorted_nodes.end());
+  for (uint32_t node_id : sorted_nodes) {
+    const auto& node = nodes[node_id];
+
+    PatchMap::Entry entry;
+    entry.coverage.codepoints = node.and_codepoints;
+    entry.coverage.features.insert(node.and_features.begin(),
+                                   node.and_features.end());
+    entry.coverage.design_space.insert(node.and_design_space.begin(),
+                                       node.and_design_space.end());
+    entry.coverage.conjunctive = (node.child_mode == AND);
+    entry.encoding = default_encoding;
+
+    for (uint32_t child_id : node.children_ids) {
+      auto it = node_id_to_entry_index.find(child_id);
+      if (it == node_id_to_entry_index.end()) {
+        return absl::InternalError(absl::StrCat(
+            "Child node ", child_id, " not yet converted to entry."));
+      }
+      entry.coverage.child_indices.insert(it->second);
+    }
+
+    auto condition_it = node_to_condition.find(node_id);
+    if (condition_it != node_to_condition.end()) {
+      entry.ignored = false;
+      entry.patch_indices = patch_mappings.at(condition_it->second);
+      entry.encoding = patch_encodings.at(condition_it->second);
+      if (!entry.patch_indices.empty()) {
+        last_patch_id = entry.patch_indices.back();
+      }
+    } else {
+      entry.ignored = true;
+      entry.patch_indices = {++last_patch_id};
+    }
+
+    node_id_to_entry_index[node_id] = entries.size();
+    entries.push_back(std::move(entry));
+  }
+
+  return entries;
+}
+
+StatusOr<std::vector<uint32_t>> EntryGraph::TopologicalSort() const {
+  std::vector<uint32_t> edge_count = incoming_edge_count;
+  std::vector<uint32_t> sorted;
+  sorted.reserve(nodes.size());
+
+  // Each top level condition generates an incoming edge we need to remove these
+  // prior to sorting. patch_mappings stores a list of them.
+  for (const auto& [condition, _] : patch_mappings) {
+    auto it = condition_to_node_id.find(condition);
+    if (it == condition_to_node_id.end()) {
+      continue;
+    }
+    if (edge_count[it->second] == 0) {
+      return absl::InternalError(
+          "Edge count underflow for top-level condition.");
+    }
+    edge_count[it->second]--;
+    if (edge_count[it->second] == 0) {
+      sorted.push_back(it->second);
+    }
+  }
+
+  std::sort(sorted.begin(), sorted.end());
+
+  // Kahn's algorithm (ref: https://en.wikipedia.org/wiki/Topological_sorting)
+  size_t head = 0;
+  while (head < sorted.size()) {
+    uint32_t id = sorted[head++];
+    for (uint32_t child : nodes[id].children_ids) {
+      if (edge_count[child] == 0) {
+        return absl::InternalError("Edge count underflow.");
+      }
+      edge_count[child]--;
+      if (edge_count[child] == 0) {
+        sorted.push_back(child);
+      }
+    }
+  }
+
+  if (sorted.size() != nodes.size()) {
+    return absl::InternalError("Cycle detected in graph.");
+  }
+
+  return sorted;
+}
+
+StatusOr<uint32_t> EntryGraph::AddMapping(
+    const ActivationCondition& condition,
+    const flat_hash_map<segment_index_t, SubsetDefinition>& segments) {
+  ActivationCondition normalized = Normalize(condition);
+
+  auto existing = condition_to_node_id.find(normalized);
+  if (existing != condition_to_node_id.end()) {
+    incoming_edge_count[existing->second]++;
+    return existing->second;
+  }
+
+  if (normalized.IsUnitary()) {
+    const auto& segment = segments.at(*normalized.TriggeringSegments().begin());
+    if (!segment.codepoints.empty() && segment.feature_tags.empty() &&
+        segment.design_space.empty()) {
+      uint32_t node_id = TRY(AddCodepointsOnly(segment.codepoints));
+      condition_to_node_id[normalized] = node_id;
+      return node_id;
+    } else if (segment.codepoints.empty() && !segment.feature_tags.empty() &&
+               segment.design_space.empty()) {
+      uint32_t node_id = TRY(AddFeaturesOnly(segment.feature_tags));
+      condition_to_node_id[normalized] = node_id;
+      return node_id;
+    } else if (segment.codepoints.empty() && segment.feature_tags.empty() &&
+               !segment.design_space.empty()) {
+      uint32_t node_id = TRY(AddDesignSpaceOnly(segment.design_space));
+      condition_to_node_id[normalized] = node_id;
+      return node_id;
+    }
+  }
+
+  uint32_t node_id = TRY(CreateNode());
+  incoming_edge_count[node_id]++;
+  condition_to_node_id[normalized] = node_id;
+
+  if (normalized.IsUnitary()) {
+    // A unitary condition that has not been handled yet has both features and
+    // codepoints and needs to be formed from two child nodes. One for the
+    // features and one for the codepoints.
+    const auto& segment = segments.at(*normalized.TriggeringSegments().begin());
+    if (!segment.codepoints.empty()) {
+      uint32_t codepoints_id = TRY(AddCodepointsOnly(segment.codepoints));
+      nodes[node_id].children_ids.insert(codepoints_id);
+    }
+    if (!segment.feature_tags.empty()) {
+      uint32_t features_id = TRY(AddFeaturesOnly(segment.feature_tags));
+      nodes[node_id].children_ids.insert(features_id);
+    }
+    if (!segment.design_space.empty()) {
+      uint32_t design_space_id = TRY(AddDesignSpaceOnly(segment.design_space));
+      nodes[node_id].children_ids.insert(design_space_id);
+    }
+
+    nodes[node_id].child_mode = OR;
+    return node_id;
+  }
+
+  // TODO XXXX handle case with more then 127 child ids
+  if (normalized.IsPurelyDisjunctive()) {
+    const auto& or_segments = *normalized.conditions().begin();
+    nodes[node_id].child_mode = OR;
+    for (const auto& s : or_segments) {
+      uint32_t child_id = TRY(
+          AddMapping(ActivationCondition::exclusive_segment(s, 0), segments));
+      nodes[node_id].children_ids.insert(child_id);
+    }
+    return node_id;
+  }
+
+  nodes[node_id].child_mode = AND;
+  for (const auto& or_segments : normalized.conditions()) {
+    uint32_t child_id = TRY(
+        AddMapping(ActivationCondition::or_segments(or_segments, 0), segments));
+    nodes[node_id].children_ids.insert(child_id);
+  }
+
+  return node_id;
+}
+
+StatusOr<uint32_t> EntryGraph::AddCodepointsOnly(
+    const common::CodepointSet& codepoints) {
+  auto existing = codepoints_to_node_id.find(codepoints);
+  if (existing != codepoints_to_node_id.end()) {
+    incoming_edge_count[existing->second]++;
+    return existing->second;
+  }
+
+  uint32_t node_id = TRY(CreateNode());
+  incoming_edge_count[node_id]++;
+  codepoints_to_node_id[codepoints] = node_id;
+  nodes[node_id].and_codepoints = codepoints;
+  return node_id;
+}
+
+StatusOr<uint32_t> EntryGraph::AddFeaturesOnly(
+    const btree_set<hb_tag_t>& features) {
+  flat_hash_set<hb_tag_t> features_set;
+  features_set.insert(features.begin(), features.end());
+
+  auto existing = features_to_node_id.find(features_set);
+  if (existing != features_to_node_id.end()) {
+    incoming_edge_count[existing->second]++;
+    return existing->second;
+  }
+
+  uint32_t node_id = TRY(CreateNode());
+  incoming_edge_count[node_id]++;
+  features_to_node_id[features_set] = node_id;
+  nodes[node_id].and_features = features_set;
+  return node_id;
+}
+
+// Returns node id. De-dups if possible.
+StatusOr<uint32_t> EntryGraph::AddDesignSpaceOnly(
+    const flat_hash_map<hb_tag_t, AxisRange>& design_space) {
+  auto existing = design_space_to_node_id.find(design_space);
+  if (existing != design_space_to_node_id.end()) {
+    incoming_edge_count[existing->second]++;
+    return existing->second;
+  }
+
+  uint32_t node_id = TRY(CreateNode());
+  incoming_edge_count[node_id]++;
+  design_space_to_node_id[design_space] = node_id;
+  nodes[node_id].and_design_space = design_space;
+  return node_id;
+}
+
+StatusOr<uint32_t> EntryGraph::CreateNode() {
+  if (nodes.size() > UINT32_MAX) {
+    return absl::InternalError("Node ID integer overflow.");
+  }
+  uint32_t node_id = nodes.size();
+  nodes.push_back({
+      .id = node_id,
+      .and_codepoints = {},
+      .and_features = {},
+      .child_mode = NONE,
+      .children_ids = {},
+  });
+  incoming_edge_count.push_back(0);
+  return node_id;
+}
+
+int64_t EntryNode::EncodingCost() const {
+  // TODO XXXX
+  return 0;
+}
+
+void EntryGraph::Optimize() {
+  // TODO XXXXX
+}
+
+}  // namespace ift::encoder

--- a/ift/encoder/entry_graph.h
+++ b/ift/encoder/entry_graph.h
@@ -20,7 +20,6 @@ enum ChildMode {
 // where possible.
 
 struct EntryNode {
-  uint32_t id;
   common::CodepointSet and_codepoints;
   absl::flat_hash_set<hb_tag_t> and_features;
   absl::flat_hash_map<hb_tag_t, ift::common::AxisRange> and_design_space;
@@ -31,17 +30,26 @@ struct EntryNode {
   int64_t EncodingCost() const;
 };
 
+// Models the condition graph formed by the patch map entries of an IFT
+// table. Can be used to construct the corresponding entry list.
 class EntryGraph {
  public:
+  // Create a new graph based on 'conditions' and 'segments'. Will utilize
+  // maximum sharing by default, and leave each segment as an individual node.
   static absl::StatusOr<EntryGraph> Create(
       absl::Span<const ActivationCondition> conditions,
       const absl::flat_hash_map<segment_index_t, SubsetDefinition>& segments);
 
+  // Modify this entry graph where possible to reduce the overall encoding cost
+  // without changing it's functionality.
   void Optimize();
 
+  // Convert this entry graph into an list of patch map entries, with child
+  // indices fully resolved.
   absl::StatusOr<std::vector<proto::PatchMap::Entry>> ToPatchMapEntries(
       proto::PatchEncoding default_encoding) const;
 
+  // Return a topological sorting of node ids for this graph.
   absl::StatusOr<std::vector<uint32_t>> TopologicalSort() const;
 
  private:

--- a/ift/encoder/entry_graph.h
+++ b/ift/encoder/entry_graph.h
@@ -1,0 +1,92 @@
+#ifndef IFT_ENCODER_ENTRY_GRAPH_H_
+#define IFT_ENCODER_ENTRY_GRAPH_H_
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/container/flat_hash_set.h"
+#include "ift/common/int_set.h"
+#include "ift/encoder/activation_condition.h"
+#include "ift/proto/patch_encoding.h"
+#include "ift/proto/patch_map.h"
+
+namespace ift::encoder {
+
+enum ChildMode {
+  NONE,
+  AND,
+  OR,
+};
+
+// TODO XXX typedef node id?
+// TODO XXXX better optimize patch id encodings by ordering entries by patch ids
+// where possible.
+
+struct EntryNode {
+  uint32_t id;
+  common::CodepointSet and_codepoints;
+  absl::flat_hash_set<hb_tag_t> and_features;
+  absl::flat_hash_map<hb_tag_t, ift::common::AxisRange> and_design_space;
+
+  ChildMode child_mode;
+  common::IntSet children_ids;
+
+  int64_t EncodingCost() const;
+};
+
+class EntryGraph {
+ public:
+  static absl::StatusOr<EntryGraph> Create(
+      absl::Span<const ActivationCondition> conditions,
+      const absl::flat_hash_map<segment_index_t, SubsetDefinition>& segments);
+
+  void Optimize();
+
+  absl::StatusOr<std::vector<proto::PatchMap::Entry>> ToPatchMapEntries(
+      proto::PatchEncoding default_encoding) const;
+
+  absl::StatusOr<std::vector<uint32_t>> TopologicalSort() const;
+
+ private:
+  EntryGraph() = default;
+
+  // Returns node id. De-dups if possible.
+  absl::StatusOr<uint32_t> AddMapping(
+      const ActivationCondition& condition,
+      const absl::flat_hash_map<segment_index_t, SubsetDefinition>& segments);
+
+  // Returns node id. De-dups if possible.
+  absl::StatusOr<uint32_t> AddCodepointsOnly(
+      const common::CodepointSet& codepoints);
+
+  // Returns node id. De-dups if possible.
+  absl::StatusOr<uint32_t> AddFeaturesOnly(
+      const absl::btree_set<hb_tag_t>& features);
+
+  // Returns node id. De-dups if possible.
+  absl::StatusOr<uint32_t> AddDesignSpaceOnly(
+      const absl::flat_hash_map<hb_tag_t, ift::common::AxisRange>&
+          design_space);
+
+  absl::StatusOr<uint32_t> CreateNode();
+
+  absl::flat_hash_map<ActivationCondition, std::vector<uint32_t>>
+      patch_mappings;
+  absl::flat_hash_map<ActivationCondition, proto::PatchEncoding>
+      patch_encodings;
+
+  std::vector<EntryNode> nodes;
+  std::vector<uint32_t> incoming_edge_count;
+  // TODO XXXX track which nodes are fully disjunctive after being fully
+  // resolved (ie. including children)
+
+  absl::flat_hash_map<ActivationCondition, uint32_t> condition_to_node_id;
+  absl::flat_hash_map<common::CodepointSet, uint32_t> codepoints_to_node_id;
+  absl::flat_hash_map<absl::flat_hash_set<hb_tag_t>, uint32_t>
+      features_to_node_id;
+  absl::flat_hash_map<absl::flat_hash_map<hb_tag_t, ift::common::AxisRange>,
+                      uint32_t>
+      design_space_to_node_id;
+};
+
+}  // namespace ift::encoder
+
+#endif  // IFT_ENCODER_ENTRY_GRAPH_H_

--- a/ift/encoder/entry_graph.h
+++ b/ift/encoder/entry_graph.h
@@ -16,8 +16,7 @@ enum ChildMode {
   OR,
 };
 
-// TODO XXX typedef node id?
-// TODO XXXX better optimize patch id encodings by ordering entries by patch ids
+// TODO(garretrieger): better optimize patch id encodings by ordering entries by patch ids
 // where possible.
 
 struct EntryNode {
@@ -68,6 +67,10 @@ class EntryGraph {
 
   absl::StatusOr<uint32_t> CreateNode();
 
+  absl::Status AddChildrenToNode(
+      uint32_t node_id, ChildMode mode,
+      absl::Span<const uint32_t> children_ids);
+
   absl::flat_hash_map<ActivationCondition, std::vector<uint32_t>>
       patch_mappings;
   absl::flat_hash_map<ActivationCondition, proto::PatchEncoding>
@@ -75,7 +78,7 @@ class EntryGraph {
 
   std::vector<EntryNode> nodes;
   std::vector<uint32_t> incoming_edge_count;
-  // TODO XXXX track which nodes are fully disjunctive after being fully
+  // TODO(garretrieger): track which nodes are fully disjunctive after being fully
   // resolved (ie. including children)
 
   absl::flat_hash_map<ActivationCondition, uint32_t> condition_to_node_id;

--- a/ift/encoder/entry_graph_test.cc
+++ b/ift/encoder/entry_graph_test.cc
@@ -1,0 +1,216 @@
+#include "ift/encoder/entry_graph.h"
+
+#include <vector>
+
+#include "absl/container/flat_hash_map.h"
+#include "gmock/gmock.h"
+#include "gtest/gtest.h"
+#include "ift/encoder/activation_condition.h"
+#include "ift/encoder/subset_definition.h"
+#include "ift/proto/patch_encoding.h"
+
+using ::ift::proto::PatchEncoding;
+using ::testing::UnorderedElementsAre;
+
+namespace ift::encoder {
+
+TEST(EntryGraphTest, ToPatchMapEntries) {
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {1, {'a'}},
+      {2, {'b'}},
+      {3, {'c'}},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({1, 2}, 10),
+      ActivationCondition::or_segments({2, 3}, 11),
+      ActivationCondition::and_segments({1, 3}, 12),
+      ActivationCondition::exclusive_segment(2, 13),
+  };
+
+  auto r1 = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(r1.ok()) << r1.status();
+  EntryGraph graph = std::move(r1).value();
+
+  auto r2 = graph.ToPatchMapEntries(proto::TABLE_KEYED_FULL);
+  ASSERT_TRUE(r2.ok()) << r2.status();
+  std::vector<proto::PatchMap::Entry> entries = *r2;
+
+  // Expected 6 nodes:
+  // (s1 OR s2) -> 10
+  // (s2 OR s3) -> 11
+  // (s1 AND s3) -> 12
+  // (s1) -> ignored
+  // (s2) -> 13
+  // (s3) -> ignored
+  EXPECT_EQ(entries.size(), 6);
+
+  absl::flat_hash_map<uint32_t, size_t> codepoint_to_index;
+  absl::flat_hash_map<uint32_t, size_t> patch_to_index;
+
+  for (size_t i = 0; i < entries.size(); ++i) {
+    const auto& entry = entries[i];
+
+    // Check that child indices refer to earlier entries
+    for (uint32_t child_idx : entry.coverage.child_indices) {
+      EXPECT_LT(child_idx, i);
+    }
+
+    if (entry.ignored) {
+      EXPECT_TRUE(entry.coverage.child_indices.empty());
+      EXPECT_EQ(entry.coverage.codepoints.size(), 1);
+      codepoint_to_index[*entry.coverage.codepoints.begin()] = i;
+      EXPECT_EQ(entry.encoding, proto::TABLE_KEYED_FULL);
+    } else {
+      EXPECT_EQ(entry.encoding, proto::GLYPH_KEYED);
+      EXPECT_EQ(entry.patch_indices.size(), 1);
+      uint32_t patch_id = entry.patch_indices[0];
+      patch_to_index[patch_id] = i;
+
+      if (patch_id == 13) {
+        EXPECT_TRUE(entry.coverage.child_indices.empty());
+        EXPECT_EQ(entry.coverage.codepoints.size(), 1);
+        codepoint_to_index[*entry.coverage.codepoints.begin()] = i;
+      } else if (patch_id == 10) {
+        EXPECT_FALSE(entry.coverage.conjunctive);
+        EXPECT_EQ(entry.coverage.child_indices.size(), 2);
+      } else if (patch_id == 11) {
+        EXPECT_FALSE(entry.coverage.conjunctive);
+        EXPECT_EQ(entry.coverage.child_indices.size(), 2);
+      } else if (patch_id == 12) {
+        EXPECT_TRUE(entry.coverage.conjunctive);
+        EXPECT_EQ(entry.coverage.child_indices.size(), 2);
+      }
+    }
+  }
+
+  ASSERT_TRUE(codepoint_to_index.contains('a'));
+  ASSERT_TRUE(codepoint_to_index.contains('b'));
+  ASSERT_TRUE(codepoint_to_index.contains('c'));
+  ASSERT_TRUE(patch_to_index.contains(10));
+  ASSERT_TRUE(patch_to_index.contains(11));
+  ASSERT_TRUE(patch_to_index.contains(12));
+  ASSERT_TRUE(patch_to_index.contains(13));
+
+  // s1 OR s2
+  EXPECT_TRUE(entries[patch_to_index[10]].coverage.child_indices.contains(
+      codepoint_to_index['a']));
+  EXPECT_TRUE(entries[patch_to_index[10]].coverage.child_indices.contains(
+      codepoint_to_index['b']));
+
+  // s2 OR s3
+  EXPECT_TRUE(entries[patch_to_index[11]].coverage.child_indices.contains(
+      codepoint_to_index['b']));
+  EXPECT_TRUE(entries[patch_to_index[11]].coverage.child_indices.contains(
+      codepoint_to_index['c']));
+
+  // s1 AND s3
+  EXPECT_TRUE(entries[patch_to_index[12]].coverage.child_indices.contains(
+      codepoint_to_index['a']));
+  EXPECT_TRUE(entries[patch_to_index[12]].coverage.child_indices.contains(
+      codepoint_to_index['c']));
+}
+
+TEST(EntryGraphTest, SplitSegment) {
+  SubsetDefinition s1;
+  s1.codepoints = {'a'};
+  s1.feature_tags = {HB_TAG('f', '1', ' ', ' ')};
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {1, s1},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::exclusive_segment(1, 10),
+  };
+
+  auto r1 = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(r1.ok()) << r1.status();
+  EntryGraph graph = std::move(*r1);
+
+  auto r2 = graph.ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(r2.ok()) << r2.status();
+  std::vector<proto::PatchMap::Entry> entries = *r2;
+
+  // Expected 3 nodes:
+  // (a OR f1) -> 10
+  // (a) -> ignored
+  // (f1) -> ignored
+  EXPECT_EQ(entries.size(), 3);
+
+  size_t a_id = -1;
+  size_t f1_id = -1;
+  size_t root_id = -1;
+
+  for (size_t i = 0; i < entries.size(); i++) {
+    const auto& entry = entries[i];
+    if (entry.ignored) {
+      EXPECT_TRUE(entry.coverage.child_indices.empty());
+      if (!entry.coverage.codepoints.empty()) {
+        EXPECT_EQ(*entry.coverage.codepoints.begin(), 'a');
+        a_id = i;
+      } else {
+        EXPECT_EQ(*entry.coverage.features.begin(), HB_TAG('f', '1', ' ', ' '));
+        f1_id = i;
+      }
+    } else {
+      EXPECT_EQ(entry.patch_indices[0], 10);
+      EXPECT_FALSE(entry.coverage.conjunctive);
+      EXPECT_EQ(entry.coverage.child_indices.size(), 2);
+      root_id = i;
+    }
+  }
+
+  ASSERT_NE(a_id, -1);
+  ASSERT_NE(f1_id, -1);
+  ASSERT_NE(root_id, -1);
+
+  EXPECT_TRUE(entries[root_id].coverage.child_indices.contains(a_id));
+  EXPECT_TRUE(entries[root_id].coverage.child_indices.contains(f1_id));
+  EXPECT_LT(a_id, root_id);
+  EXPECT_LT(f1_id, root_id);
+}
+
+TEST(EntryGraphTest, TopologicalSort_SharedChildren) {
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {1, {'a'}},
+      {2, {'b'}},
+      {3, {'c'}},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({1, 2}, 10),
+      ActivationCondition::or_segments({2, 3}, 11),
+  };
+
+  auto graph_or_status = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph_or_status.ok()) << graph_or_status.status();
+  EntryGraph graph = std::move(graph_or_status).value();
+
+  auto r = graph.TopologicalSort();
+  ASSERT_TRUE(r.ok()) << r.status();
+  std::vector<uint32_t> sorted = *r;
+
+  // The graph should have 5 nodes:
+  // 0: (s1 OR s2)
+  // 1: (s1)
+  // 2: (s2) shared
+  // 3: (s2 or s3)
+  // 4: (s3)
+  EXPECT_THAT(sorted, UnorderedElementsAre(0, 1, 2, 3, 4));
+
+  auto n0 = std::find(sorted.begin(), sorted.end(), 0);
+  auto n1 = std::find(sorted.begin(), sorted.end(), 1);
+  auto n2 = std::find(sorted.begin(), sorted.end(), 2);
+  auto n3 = std::find(sorted.begin(), sorted.end(), 3);
+  auto n4 = std::find(sorted.begin(), sorted.end(), 4);
+
+  // n0 comes before it's children
+  EXPECT_LT(n0, n1);
+  EXPECT_LT(n0, n2);
+
+  // n3 comes before it's children
+  EXPECT_LT(n3, n2);
+  EXPECT_LT(n3, n4);
+}
+
+}  // namespace ift::encoder

--- a/ift/encoder/entry_graph_test.cc
+++ b/ift/encoder/entry_graph_test.cc
@@ -213,4 +213,48 @@ TEST(EntryGraphTest, TopologicalSort_SharedChildren) {
   EXPECT_LT(n3, n4);
 }
 
+TEST(EntryGraphTest, SplitLargeNode) {
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments;
+  ift::common::SegmentSet segment_ids;
+  for (int i = 1; i <= 130; ++i) {
+    segments[i].codepoints = {static_cast<hb_codepoint_t>(i)};
+    segment_ids.insert(i);
+  }
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments(segment_ids, 10),
+  };
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+
+  // Expected 130 codepoint nodes, 1 root node, and 1 intermediate split node.
+  EXPECT_EQ(entries->size(), 132);
+
+  size_t root_id = -1;
+  size_t split_node_id = -1;
+
+  for (size_t i = 0; i < entries->size(); i++) {
+    const auto& entry = (*entries)[i];
+    if (!entry.ignored && !entry.patch_indices.empty() && entry.patch_indices[0] == 10) {
+      root_id = i;
+    } else if (entry.ignored && entry.coverage.codepoints.empty() && !entry.coverage.child_indices.empty()) {
+      split_node_id = i;
+    }
+  }
+
+  ASSERT_NE(root_id, -1);
+  ASSERT_NE(split_node_id, -1);
+
+  // The root node gets the first 126 children + the split node (total 127).
+  EXPECT_EQ((*entries)[root_id].coverage.child_indices.size(), 127);
+  EXPECT_TRUE((*entries)[root_id].coverage.child_indices.contains(split_node_id));
+
+  // The split node gets the remaining 4 children.
+  EXPECT_EQ((*entries)[split_node_id].coverage.child_indices.size(), 4);
+}
+
 }  // namespace ift::encoder


### PR DESCRIPTION
- More flexible approach that first encodes as a graph and then turns that into the patch map entries.
- Will allow the entry graph  to be optimized to reduce encoded size.
- Fixes encoding failure when an entry ends up with more than 127 children (for issue #205)