### PR TITLE
Add basic entry graph optimization.

### DIFF
--- a/ift/common/testdata/roboto_vf_seg_plan.txtpb
+++ b/ift/common/testdata/roboto_vf_seg_plan.txtpb
@@ -1,0 +1,15566 @@
+segments {
+  key: 11
+  value {
+    codepoints {
+      values: 95
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 13
+  value {
+    codepoints {
+      values: 33
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 14
+  value {
+    codepoints {
+      values: 169
+      values: 8194
+      values: 8243
+      values: 65279
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 15
+  value {
+    codepoints {
+      values: 38
+      values: 189
+      values: 8201
+      values: 8242
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 16
+  value {
+    codepoints {
+      values: 37
+      values: 91
+      values: 92
+      values: 93
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 17
+  value {
+    codepoints {
+      values: 43
+      values: 124
+      values: 8211
+      values: 8230
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 19
+  value {
+    codepoints {
+      values: 8217
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 22
+  value {
+    codepoints {
+      values: 64
+      values: 188
+      values: 258
+      values: 286
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 23
+  value {
+    codepoints {
+      values: 125
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 24
+  value {
+    codepoints {
+      values: 123
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 27
+  value {
+    codepoints {
+      values: 196
+      values: 8216
+      values: 8220
+      values: 8221
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 29
+  value {
+    codepoints {
+      values: 243
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 30
+  value {
+    codepoints {
+      values: 199
+      values: 231
+      values: 287
+      values: 355
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 31
+  value {
+    codepoints {
+      values: 225
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 32
+  value {
+    codepoints {
+      values: 36
+      values: 8224
+      values: 8722
+      values: 65533
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 33
+  value {
+    codepoints {
+      values: 237
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 34
+  value {
+    codepoints {
+      values: 226
+      values: 234
+      values: 244
+      values: 259
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 35
+  value {
+    codepoints {
+      values: 183
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 36
+  value {
+    codepoints {
+      values: 250
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 38
+  value {
+    codepoints {
+      values: 224
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 39
+  value {
+    codepoints {
+      values: 220
+      values: 228
+      values: 246
+      values: 252
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 40
+  value {
+    codepoints {
+      values: 241
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 41
+  value {
+    codepoints {
+      values: 94
+      values: 177
+      values: 215
+      values: 322
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 42
+  value {
+    codepoints {
+      values: 62
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 44
+  value {
+    codepoints {
+      values: 8212
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 46
+  value {
+    codepoints {
+      values: 232
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 47
+  value {
+    codepoints {
+      values: 270
+      values: 282
+      values: 344
+      values: 8364
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 50
+  value {
+    codepoints {
+      values: 201
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 51
+  value {
+    codepoints {
+      values: 187
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 52
+  value {
+    codepoints {
+      values: 227
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 56
+  value {
+    codepoints {
+      values: 245
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 57
+  value {
+    codepoints {
+      values: 214
+      values: 235
+      values: 239
+      values: 318
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 58
+  value {
+    codepoints {
+      values: 165
+      values: 174
+      values: 363
+      values: 8363
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 59
+  value {
+    codepoints {
+      values: 176
+      values: 321
+      values: 379
+      values: 380
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 60
+  value {
+    codepoints {
+      values: 249
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 61
+  value {
+    codepoints {
+      values: 223
+      values: 271
+      values: 328
+      values: 357
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 62
+  value {
+    codepoints {
+      values: 218
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 64
+  value {
+    codepoints {
+      values: 205
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 65
+  value {
+    codepoints {
+      values: 60
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 66
+  value {
+    codepoints {
+      values: 211
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 67
+  value {
+    codepoints {
+      values: 268
+      values: 269
+      values: 353
+      values: 382
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 68
+  value {
+    codepoints {
+      values: 171
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 69
+  value {
+    codepoints {
+      values: 7844
+      values: 7845
+      values: 7853
+      values: 7870
+      values: 7871
+      values: 7879
+      values: 7888
+      values: 7889
+      values: 7897
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 70
+  value {
+    codepoints {
+      values: 161
+      values: 191
+      values: 257
+      values: 8378
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 74
+  value {
+    codepoints {
+      values: 192
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 76
+  value {
+    codepoints {
+      values: 283
+      values: 345
+      values: 381
+      values: 8222
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 77
+  value {
+    codepoints {
+      values: 126
+      values: 202
+      values: 206
+      values: 251
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 78
+  value {
+    codepoints {
+      values: 253
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 79
+  value {
+    codepoints {
+      values: 242
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 80
+  value {
+    codepoints {
+      values: 194
+      values: 212
+      values: 238
+      values: 7854
+      values: 7855
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 83
+  value {
+    codepoints {
+      values: 236
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 85
+  value {
+    codepoints {
+      values: 8250
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 87
+  value {
+    codepoints {
+      values: 263
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 88
+  value {
+    codepoints {
+      values: 261
+      values: 279
+      values: 280
+      values: 281
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 89
+  value {
+    codepoints {
+      values: 304
+      values: 350
+      values: 351
+      values: 8369
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 91
+  value {
+    codepoints {
+      values: 197
+      values: 229
+      values: 366
+      values: 367
+      values: 730
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 92
+  value {
+    codepoints {
+      values: 163
+      values: 7890
+      values: 8361
+      values: 8362
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 93
+  value {
+    codepoints {
+      values: 347
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 94
+  value {
+    codepoints {
+      values: 305
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 95
+  value {
+    codepoints {
+      values: 7846
+      values: 7847
+      values: 7872
+      values: 7873
+      values: 7891
+      values: 8482
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 99
+  value {
+    codepoints {
+      values: 324
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 102
+  value {
+    codepoints {
+      values: 170
+      values: 186
+      values: 337
+      values: 369
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 104
+  value {
+    codepoints {
+      values: 378
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 105
+  value {
+    codepoints {
+      values: 195
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 106
+  value {
+    codepoints {
+      values: 272
+      values: 273
+      values: 7848
+      values: 7849
+      values: 7850
+      values: 7851
+      values: 7856
+      values: 7857
+      values: 7863
+      values: 7874
+      values: 7875
+      values: 7876
+      values: 7877
+      values: 7892
+      values: 7893
+      values: 7894
+      values: 7895
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 109
+  value {
+    codepoints {
+      values: 432
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 110
+  value {
+    codepoints {
+      values: 352
+      values: 371
+      values: 7858
+      values: 7859
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 111
+  value {
+    codepoints {
+      values: 7843
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 112
+  value {
+    codepoints {
+      values: 7841
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 114
+  value {
+    codepoints {
+      values: 7899
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 118
+  value {
+    codepoints {
+      values: 7901
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 119
+  value {
+    codepoints {
+      values: 7883
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 120
+  value {
+    codepoints {
+      values: 417
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 122
+  value {
+    codepoints {
+      values: 7911
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 125
+  value {
+    codepoints {
+      values: 7907
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 127
+  value {
+    codepoints {
+      values: 7909
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 128
+  value {
+    codepoints {
+      values: 7885
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 129
+  value {
+    codepoints {
+      values: 7921
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 130
+  value {
+    codepoints {
+      values: 7913
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 134
+  value {
+    codepoints {
+      values: 200
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 136
+  value {
+    codepoints {
+      values: 346
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 138
+  value {
+    codepoints {
+      values: 7903
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 139
+  value {
+    codepoints {
+      values: 7917
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 140
+  value {
+    codepoints {
+      values: 7919
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 143
+  value {
+    codepoints {
+      values: 7915
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 144
+  value {
+    codepoints {
+      values: 7881
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 145
+  value {
+    codepoints {
+      values: 8249
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 148
+  value {
+    codepoints {
+      values: 7887
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 149
+  value {
+    codepoints {
+      values: 7852
+      values: 7860
+      values: 7861
+      values: 8377
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 155
+  value {
+    codepoints {
+      values: 260
+      values: 339
+      values: 7878
+      values: 7896
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 164
+  value {
+    codepoints {
+      values: 7867
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 165
+  value {
+    codepoints {
+      values: 361
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 167
+  value {
+    codepoints {
+      values: 167
+      values: 216
+      values: 248
+      values: 510
+      values: 511
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 170
+  value {
+    codepoints {
+      values: 7869
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 171
+  value {
+    codepoints {
+      values: 297
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 173
+  value {
+    codepoints {
+      values: 7865
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 174
+  value {
+    codepoints {
+      values: 230
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 175
+  value {
+    codepoints {
+      values: 209
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 176
+  value {
+    codepoints {
+      values: 7929
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 177
+  value {
+    codepoints {
+      values: 96
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 178
+  value {
+    codepoints {
+      values: 7842
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 180
+  value {
+    codepoints {
+      values: 431
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 182
+  value {
+    codepoints {
+      values: 7905
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 183
+  value {
+    codepoints {
+      values: 7923
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 187
+  value {
+    codepoints {
+      values: 213
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 188
+  value {
+    codepoints {
+      values: 221
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 189
+  value {
+    codepoints {
+      values: 537
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 194
+  value {
+    codepoints {
+      values: 539
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 197
+  value {
+    codepoints {
+      values: 7840
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 203
+  value {
+    codepoints {
+      values: 7927
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 208
+  value {
+    codepoints {
+      values: 7912
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 209
+  value {
+    codepoints {
+      values: 7898
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 214
+  value {
+    codepoints {
+      values: 7908
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 216
+  value {
+    codepoints {
+      values: 416
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 218
+  value {
+    codepoints {
+      values: 7910
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 219
+  value {
+    codepoints {
+      values: 7882
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 223
+  value {
+    codepoints {
+      values: 204
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 224
+  value {
+    codepoints {
+      values: 262
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 229
+  value {
+    codepoints {
+      values: 768
+      values: 7808
+      values: 7809
+      values: 7922
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 235
+  value {
+    codepoints {
+      values: 7900
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 236
+  value {
+    codepoints {
+      values: 7884
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 237
+  value {
+    codepoints {
+      values: 7906
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 238
+  value {
+    codepoints {
+      values: 7902
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 240
+  value {
+    codepoints {
+      values: 7920
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 241
+  value {
+    codepoints {
+      values: 217
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 242
+  value {
+    codepoints {
+      values: 377
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 243
+  value {
+    codepoints {
+      values: 181
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 245
+  value {
+    codepoints {
+      values: 803
+      values: 7864
+      values: 7924
+      values: 7925
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 246
+  value {
+    codepoints {
+      values: 601
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 247
+  value {
+    codepoints {
+      values: 210
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 250
+  value {
+    codepoints {
+      values: 536
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 252
+  value {
+    codepoints {
+      values: 7916
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 253
+  value {
+    codepoints {
+      values: 323
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 256
+  value {
+    codepoints {
+      values: 296
+      values: 360
+      values: 771
+      values: 7868
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 259
+  value {
+    codepoints {
+      values: 777
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 264
+  value {
+    codepoints {
+      values: 317
+      values: 333
+      values: 336
+      values: 7862
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 265
+  value {
+    codepoints {
+      values: 314
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 266
+  value {
+    codepoints {
+      values: 538
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 271
+  value {
+    codepoints {
+      values: 198
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 272
+  value {
+    codepoints {
+      values: 275
+      values: 299
+      values: 303
+      values: 356
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 275
+  value {
+    codepoints {
+      values: 7918
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 276
+  value {
+    codepoints {
+      values: 7886
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 280
+  value {
+    codepoints {
+      values: 247
+      values: 302
+      values: 8358
+      values: 8360
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 283
+  value {
+    codepoints {
+      values: 7914
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 285
+  value {
+    codepoints {
+      values: 190
+      values: 203
+      values: 402
+      values: 8218
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 286
+  value {
+    codepoints {
+      values: 7928
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 287
+  value {
+    codepoints {
+      values: 7880
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 290
+  value {
+    codepoints {
+      values: 341
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 292
+  value {
+    codepoints {
+      values: 162
+      values: 338
+      values: 8203
+      values: 8380
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 294
+  value {
+    codepoints {
+      values: 7866
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 298
+  value {
+    codepoints {
+      values: 326
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 300
+  value {
+    codepoints {
+      values: 316
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 304
+  value {
+    codepoints {
+      values: 240
+      values: 327
+      values: 354
+      values: 399
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 306
+  value {
+    codepoints {
+      values: 168
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 310
+  value {
+    codepoints {
+      values: 256
+      values: 291
+      values: 362
+      values: 700
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 312
+  value {
+    codepoints {
+      values: 311
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 316
+  value {
+    codepoints {
+      values: 182
+      values: 207
+      values: 278
+      values: 368
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 318
+  value {
+    codepoints {
+      values: 175
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 322
+  value {
+    codepoints {
+      values: 732
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 325
+  value {
+    codepoints {
+      values: 7904
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 326
+  value {
+    codepoints {
+      values: 254
+      values: 274
+      values: 298
+      values: 332
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 327
+  value {
+    codepoints {
+      values: 7926
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 331
+  value {
+    codepoints {
+      values: 164
+      values: 208
+      values: 222
+      values: 8381
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 335
+  value {
+    codepoints {
+      values: 166
+      values: 172
+      values: 219
+      values: 370
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 339
+  value {
+    codepoints {
+      values: 710
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 340
+  value {
+    codepoints {
+      values: 255
+      values: 331
+      values: 376
+      values: 8467
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 341
+  value {
+    codepoints {
+      values: 184
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 343
+  value {
+    codepoints {
+      values: 310
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 347
+  value {
+    codepoints {
+      values: 290
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 348
+  value {
+    codepoints {
+      values: 315
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 350
+  value {
+    codepoints {
+      values: 313
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 351
+  value {
+    codepoints {
+      values: 173
+      values: 277
+      values: 335
+      values: 8355
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 352
+  value {
+    codepoints {
+      values: 325
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 356
+  value {
+    codepoints {
+      values: 711
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 358
+  value {
+    codepoints {
+      values: 267
+      values: 359
+      values: 365
+      values: 7838
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 362
+  value {
+    codepoints {
+      values: 733
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 363
+  value {
+    codepoints {
+      values: 289
+      values: 295
+      values: 301
+      values: 349
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 367
+  value {
+    codepoints {
+      values: 285
+      values: 294
+      values: 373
+      values: 375
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 370
+  value {
+    codepoints {
+      values: 340
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 372
+  value {
+    codepoints {
+      values: 265
+      values: 288
+      values: 293
+      values: 309
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 377
+  value {
+    codepoints {
+      values: 266
+      values: 307
+      values: 383
+      values: 713
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 381
+  value {
+    codepoints {
+      values: 264
+      values: 348
+      values: 358
+      values: 374
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 382
+  value {
+    codepoints {
+      values: 342
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 383
+  value {
+    codepoints {
+      values: 312
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 387
+  value {
+    codepoints {
+      values: 306
+      values: 308
+      values: 329
+      values: 330
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 391
+  value {
+    codepoints {
+      values: 755
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 392
+  value {
+    codepoints {
+      values: 284
+      values: 292
+      values: 320
+      values: 8356
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 394
+  value {
+    codepoints {
+      values: 343
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 397
+  value {
+    codepoints {
+      values: 300
+      values: 319
+      values: 372
+      values: 496
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 402
+  value {
+    codepoints {
+      values: 276
+      values: 334
+      values: 364
+      values: 7812
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 404
+  value {
+    codepoints {
+      values: 567
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 407
+  value {
+    codepoints {
+      values: 7743
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 409
+  value {
+    codepoints {
+      values: 506
+      values: 7681
+      values: 7813
+      values: 8359
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 411
+  value {
+    codepoints {
+      values: 509
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 412
+  value {
+    codepoints {
+      values: 508
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 415
+  value {
+    codepoints {
+      values: 7811
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 416
+  value {
+    codepoints {
+      values: 7742
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 418
+  value {
+    codepoints {
+      values: 7810
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 420
+  value {
+    codepoints {
+      values: 507
+      values: 7680
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 422
+  value {
+    codepoints {
+      values: 8196
+      values: 8197
+      values: 8198
+      values: 8202
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 426
+  value {
+    codepoints {
+      values: 8192
+      values: 8193
+      values: 8199
+      values: 9674
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 427
+  value {
+    codepoints {
+      values: 8200
+      values: 8540
+      values: 8541
+      values: 8542
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 429
+  value {
+    codepoints {
+      values: 8539
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 435
+  value {
+    codepoints {
+      values: 1085
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 436
+  value {
+    codepoints {
+      values: 1090
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 437
+  value {
+    codepoints {
+      values: 1040
+      values: 1041
+      values: 1042
+      values: 1043
+      values: 1044
+      values: 1045
+      values: 1050
+      values: 1052
+      values: 1053
+      values: 1054
+      values: 1055
+      values: 1056
+      values: 1057
+      values: 1058
+      values: 1060
+      values: 1061
+      values: 1062
+      values: 1064
+      values: 1071
+      values: 1072
+      values: 1073
+      values: 1074
+      values: 1076
+      values: 1077
+      values: 1081
+      values: 1086
+      values: 1087
+      values: 1088
+      values: 1089
+      values: 1091
+      values: 1092
+      values: 1093
+      values: 1094
+      values: 1096
+      values: 1097
+      values: 1098
+      values: 1099
+      values: 1100
+      values: 1102
+      values: 1103
+      values: 1105
+      values: 1273
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 440
+  value {
+    codepoints {
+      values: 1083
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 444
+  value {
+    codepoints {
+      values: 1080
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 445
+  value {
+    codepoints {
+      values: 1082
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 447
+  value {
+    codepoints {
+      values: 1084
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 449
+  value {
+    codepoints {
+      values: 1079
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 450
+  value {
+    codepoints {
+      values: 1075
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 454
+  value {
+    codepoints {
+      values: 1095
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 456
+  value {
+    codepoints {
+      values: 1078
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 476
+  value {
+    codepoints {
+      values: 1047
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 478
+  value {
+    codepoints {
+      values: 1059
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 479
+  value {
+    codepoints {
+      values: 1048
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 481
+  value {
+    codepoints {
+      values: 1051
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 484
+  value {
+    codepoints {
+      values: 1063
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 485
+  value {
+    codepoints {
+      values: 1101
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 489
+  value {
+    codepoints {
+      values: 1069
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 491
+  value {
+    codepoints {
+      values: 1046
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 494
+  value {
+    codepoints {
+      values: 1025
+      values: 1030
+      values: 1031
+      values: 1070
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 495
+  value {
+    codepoints {
+      values: 1049
+      values: 1067
+      values: 1068
+      values: 1272
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 497
+  value {
+    codepoints {
+      values: 1065
+      values: 1108
+      values: 1110
+      values: 1111
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 498
+  value {
+    codepoints {
+      values: 1066
+      values: 1178
+      values: 1179
+      values: 8470
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 504
+  value {
+    codepoints {
+      values: 1028
+      values: 1139
+      values: 1169
+      values: 1199
+      values: 1257
+      values: 1259
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 513
+  value {
+    codepoints {
+      values: 1112
+      values: 1114
+      values: 1171
+      values: 1187
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 517
+  value {
+    codepoints {
+      values: 1113
+      values: 1201
+      values: 1241
+      values: 1256
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 521
+  value {
+    codepoints {
+      values: 1032
+      values: 1106
+      values: 1115
+      values: 1198
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 524
+  value {
+    codepoints {
+      values: 1240
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 526
+  value {
+    codepoints {
+      values: 1116
+      values: 1118
+      values: 1168
+      values: 1200
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 530
+  value {
+    codepoints {
+      values: 1034
+      values: 1117
+      values: 1119
+      values: 1170
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 534
+  value {
+    codepoints {
+      values: 1026
+      values: 1035
+      values: 1038
+      values: 1107
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 538
+  value {
+    codepoints {
+      values: 1027
+      values: 1029
+      values: 1033
+      values: 1109
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 542
+  value {
+    codepoints {
+      values: 1039
+      values: 1186
+      values: 1207
+      values: 1251
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 546
+  value {
+    codepoints {
+      values: 1036
+      values: 1185
+      values: 1203
+      values: 1211
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 550
+  value {
+    codepoints {
+      values: 1104
+      values: 1202
+      values: 1206
+      values: 1263
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 554
+  value {
+    codepoints {
+      values: 1123
+      values: 1177
+      values: 1233
+      values: 1255
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 558
+  value {
+    codepoints {
+      values: 1122
+      values: 1210
+      values: 1250
+      values: 1262
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 559
+  value {
+    codepoints {
+      values: 1140
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 564
+  value {
+    codepoints {
+      values: 1174
+      values: 1175
+      values: 1195
+      values: 1254
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 568
+  value {
+    codepoints {
+      values: 1127
+      values: 1145
+      values: 1156
+      values: 1158
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 572
+  value {
+    codepoints {
+      values: 1121
+      values: 1184
+      values: 1189
+      values: 1216
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 573
+  value {
+    codepoints {
+      values: 1138
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 577
+  value {
+    codepoints {
+      values: 1180
+      values: 1231
+      values: 1265
+      values: 1277
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 581
+  value {
+    codepoints {
+      values: 1173
+      values: 1226
+      values: 1239
+      values: 1244
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 584
+  value {
+    codepoints {
+      values: 1141
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 586
+  value {
+    codepoints {
+      values: 1129
+      values: 1193
+      values: 1220
+      values: 1237
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 588
+  value {
+    codepoints {
+      values: 1213
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 592
+  value {
+    codepoints {
+      values: 1133
+      values: 1246
+      values: 1268
+      values: 1298
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 596
+  value {
+    codepoints {
+      values: 1253
+      values: 1267
+      values: 1278
+      values: 1299
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 600
+  value {
+    codepoints {
+      values: 1224
+      values: 1245
+      values: 1247
+      values: 1269
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 604
+  value {
+    codepoints {
+      values: 1024
+      values: 1037
+      values: 1131
+      values: 1243
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 608
+  value {
+    codepoints {
+      values: 1120
+      values: 1176
+      values: 1191
+      values: 1242
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 612
+  value {
+    codepoints {
+      values: 1125
+      values: 1188
+      values: 1234
+      values: 1249
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 616
+  value {
+    codepoints {
+      values: 1183
+      values: 1190
+      values: 1225
+      values: 1235
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 620
+  value {
+    codepoints {
+      values: 1126
+      values: 1150
+      values: 1227
+      values: 1271
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 624
+  value {
+    codepoints {
+      values: 1172
+      values: 1194
+      values: 1208
+      values: 1281
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 628
+  value {
+    codepoints {
+      values: 1154
+      values: 1197
+      values: 1205
+      values: 1215
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 632
+  value {
+    codepoints {
+      values: 1130
+      values: 1181
+      values: 1182
+      values: 1209
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 636
+  value {
+    codepoints {
+      values: 1204
+      values: 1264
+      values: 1274
+      values: 1296
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 640
+  value {
+    codepoints {
+      values: 1132
+      values: 1152
+      values: 1192
+      values: 1214
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 641
+  value {
+    codepoints {
+      values: 1212
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 645
+  value {
+    codepoints {
+      values: 1124
+      values: 1128
+      values: 1134
+      values: 1196
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 649
+  value {
+    codepoints {
+      values: 1136
+      values: 1137
+      values: 1144
+      values: 1151
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 653
+  value {
+    codepoints {
+      values: 1219
+      values: 1236
+      values: 1276
+      values: 1297
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 657
+  value {
+    codepoints {
+      values: 1162
+      values: 1166
+      values: 1248
+      values: 1258
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 662
+  value {
+    codepoints {
+      values: 1142
+      values: 1146
+      values: 1260
+      values: 1266
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 666
+  value {
+    codepoints {
+      values: 1164
+      values: 1217
+      values: 1221
+      values: 1223
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 670
+  value {
+    codepoints {
+      values: 1229
+      values: 1232
+      values: 1238
+      values: 1252
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 674
+  value {
+    codepoints {
+      values: 1135
+      values: 1163
+      values: 1270
+      values: 1280
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 678
+  value {
+    codepoints {
+      values: 1282
+      values: 1284
+      values: 1285
+      values: 1286
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 682
+  value {
+    codepoints {
+      values: 1288
+      values: 1290
+      values: 1292
+      values: 1294
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 686
+  value {
+    codepoints {
+      values: 1148
+      values: 1153
+      values: 1155
+      values: 1228
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 690
+  value {
+    codepoints {
+      values: 1165
+      values: 1283
+      values: 1287
+      values: 1293
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 694
+  value {
+    codepoints {
+      values: 1161
+      values: 1289
+      values: 1291
+      values: 1295
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 698
+  value {
+    codepoints {
+      values: 1261
+      values: 1275
+      values: 1279
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 706
+  value {
+    codepoints {
+      values: 949
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 718
+  value {
+    codepoints {
+      values: 947
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 727
+  value {
+    codepoints {
+      values: 928
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 737
+  value {
+    codepoints {
+      values: 916
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 743
+  value {
+    codepoints {
+      values: 915
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 753
+  value {
+    codepoints {
+      values: 968
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 755
+  value {
+    codepoints {
+      values: 937
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 761
+  value {
+    codepoints {
+      values: 936
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 762
+  value {
+    codepoints {
+      values: 901
+      values: 902
+      values: 904
+      values: 905
+      values: 908
+      values: 912
+      values: 913
+      values: 914
+      values: 917
+      values: 918
+      values: 919
+      values: 920
+      values: 921
+      values: 922
+      values: 923
+      values: 924
+      values: 925
+      values: 926
+      values: 927
+      values: 929
+      values: 931
+      values: 932
+      values: 933
+      values: 934
+      values: 935
+      values: 938
+      values: 940
+      values: 941
+      values: 942
+      values: 943
+      values: 944
+      values: 945
+      values: 946
+      values: 948
+      values: 950
+      values: 951
+      values: 952
+      values: 953
+      values: 954
+      values: 955
+      values: 956
+      values: 957
+      values: 958
+      values: 959
+      values: 960
+      values: 961
+      values: 962
+      values: 963
+      values: 964
+      values: 965
+      values: 966
+      values: 967
+      values: 969
+      values: 970
+      values: 971
+      values: 972
+      values: 973
+      values: 974
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 766
+  value {
+    codepoints {
+      values: 906
+      values: 910
+      values: 911
+      values: 939
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 768
+  value {
+    codepoints {
+      values: 900
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 772
+  value {
+    codepoints {
+      values: 903
+      values: 977
+      values: 8013
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 776
+  value {
+    codepoints {
+      values: 783
+      values: 8231
+      values: 65532
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 846
+  value {
+    codepoints {
+      values: 42
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 847
+  value {
+    codepoints {
+      values: 35
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 848
+  value {
+    codepoints {
+      values: 8226
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 849
+  value {
+    codepoints {
+      values: 160
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 850
+  value {
+    codepoints {
+      values: 769
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 851
+  value {
+    codepoints {
+    }
+    features {
+      values: "c2sc"
+    }
+  }
+}
+segments {
+  key: 852
+  value {
+    codepoints {
+    }
+    features {
+      values: "cpsp"
+    }
+  }
+}
+segments {
+  key: 853
+  value {
+    codepoints {
+    }
+    features {
+      values: "dlig"
+    }
+  }
+}
+segments {
+  key: 854
+  value {
+    codepoints {
+    }
+    features {
+      values: "lnum"
+    }
+  }
+}
+segments {
+  key: 855
+  value {
+    codepoints {
+    }
+    features {
+      values: "onum"
+    }
+  }
+}
+segments {
+  key: 856
+  value {
+    codepoints {
+    }
+    features {
+      values: "pnum"
+    }
+  }
+}
+segments {
+  key: 857
+  value {
+    codepoints {
+    }
+    features {
+      values: "smcp"
+    }
+  }
+}
+segments {
+  key: 858
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss01"
+    }
+  }
+}
+segments {
+  key: 859
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss02"
+    }
+  }
+}
+segments {
+  key: 860
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss03"
+    }
+  }
+}
+segments {
+  key: 861
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss04"
+    }
+  }
+}
+segments {
+  key: 862
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss05"
+    }
+  }
+}
+segments {
+  key: 863
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss06"
+    }
+  }
+}
+segments {
+  key: 864
+  value {
+    codepoints {
+    }
+    features {
+      values: "ss07"
+    }
+  }
+}
+segments {
+  key: 865
+  value {
+    codepoints {
+    }
+    features {
+      values: "subs"
+    }
+  }
+}
+segments {
+  key: 866
+  value {
+    codepoints {
+    }
+    features {
+      values: "sups"
+    }
+  }
+}
+segments {
+  key: 867
+  value {
+    codepoints {
+    }
+    features {
+      values: "tnum"
+    }
+  }
+}
+segments {
+  key: 868
+  value {
+    codepoints {
+      values: 0
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 869
+  value {
+    codepoints {
+      values: 2
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 870
+  value {
+    codepoints {
+      values: 13
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 871
+  value {
+    codepoints {
+      values: 728
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 872
+  value {
+    codepoints {
+      values: 729
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 873
+  value {
+    codepoints {
+      values: 731
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 874
+  value {
+    codepoints {
+      values: 978
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 875
+  value {
+    codepoints {
+      values: 982
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 876
+  value {
+    codepoints {
+      values: 1143
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 877
+  value {
+    codepoints {
+      values: 1147
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 878
+  value {
+    codepoints {
+      values: 1149
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 879
+  value {
+    codepoints {
+      values: 1157
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 880
+  value {
+    codepoints {
+      values: 1160
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 881
+  value {
+    codepoints {
+      values: 1167
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 882
+  value {
+    codepoints {
+      values: 1218
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 883
+  value {
+    codepoints {
+      values: 1222
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 884
+  value {
+    codepoints {
+      values: 1230
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 885
+  value {
+    codepoints {
+      values: 8195
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 886
+  value {
+    codepoints {
+      values: 8208
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 887
+  value {
+    codepoints {
+      values: 8209
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 888
+  value {
+    codepoints {
+      values: 8213
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 889
+  value {
+    codepoints {
+      values: 8215
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 890
+  value {
+    codepoints {
+      values: 8219
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 891
+  value {
+    codepoints {
+      values: 8225
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 892
+  value {
+    codepoints {
+      values: 8229
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 893
+  value {
+    codepoints {
+      values: 8240
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 894
+  value {
+    codepoints {
+      values: 8252
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 895
+  value {
+    codepoints {
+      values: 8304
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 896
+  value {
+    codepoints {
+      values: 8308
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 897
+  value {
+    codepoints {
+      values: 8309
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 898
+  value {
+    codepoints {
+      values: 8310
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 899
+  value {
+    codepoints {
+      values: 8311
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 900
+  value {
+    codepoints {
+      values: 8312
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 901
+  value {
+    codepoints {
+      values: 8313
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 902
+  value {
+    codepoints {
+      values: 8314
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 903
+  value {
+    codepoints {
+      values: 8315
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 904
+  value {
+    codepoints {
+      values: 8316
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 905
+  value {
+    codepoints {
+      values: 8317
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 906
+  value {
+    codepoints {
+      values: 8318
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 907
+  value {
+    codepoints {
+      values: 8319
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 908
+  value {
+    codepoints {
+      values: 8320
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 909
+  value {
+    codepoints {
+      values: 8321
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 910
+  value {
+    codepoints {
+      values: 8322
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 911
+  value {
+    codepoints {
+      values: 8323
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 912
+  value {
+    codepoints {
+      values: 8324
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 913
+  value {
+    codepoints {
+      values: 8325
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 914
+  value {
+    codepoints {
+      values: 8326
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 915
+  value {
+    codepoints {
+      values: 8327
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 916
+  value {
+    codepoints {
+      values: 8328
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 917
+  value {
+    codepoints {
+      values: 8329
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 918
+  value {
+    codepoints {
+      values: 8330
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 919
+  value {
+    codepoints {
+      values: 8331
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 920
+  value {
+    codepoints {
+      values: 8332
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 921
+  value {
+    codepoints {
+      values: 8333
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 922
+  value {
+    codepoints {
+      values: 8334
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 923
+  value {
+    codepoints {
+      values: 8453
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 924
+  value {
+    codepoints {
+      values: 8486
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 925
+  value {
+    codepoints {
+      values: 8494
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 926
+  value {
+    codepoints {
+      values: 8706
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 927
+  value {
+    codepoints {
+      values: 8710
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 928
+  value {
+    codepoints {
+      values: 8719
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 929
+  value {
+    codepoints {
+      values: 8721
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 930
+  value {
+    codepoints {
+      values: 8730
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 931
+  value {
+    codepoints {
+      values: 8734
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 932
+  value {
+    codepoints {
+      values: 8747
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 933
+  value {
+    codepoints {
+      values: 8776
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 934
+  value {
+    codepoints {
+      values: 8800
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 935
+  value {
+    codepoints {
+      values: 8804
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 936
+  value {
+    codepoints {
+      values: 8805
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 937
+  value {
+    codepoints {
+      values: 60929
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 938
+  value {
+    codepoints {
+      values: 60930
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 939
+  value {
+    codepoints {
+      values: 63171
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 940
+  value {
+    codepoints {
+      values: 32
+      values: 33
+      values: 34
+      values: 35
+      values: 36
+      values: 37
+      values: 38
+      values: 39
+      values: 40
+      values: 41
+      values: 42
+      values: 43
+      values: 44
+      values: 45
+      values: 46
+      values: 47
+      values: 48
+      values: 49
+      values: 50
+      values: 51
+      values: 52
+      values: 53
+      values: 54
+      values: 55
+      values: 56
+      values: 57
+      values: 58
+      values: 59
+      values: 60
+      values: 61
+      values: 62
+      values: 63
+      values: 64
+      values: 65
+      values: 66
+      values: 67
+      values: 68
+      values: 69
+      values: 70
+      values: 71
+      values: 72
+      values: 73
+      values: 74
+      values: 75
+      values: 76
+      values: 77
+      values: 78
+      values: 79
+      values: 80
+      values: 81
+      values: 82
+      values: 83
+      values: 84
+      values: 85
+      values: 86
+      values: 87
+      values: 88
+      values: 89
+      values: 90
+      values: 91
+      values: 92
+      values: 93
+      values: 94
+      values: 95
+      values: 96
+      values: 97
+      values: 98
+      values: 99
+      values: 100
+      values: 101
+      values: 102
+      values: 103
+      values: 104
+      values: 105
+      values: 106
+      values: 107
+      values: 108
+      values: 109
+      values: 110
+      values: 111
+      values: 112
+      values: 113
+      values: 114
+      values: 115
+      values: 116
+      values: 117
+      values: 118
+      values: 119
+      values: 120
+      values: 121
+      values: 122
+      values: 123
+      values: 124
+      values: 125
+      values: 126
+      values: 160
+      values: 161
+      values: 162
+      values: 163
+      values: 164
+      values: 165
+      values: 166
+      values: 167
+      values: 168
+      values: 169
+      values: 170
+      values: 171
+      values: 172
+      values: 173
+      values: 174
+      values: 175
+      values: 176
+      values: 177
+      values: 178
+      values: 179
+      values: 180
+      values: 181
+      values: 182
+      values: 183
+      values: 184
+      values: 185
+      values: 186
+      values: 187
+      values: 188
+      values: 189
+      values: 190
+      values: 191
+      values: 192
+      values: 193
+      values: 194
+      values: 195
+      values: 196
+      values: 197
+      values: 198
+      values: 199
+      values: 200
+      values: 201
+      values: 202
+      values: 203
+      values: 204
+      values: 205
+      values: 206
+      values: 207
+      values: 208
+      values: 209
+      values: 210
+      values: 211
+      values: 212
+      values: 213
+      values: 214
+      values: 215
+      values: 216
+      values: 217
+      values: 218
+      values: 219
+      values: 220
+      values: 221
+      values: 222
+      values: 223
+      values: 224
+      values: 225
+      values: 226
+      values: 227
+      values: 228
+      values: 229
+      values: 230
+      values: 231
+      values: 232
+      values: 233
+      values: 234
+      values: 235
+      values: 236
+      values: 237
+      values: 238
+      values: 239
+      values: 240
+      values: 241
+      values: 242
+      values: 243
+      values: 244
+      values: 245
+      values: 246
+      values: 247
+      values: 248
+      values: 249
+      values: 250
+      values: 251
+      values: 252
+      values: 253
+      values: 254
+      values: 255
+      values: 256
+      values: 257
+      values: 258
+      values: 259
+      values: 260
+      values: 261
+      values: 262
+      values: 263
+      values: 264
+      values: 265
+      values: 266
+      values: 267
+      values: 268
+      values: 269
+      values: 270
+      values: 271
+      values: 272
+      values: 273
+      values: 274
+      values: 275
+      values: 276
+      values: 277
+      values: 278
+      values: 279
+      values: 280
+      values: 281
+      values: 282
+      values: 283
+      values: 284
+      values: 285
+      values: 286
+      values: 287
+      values: 288
+      values: 289
+      values: 290
+      values: 291
+      values: 292
+      values: 293
+      values: 294
+      values: 295
+      values: 296
+      values: 297
+      values: 298
+      values: 299
+      values: 300
+      values: 301
+      values: 302
+      values: 303
+      values: 304
+      values: 305
+      values: 306
+      values: 307
+      values: 308
+      values: 309
+      values: 310
+      values: 311
+      values: 312
+      values: 313
+      values: 314
+      values: 315
+      values: 316
+      values: 317
+      values: 318
+      values: 319
+      values: 320
+      values: 321
+      values: 322
+      values: 323
+      values: 324
+      values: 325
+      values: 326
+      values: 327
+      values: 328
+      values: 329
+      values: 330
+      values: 331
+      values: 332
+      values: 333
+      values: 334
+      values: 335
+      values: 336
+      values: 337
+      values: 338
+      values: 339
+      values: 340
+      values: 341
+      values: 342
+      values: 343
+      values: 344
+      values: 345
+      values: 346
+      values: 347
+      values: 348
+      values: 349
+      values: 350
+      values: 351
+      values: 352
+      values: 353
+      values: 354
+      values: 355
+      values: 356
+      values: 357
+      values: 358
+      values: 359
+      values: 360
+      values: 361
+      values: 362
+      values: 363
+      values: 364
+      values: 365
+      values: 366
+      values: 367
+      values: 368
+      values: 369
+      values: 370
+      values: 371
+      values: 372
+      values: 373
+      values: 374
+      values: 375
+      values: 376
+      values: 377
+      values: 378
+      values: 379
+      values: 380
+      values: 381
+      values: 382
+      values: 383
+      values: 399
+      values: 402
+      values: 416
+      values: 417
+      values: 431
+      values: 432
+      values: 496
+      values: 506
+      values: 507
+      values: 508
+      values: 509
+      values: 510
+      values: 511
+      values: 536
+      values: 537
+      values: 538
+      values: 539
+      values: 567
+      values: 601
+      values: 700
+      values: 710
+      values: 711
+      values: 713
+      values: 730
+      values: 732
+      values: 733
+      values: 755
+      values: 768
+      values: 769
+      values: 771
+      values: 777
+      values: 803
+      values: 7680
+      values: 7681
+      values: 7742
+      values: 7743
+      values: 7808
+      values: 7809
+      values: 7810
+      values: 7811
+      values: 7812
+      values: 7813
+      values: 7838
+      values: 7840
+      values: 7841
+      values: 7842
+      values: 7843
+      values: 7844
+      values: 7845
+      values: 7846
+      values: 7847
+      values: 7848
+      values: 7849
+      values: 7850
+      values: 7851
+      values: 7852
+      values: 7853
+      values: 7854
+      values: 7855
+      values: 7856
+      values: 7857
+      values: 7858
+      values: 7859
+      values: 7860
+      values: 7861
+      values: 7862
+      values: 7863
+      values: 7864
+      values: 7865
+      values: 7866
+      values: 7867
+      values: 7868
+      values: 7869
+      values: 7870
+      values: 7871
+      values: 7872
+      values: 7873
+      values: 7874
+      values: 7875
+      values: 7876
+      values: 7877
+      values: 7878
+      values: 7879
+      values: 7880
+      values: 7881
+      values: 7882
+      values: 7883
+      values: 7884
+      values: 7885
+      values: 7886
+      values: 7887
+      values: 7888
+      values: 7889
+      values: 7890
+      values: 7891
+      values: 7892
+      values: 7893
+      values: 7894
+      values: 7895
+      values: 7896
+      values: 7897
+      values: 7898
+      values: 7899
+      values: 7900
+      values: 7901
+      values: 7902
+      values: 7903
+      values: 7904
+      values: 7905
+      values: 7906
+      values: 7907
+      values: 7908
+      values: 7909
+      values: 7910
+      values: 7911
+      values: 7912
+      values: 7913
+      values: 7914
+      values: 7915
+      values: 7916
+      values: 7917
+      values: 7918
+      values: 7919
+      values: 7920
+      values: 7921
+      values: 7922
+      values: 7923
+      values: 7924
+      values: 7925
+      values: 7926
+      values: 7927
+      values: 7928
+      values: 7929
+      values: 8194
+      values: 8201
+      values: 8203
+      values: 8211
+      values: 8212
+      values: 8216
+      values: 8217
+      values: 8218
+      values: 8220
+      values: 8221
+      values: 8222
+      values: 8224
+      values: 8226
+      values: 8230
+      values: 8242
+      values: 8243
+      values: 8249
+      values: 8250
+      values: 8260
+      values: 8355
+      values: 8356
+      values: 8358
+      values: 8359
+      values: 8360
+      values: 8361
+      values: 8362
+      values: 8363
+      values: 8364
+      values: 8369
+      values: 8377
+      values: 8378
+      values: 8380
+      values: 8381
+      values: 8467
+      values: 8482
+      values: 8722
+      values: 65279
+      values: 65533
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 941
+  value {
+    codepoints {
+      values: 32
+      values: 35
+      values: 42
+      values: 48
+      values: 49
+      values: 50
+      values: 51
+      values: 52
+      values: 53
+      values: 54
+      values: 55
+      values: 56
+      values: 57
+      values: 65
+      values: 66
+      values: 67
+      values: 68
+      values: 69
+      values: 70
+      values: 71
+      values: 72
+      values: 73
+      values: 74
+      values: 75
+      values: 76
+      values: 77
+      values: 78
+      values: 79
+      values: 80
+      values: 81
+      values: 82
+      values: 83
+      values: 84
+      values: 85
+      values: 86
+      values: 87
+      values: 88
+      values: 89
+      values: 90
+      values: 97
+      values: 98
+      values: 99
+      values: 100
+      values: 101
+      values: 102
+      values: 103
+      values: 104
+      values: 105
+      values: 106
+      values: 107
+      values: 108
+      values: 109
+      values: 110
+      values: 111
+      values: 112
+      values: 113
+      values: 114
+      values: 115
+      values: 116
+      values: 117
+      values: 118
+      values: 119
+      values: 120
+      values: 121
+      values: 122
+      values: 160
+      values: 8192
+      values: 8193
+      values: 8196
+      values: 8197
+      values: 8198
+      values: 8199
+      values: 8200
+      values: 8202
+      values: 8226
+      values: 8539
+      values: 8540
+      values: 8541
+      values: 8542
+      values: 9674
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 942
+  value {
+    codepoints {
+      values: 32
+      values: 160
+      values: 769
+      values: 1024
+      values: 1025
+      values: 1026
+      values: 1027
+      values: 1028
+      values: 1029
+      values: 1030
+      values: 1031
+      values: 1032
+      values: 1033
+      values: 1034
+      values: 1035
+      values: 1036
+      values: 1037
+      values: 1038
+      values: 1039
+      values: 1040
+      values: 1041
+      values: 1042
+      values: 1043
+      values: 1044
+      values: 1045
+      values: 1046
+      values: 1047
+      values: 1048
+      values: 1049
+      values: 1050
+      values: 1051
+      values: 1052
+      values: 1053
+      values: 1054
+      values: 1055
+      values: 1056
+      values: 1057
+      values: 1058
+      values: 1059
+      values: 1060
+      values: 1061
+      values: 1062
+      values: 1063
+      values: 1064
+      values: 1065
+      values: 1066
+      values: 1067
+      values: 1068
+      values: 1069
+      values: 1070
+      values: 1071
+      values: 1072
+      values: 1073
+      values: 1074
+      values: 1075
+      values: 1076
+      values: 1077
+      values: 1078
+      values: 1079
+      values: 1080
+      values: 1081
+      values: 1082
+      values: 1083
+      values: 1084
+      values: 1085
+      values: 1086
+      values: 1087
+      values: 1088
+      values: 1089
+      values: 1090
+      values: 1091
+      values: 1092
+      values: 1093
+      values: 1094
+      values: 1095
+      values: 1096
+      values: 1097
+      values: 1098
+      values: 1099
+      values: 1100
+      values: 1101
+      values: 1102
+      values: 1103
+      values: 1104
+      values: 1105
+      values: 1106
+      values: 1107
+      values: 1108
+      values: 1109
+      values: 1110
+      values: 1111
+      values: 1112
+      values: 1113
+      values: 1114
+      values: 1115
+      values: 1116
+      values: 1117
+      values: 1118
+      values: 1119
+      values: 1120
+      values: 1121
+      values: 1122
+      values: 1123
+      values: 1124
+      values: 1125
+      values: 1126
+      values: 1127
+      values: 1128
+      values: 1129
+      values: 1130
+      values: 1131
+      values: 1132
+      values: 1133
+      values: 1134
+      values: 1135
+      values: 1136
+      values: 1137
+      values: 1138
+      values: 1139
+      values: 1140
+      values: 1141
+      values: 1142
+      values: 1144
+      values: 1145
+      values: 1146
+      values: 1148
+      values: 1150
+      values: 1151
+      values: 1152
+      values: 1153
+      values: 1154
+      values: 1155
+      values: 1156
+      values: 1158
+      values: 1161
+      values: 1162
+      values: 1163
+      values: 1164
+      values: 1165
+      values: 1166
+      values: 1168
+      values: 1169
+      values: 1170
+      values: 1171
+      values: 1172
+      values: 1173
+      values: 1174
+      values: 1175
+      values: 1176
+      values: 1177
+      values: 1178
+      values: 1179
+      values: 1180
+      values: 1181
+      values: 1182
+      values: 1183
+      values: 1184
+      values: 1185
+      values: 1186
+      values: 1187
+      values: 1188
+      values: 1189
+      values: 1190
+      values: 1191
+      values: 1192
+      values: 1193
+      values: 1194
+      values: 1195
+      values: 1196
+      values: 1197
+      values: 1198
+      values: 1199
+      values: 1200
+      values: 1201
+      values: 1202
+      values: 1203
+      values: 1204
+      values: 1205
+      values: 1206
+      values: 1207
+      values: 1208
+      values: 1209
+      values: 1210
+      values: 1211
+      values: 1212
+      values: 1213
+      values: 1214
+      values: 1215
+      values: 1216
+      values: 1217
+      values: 1219
+      values: 1220
+      values: 1221
+      values: 1223
+      values: 1224
+      values: 1225
+      values: 1226
+      values: 1227
+      values: 1228
+      values: 1229
+      values: 1231
+      values: 1232
+      values: 1233
+      values: 1234
+      values: 1235
+      values: 1236
+      values: 1237
+      values: 1238
+      values: 1239
+      values: 1240
+      values: 1241
+      values: 1242
+      values: 1243
+      values: 1244
+      values: 1245
+      values: 1246
+      values: 1247
+      values: 1248
+      values: 1249
+      values: 1250
+      values: 1251
+      values: 1252
+      values: 1253
+      values: 1254
+      values: 1255
+      values: 1256
+      values: 1257
+      values: 1258
+      values: 1259
+      values: 1260
+      values: 1261
+      values: 1262
+      values: 1263
+      values: 1264
+      values: 1265
+      values: 1266
+      values: 1267
+      values: 1268
+      values: 1269
+      values: 1270
+      values: 1271
+      values: 1272
+      values: 1273
+      values: 1274
+      values: 1275
+      values: 1276
+      values: 1277
+      values: 1278
+      values: 1279
+      values: 1280
+      values: 1281
+      values: 1282
+      values: 1283
+      values: 1284
+      values: 1285
+      values: 1286
+      values: 1287
+      values: 1288
+      values: 1289
+      values: 1290
+      values: 1291
+      values: 1292
+      values: 1293
+      values: 1294
+      values: 1295
+      values: 1296
+      values: 1297
+      values: 1298
+      values: 1299
+      values: 8470
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 943
+  value {
+    codepoints {
+      values: 32
+      values: 160
+      values: 900
+      values: 901
+      values: 902
+      values: 903
+      values: 904
+      values: 905
+      values: 906
+      values: 908
+      values: 910
+      values: 911
+      values: 912
+      values: 913
+      values: 914
+      values: 915
+      values: 916
+      values: 917
+      values: 918
+      values: 919
+      values: 920
+      values: 921
+      values: 922
+      values: 923
+      values: 924
+      values: 925
+      values: 926
+      values: 927
+      values: 928
+      values: 929
+      values: 931
+      values: 932
+      values: 933
+      values: 934
+      values: 935
+      values: 936
+      values: 937
+      values: 938
+      values: 939
+      values: 940
+      values: 941
+      values: 942
+      values: 943
+      values: 944
+      values: 945
+      values: 946
+      values: 947
+      values: 948
+      values: 949
+      values: 950
+      values: 951
+      values: 952
+      values: 953
+      values: 954
+      values: 955
+      values: 956
+      values: 957
+      values: 958
+      values: 959
+      values: 960
+      values: 961
+      values: 962
+      values: 963
+      values: 964
+      values: 965
+      values: 966
+      values: 967
+      values: 968
+      values: 969
+      values: 970
+      values: 971
+      values: 972
+      values: 973
+      values: 974
+      values: 977
+      values: 8013
+    }
+    features {
+    }
+  }
+}
+segments {
+  key: 944
+  value {
+    codepoints {
+      values: 783
+      values: 8231
+      values: 64257
+      values: 64258
+      values: 64259
+      values: 64260
+      values: 65532
+    }
+    features {
+    }
+  }
+}
+glyph_patches {
+  key: 0
+  value {
+    values: 107
+    values: 373
+    values: 477
+    values: 1016
+  }
+}
+glyph_patches {
+  key: 1
+  value {
+    values: 10
+    values: 126
+    values: 380
+    values: 381
+    values: 1015
+  }
+}
+glyph_patches {
+  key: 2
+  value {
+    values: 9
+    values: 63
+    values: 64
+    values: 65
+  }
+}
+glyph_patches {
+  key: 3
+  value {
+    values: 15
+    values: 96
+    values: 386
+    values: 400
+  }
+}
+glyph_patches {
+  key: 4
+  value {
+    values: 36
+    values: 125
+    values: 724
+    values: 750
+  }
+}
+glyph_patches {
+  key: 5
+  value {
+    values: 389
+    values: 393
+    values: 394
+    values: 671
+  }
+}
+glyph_patches {
+  key: 6
+  value {
+    values: 674
+    values: 701
+    values: 751
+    values: 813
+  }
+}
+glyph_patches {
+  key: 7
+  value {
+    values: 8
+    values: 396
+    values: 458
+    values: 479
+  }
+}
+glyph_patches {
+  key: 8
+  value {
+    values: 696
+    values: 704
+    values: 713
+    values: 725
+  }
+}
+glyph_patches {
+  key: 9
+  value {
+    values: 692
+    values: 698
+    values: 715
+    values: 719
+  }
+}
+glyph_patches {
+  key: 10
+  value {
+    values: 66
+    values: 114
+    values: 130
+    values: 144
+  }
+}
+glyph_patches {
+  key: 11
+  value {
+    values: 440
+    values: 736
+    values: 746
+    values: 798
+  }
+}
+glyph_patches {
+  key: 12
+  value {
+    values: 688
+    values: 705
+    values: 709
+    values: 778
+  }
+}
+glyph_patches {
+  key: 13
+  value {
+    values: 103
+    values: 111
+    values: 819
+    values: 1170
+  }
+}
+glyph_patches {
+  key: 14
+  value {
+    values: 113
+    values: 143
+    values: 835
+    values: 836
+  }
+}
+glyph_patches {
+  key: 15
+  value {
+    values: 133
+    values: 737
+    values: 786
+    values: 815
+  }
+}
+glyph_patches {
+  key: 16
+  value {
+    values: 734
+    values: 735
+    values: 809
+    values: 838
+  }
+}
+glyph_patches {
+  key: 17
+  value {
+    values: 594
+    values: 1086
+    values: 1087
+    values: 1095
+    values: 1112
+    values: 1113
+    values: 1121
+    values: 1130
+    values: 1131
+    values: 1139
+  }
+}
+glyph_patches {
+  key: 18
+  value {
+    values: 99
+    values: 128
+    values: 443
+    values: 723
+  }
+}
+glyph_patches {
+  key: 19
+  value {
+    values: 395
+    values: 747
+    values: 799
+    values: 837
+  }
+}
+glyph_patches {
+  key: 20
+  value {
+    values: 98
+    values: 677
+    values: 681
+    values: 718
+  }
+}
+glyph_patches {
+  key: 21
+  value {
+    values: 599
+    values: 669
+    values: 686
+    values: 708
+    values: 1096
+    values: 1097
+  }
+}
+glyph_patches {
+  key: 22
+  value {
+    values: 727
+    values: 743
+    values: 744
+    values: 745
+    values: 1316
+    values: 1317
+    values: 1318
+  }
+}
+glyph_patches {
+  key: 23
+  value {
+    values: 441
+    values: 766
+    values: 804
+    values: 805
+  }
+}
+glyph_patches {
+  key: 24
+  value {
+    values: 163
+    values: 672
+    values: 699
+    values: 822
+    values: 823
+  }
+}
+glyph_patches {
+  key: 25
+  value {
+    values: 101
+    values: 438
+    values: 439
+    values: 1132
+  }
+}
+glyph_patches {
+  key: 26
+  value {
+    values: 449
+    values: 1088
+    values: 1089
+    values: 1114
+    values: 1115
+    values: 1133
+  }
+}
+glyph_patches {
+  key: 27
+  value {
+    values: 108
+    values: 123
+    values: 793
+    values: 825
+  }
+}
+glyph_patches {
+  key: 28
+  value {
+    values: 139
+    values: 592
+    values: 596
+    values: 597
+    values: 662
+    values: 1090
+    values: 1091
+    values: 1092
+    values: 1093
+    values: 1098
+    values: 1099
+    values: 1105
+    values: 1116
+    values: 1117
+    values: 1118
+    values: 1119
+    values: 1134
+    values: 1135
+    values: 1136
+    values: 1137
+  }
+}
+glyph_patches {
+  key: 29
+  value {
+    values: 600
+    values: 808
+    values: 827
+    values: 1100
+    values: 1101
+  }
+}
+glyph_patches {
+  key: 30
+  value {
+    values: 442
+    values: 619
+    values: 1094
+    values: 1102
+    values: 1103
+  }
+}
+glyph_patches {
+  key: 31
+  value {
+    values: 148
+    values: 726
+    values: 1120
+    values: 1138
+    values: 1315
+  }
+}
+glyph_patches {
+  key: 32
+  value {
+    values: 105
+    values: 131
+    values: 137
+    values: 841
+    values: 842
+  }
+}
+glyph_patches {
+  key: 33
+  value {
+    values: 168
+    values: 1007
+    values: 1008
+    values: 1013
+    values: 1203
+    values: 1204
+  }
+}
+glyph_patches {
+  key: 34
+  value {
+    values: 1106
+    values: 1164
+    values: 1165
+    values: 1218
+    values: 1219
+    values: 1220
+    values: 1221
+    values: 1224
+    values: 1225
+    values: 1228
+    values: 1229
+    values: 1230
+    values: 1231
+    values: 1232
+    values: 1233
+    values: 1234
+    values: 1235
+    values: 1239
+    values: 1240
+    values: 1241
+    values: 1242
+    values: 1243
+    values: 1244
+    values: 1248
+    values: 1249
+    values: 1250
+    values: 1251
+    values: 1252
+    values: 1253
+  }
+}
+glyph_patches {
+  key: 35
+  value {
+    values: 170
+    values: 758
+    values: 816
+    values: 1110
+    values: 1246
+    values: 1247
+  }
+}
+glyph_patches {
+  key: 36
+  value {
+    values: 777
+    values: 789
+    values: 792
+    values: 1104
+  }
+}
+glyph_patches {
+  key: 37
+  value {
+    values: 739
+    values: 761
+    values: 765
+    values: 814
+  }
+}
+glyph_patches {
+  key: 38
+  value {
+    values: 136
+    values: 435
+    values: 437
+    values: 764
+  }
+}
+glyph_patches {
+  key: 39
+  value {
+    values: 127
+    values: 151
+    values: 391
+    values: 678
+  }
+}
+glyph_patches {
+  key: 40
+  value {
+    values: 100
+    values: 147
+    values: 383
+    values: 444
+  }
+}
+glyph_patches {
+  key: 41
+  value {
+    values: 135
+    values: 150
+    values: 785
+    values: 812
+  }
+}
+glyph_patches {
+  key: 42
+  value {
+    values: 591
+    values: 722
+    values: 755
+    values: 818
+    values: 1019
+  }
+}
+glyph_patches {
+  key: 43
+  value {
+    values: 119
+    values: 682
+    values: 742
+    values: 824
+  }
+}
+glyph_patches {
+  key: 44
+  value {
+    values: 138
+    values: 738
+    values: 760
+    values: 788
+  }
+}
+glyph_patches {
+  key: 45
+  value {
+    values: 102
+    values: 132
+    values: 445
+    values: 663
+  }
+}
+glyph_patches {
+  key: 46
+  value {
+    values: 104
+    values: 110
+    values: 691
+    values: 826
+  }
+}
+glyph_patches {
+  key: 47
+  value {
+    values: 146
+    values: 447
+    values: 721
+    values: 832
+  }
+}
+glyph_patches {
+  key: 48
+  value {
+    values: 661
+    values: 741
+    values: 791
+    values: 1191
+  }
+}
+glyph_patches {
+  key: 49
+  value {
+    values: 369
+    values: 666
+    values: 733
+    values: 821
+  }
+}
+glyph_patches {
+  key: 50
+  value {
+    values: 664
+    values: 753
+    values: 763
+    values: 803
+  }
+}
+glyph_patches {
+  key: 51
+  value {
+    values: 140
+    values: 749
+    values: 829
+    values: 831
+  }
+}
+glyph_patches {
+  key: 52
+  value {
+    values: 731
+    values: 752
+    values: 757
+    values: 770
+  }
+}
+glyph_patches {
+  key: 53
+  value {
+    values: 149
+    values: 160
+    values: 732
+    values: 768
+  }
+}
+glyph_patches {
+  key: 54
+  value {
+    values: 665
+    values: 730
+    values: 802
+    values: 830
+  }
+}
+glyph_patches {
+  key: 55
+  value {
+    values: 145
+    values: 767
+    values: 769
+    values: 787
+  }
+}
+glyph_patches {
+  key: 56
+  value {
+    values: 434
+    values: 748
+    values: 756
+    values: 780
+  }
+}
+glyph_patches {
+  key: 57
+  value {
+    values: 762
+    values: 779
+    values: 828
+    values: 1018
+  }
+}
+glyph_patches {
+  key: 58
+  value {
+    values: 740
+    values: 790
+    values: 820
+    values: 1011
+  }
+}
+glyph_patches {
+  key: 59
+  value {
+    values: 436
+    values: 673
+    values: 1012
+    values: 1023
+  }
+}
+glyph_patches {
+  key: 60
+  value {
+    values: 700
+    values: 1022
+  }
+}
+glyph_patches {
+  key: 61
+  value {
+    values: 375
+    values: 376
+    values: 377
+    values: 382
+  }
+}
+glyph_patches {
+  key: 62
+  value {
+    values: 371
+    values: 372
+    values: 378
+    values: 466
+  }
+}
+glyph_patches {
+  key: 63
+  value {
+    values: 379
+    values: 452
+    values: 453
+    values: 454
+  }
+}
+glyph_patches {
+  key: 64
+  value {
+    values: 451
+  }
+}
+glyph_patches {
+  key: 65
+  value {
+    values: 216
+    values: 217
+    values: 223
+    values: 224
+    values: 226
+    values: 233
+    values: 234
+    values: 235
+    values: 237
+    values: 245
+    values: 247
+    values: 248
+    values: 250
+    values: 251
+    values: 252
+    values: 253
+    values: 254
+    values: 256
+    values: 257
+    values: 975
+    values: 978
+    values: 979
+    values: 980
+    values: 981
+    values: 983
+    values: 984
+    values: 985
+    values: 986
+    values: 987
+    values: 988
+    values: 989
+    values: 990
+    values: 991
+    values: 992
+    values: 993
+    values: 994
+    values: 995
+    values: 996
+    values: 997
+    values: 998
+    values: 999
+    values: 1080
+  }
+}
+glyph_patches {
+  key: 66
+  value {
+    values: 232
+    values: 969
+    values: 972
+    values: 973
+  }
+}
+glyph_patches {
+  key: 67
+  value {
+    values: 229
+    values: 230
+    values: 982
+    values: 1079
+  }
+}
+glyph_patches {
+  key: 68
+  value {
+    values: 227
+    values: 259
+    values: 1002
+    values: 1003
+  }
+}
+glyph_patches {
+  key: 69
+  value {
+    values: 228
+    values: 309
+    values: 310
+    values: 448
+  }
+}
+glyph_patches {
+  key: 70
+  value {
+    values: 211
+    values: 280
+    values: 304
+    values: 1039
+    values: 1066
+    values: 1068
+  }
+}
+glyph_patches {
+  key: 71
+  value {
+    values: 261
+    values: 316
+    values: 1004
+    values: 1183
+  }
+}
+glyph_patches {
+  key: 72
+  value {
+    values: 260
+    values: 1053
+    values: 1065
+    values: 1187
+  }
+}
+glyph_patches {
+  key: 73
+  value {
+    values: 258
+    values: 262
+    values: 974
+    values: 1038
+  }
+}
+glyph_patches {
+  key: 74
+  value {
+    values: 303
+    values: 1005
+    values: 1006
+    values: 1186
+  }
+}
+glyph_patches {
+  key: 75
+  value {
+    values: 213
+    values: 263
+    values: 1027
+    values: 1182
+  }
+}
+glyph_patches {
+  key: 76
+  value {
+    values: 210
+    values: 214
+    values: 977
+    values: 1000
+  }
+}
+glyph_patches {
+  key: 77
+  value {
+    values: 212
+    values: 970
+    values: 971
+    values: 1001
+  }
+}
+glyph_patches {
+  key: 78
+  value {
+    values: 215
+    values: 315
+    values: 328
+    values: 1060
+  }
+}
+glyph_patches {
+  key: 79
+  value {
+    values: 314
+    values: 324
+    values: 976
+    values: 1179
+  }
+}
+glyph_patches {
+  key: 80
+  value {
+    values: 323
+    values: 327
+    values: 1026
+    values: 1072
+  }
+}
+glyph_patches {
+  key: 81
+  value {
+    values: 266
+    values: 1035
+    values: 1045
+    values: 1064
+  }
+}
+glyph_patches {
+  key: 82
+  value {
+    values: 331
+    values: 1059
+    values: 1071
+    values: 1181
+  }
+}
+glyph_patches {
+  key: 83
+  value {
+    values: 307
+    values: 308
+    values: 1037
+    values: 1063
+  }
+}
+glyph_patches {
+  key: 84
+  value {
+    values: 270
+    values: 293
+    values: 295
+    values: 1032
+  }
+}
+glyph_patches {
+  key: 85
+  value {
+    values: 265
+    values: 313
+    values: 318
+    values: 1040
+  }
+}
+glyph_patches {
+  key: 86
+  value {
+    values: 311
+    values: 350
+    values: 1043
+    values: 1074
+  }
+}
+glyph_patches {
+  key: 87
+  value {
+    values: 306
+    values: 341
+    values: 1051
+    values: 1055
+  }
+}
+glyph_patches {
+  key: 88
+  value {
+    values: 272
+    values: 322
+    values: 335
+    values: 1049
+  }
+}
+glyph_patches {
+  key: 89
+  value {
+    values: 276
+    values: 367
+    values: 1057
+    values: 1077
+  }
+}
+glyph_patches {
+  key: 90
+  value {
+    values: 368
+    values: 1062
+    values: 1076
+    values: 1188
+  }
+}
+glyph_patches {
+  key: 91
+  value {
+    values: 339
+    values: 1056
+    values: 1058
+    values: 1078
+  }
+}
+glyph_patches {
+  key: 92
+  value {
+    values: 274
+    values: 1024
+    values: 1025
+    values: 1054
+  }
+}
+glyph_patches {
+  key: 93
+  value {
+    values: 264
+    values: 320
+    values: 1034
+    values: 1052
+  }
+}
+glyph_patches {
+  key: 94
+  value {
+    values: 268
+    values: 317
+    values: 346
+    values: 1046
+  }
+}
+glyph_patches {
+  key: 95
+  value {
+    values: 319
+    values: 340
+    values: 1047
+    values: 1185
+  }
+}
+glyph_patches {
+  key: 96
+  value {
+    values: 269
+    values: 287
+    values: 1173
+    values: 1176
+  }
+}
+glyph_patches {
+  key: 97
+  value {
+    values: 305
+    values: 329
+    values: 1036
+    values: 1081
+  }
+}
+glyph_patches {
+  key: 98
+  value {
+    values: 291
+    values: 326
+    values: 1172
+    values: 1178
+  }
+}
+glyph_patches {
+  key: 99
+  value {
+    values: 273
+    values: 312
+    values: 330
+    values: 1184
+  }
+}
+glyph_patches {
+  key: 100
+  value {
+    values: 325
+    values: 347
+    values: 366
+    values: 1073
+  }
+}
+glyph_patches {
+  key: 101
+  value {
+    values: 275
+    values: 289
+    values: 321
+    values: 1177
+  }
+}
+glyph_patches {
+  key: 102
+  value {
+    values: 267
+    values: 271
+    values: 277
+    values: 1171
+  }
+}
+glyph_patches {
+  key: 103
+  value {
+    values: 288
+    values: 1028
+    values: 1029
+    values: 1033
+  }
+}
+glyph_patches {
+  key: 104
+  value {
+    values: 334
+    values: 349
+    values: 1048
+    values: 1190
+  }
+}
+glyph_patches {
+  key: 105
+  value {
+    values: 298
+    values: 301
+    values: 345
+    values: 1067
+  }
+}
+glyph_patches {
+  key: 106
+  value {
+    values: 283
+    values: 1030
+    values: 1069
+    values: 1075
+  }
+}
+glyph_patches {
+  key: 107
+  value {
+    values: 336
+    values: 338
+    values: 1041
+    values: 1180
+  }
+}
+glyph_patches {
+  key: 108
+  value {
+    values: 342
+    values: 1044
+    values: 1050
+    values: 1061
+  }
+}
+glyph_patches {
+  key: 109
+  value {
+    values: 278
+    values: 299
+    values: 351
+    values: 1175
+  }
+}
+glyph_patches {
+  key: 110
+  value {
+    values: 352
+    values: 354
+    values: 355
+    values: 356
+  }
+}
+glyph_patches {
+  key: 111
+  value {
+    values: 358
+    values: 360
+    values: 362
+    values: 364
+  }
+}
+glyph_patches {
+  key: 112
+  value {
+    values: 285
+    values: 290
+    values: 292
+    values: 1174
+  }
+}
+glyph_patches {
+  key: 113
+  value {
+    values: 300
+    values: 353
+    values: 357
+    values: 363
+  }
+}
+glyph_patches {
+  key: 114
+  value {
+    values: 297
+    values: 359
+    values: 361
+    values: 365
+  }
+}
+glyph_patches {
+  key: 115
+  value {
+    values: 348
+    values: 1070
+    values: 1189
+  }
+}
+glyph_patches {
+  key: 116
+  value {
+    values: 175
+    values: 179
+    values: 180
+    values: 181
+    values: 183
+    values: 184
+    values: 187
+    values: 188
+    values: 190
+    values: 192
+    values: 193
+    values: 194
+    values: 195
+    values: 196
+    values: 197
+    values: 198
+    values: 199
+    values: 200
+    values: 201
+    values: 202
+    values: 203
+    values: 204
+    values: 206
+    values: 651
+    values: 930
+    values: 931
+    values: 932
+    values: 934
+    values: 937
+    values: 938
+    values: 939
+    values: 940
+    values: 941
+    values: 942
+    values: 943
+    values: 944
+    values: 945
+    values: 946
+    values: 947
+    values: 948
+    values: 949
+    values: 950
+    values: 951
+    values: 952
+    values: 954
+    values: 955
+    values: 956
+    values: 957
+    values: 958
+    values: 959
+    values: 960
+    values: 961
+    values: 962
+    values: 963
+    values: 964
+    values: 965
+    values: 966
+    values: 967
+    values: 968
+  }
+}
+glyph_patches {
+  key: 117
+  value {
+    values: 933
+    values: 935
+    values: 936
+    values: 953
+  }
+}
+glyph_patches {
+  key: 118
+  value {
+    values: 176
+    values: 207
+    values: 370
+    values: 1254
+  }
+}
+glyph_patches {
+  key: 119
+  value {
+    values: 401
+    values: 478
+    values: 1205
+    values: 1206
+    values: 1207
+    values: 1208
+    values: 1209
+    values: 1211
+    values: 1212
+    values: 1213
+    values: 1214
+    values: 1215
+    values: 1216
+  }
+}
+glyph_patches {
+  key: 120
+  value {
+    values: 14
+  }
+}
+glyph_patches {
+  key: 121
+  value {
+    values: 7
+  }
+}
+glyph_patches {
+  key: 122
+  value {
+    values: 398
+  }
+}
+glyph_patches {
+  key: 123
+  value {
+    values: 660
+  }
+}
+glyph_patches {
+  key: 124
+  value {
+    values: 169
+    values: 1201
+    values: 1202
+    values: 1226
+    values: 1227
+    values: 1237
+    values: 1238
+  }
+}
+glyph_patches {
+  key: 125
+  value {
+    values: 483
+    values: 484
+    values: 485
+    values: 486
+    values: 487
+    values: 488
+    values: 489
+    values: 490
+    values: 491
+    values: 492
+  }
+}
+glyph_patches {
+  key: 126
+  value {
+    values: 470
+    values: 476
+  }
+}
+glyph_patches {
+  key: 127
+  value {
+    values: 613
+    values: 614
+    values: 615
+    values: 616
+    values: 617
+    values: 618
+    values: 622
+    values: 624
+    values: 625
+    values: 626
+    values: 627
+    values: 628
+    values: 629
+    values: 631
+    values: 633
+    values: 640
+  }
+}
+glyph_patches {
+  key: 128
+  value {
+    values: 641
+    values: 652
+    values: 1193
+    values: 1194
+    values: 1195
+    values: 1200
+  }
+}
+glyph_patches {
+  key: 129
+  value {
+    values: 580
+  }
+}
+glyph_patches {
+  key: 130
+  value {
+    values: 582
+  }
+}
+glyph_patches {
+  key: 131
+  value {
+    values: 584
+  }
+}
+glyph_patches {
+  key: 132
+  value {
+    values: 585
+    values: 586
+  }
+}
+glyph_patches {
+  key: 133
+  value {
+    values: 608
+    values: 609
+    values: 610
+    values: 611
+    values: 612
+    values: 642
+    values: 643
+    values: 644
+    values: 645
+    values: 646
+    values: 647
+    values: 648
+  }
+}
+glyph_patches {
+  key: 134
+  value {
+    values: 649
+    values: 650
+  }
+}
+glyph_patches {
+  key: 135
+  value {
+    values: 1
+  }
+}
+glyph_patches {
+  key: 136
+  value {
+    values: 2
+  }
+}
+glyph_patches {
+  key: 137
+  value {
+    values: 3
+  }
+}
+glyph_patches {
+  key: 138
+  value {
+    values: 208
+  }
+}
+glyph_patches {
+  key: 139
+  value {
+    values: 209
+  }
+}
+glyph_patches {
+  key: 140
+  value {
+    values: 1031
+  }
+}
+glyph_patches {
+  key: 141
+  value {
+    values: 284
+  }
+}
+glyph_patches {
+  key: 142
+  value {
+    values: 286
+  }
+}
+glyph_patches {
+  key: 143
+  value {
+    values: 294
+  }
+}
+glyph_patches {
+  key: 144
+  value {
+    values: 296
+  }
+}
+glyph_patches {
+  key: 145
+  value {
+    values: 302
+  }
+}
+glyph_patches {
+  key: 146
+  value {
+    values: 1042
+  }
+}
+glyph_patches {
+  key: 147
+  value {
+    values: 337
+  }
+}
+glyph_patches {
+  key: 148
+  value {
+    values: 343
+  }
+}
+glyph_patches {
+  key: 149
+  value {
+    values: 374
+  }
+}
+glyph_patches {
+  key: 150
+  value {
+    values: 384
+  }
+}
+glyph_patches {
+  key: 151
+  value {
+    values: 385
+  }
+}
+glyph_patches {
+  key: 152
+  value {
+    values: 1192
+  }
+}
+glyph_patches {
+  key: 153
+  value {
+    values: 388
+  }
+}
+glyph_patches {
+  key: 154
+  value {
+    values: 392
+  }
+}
+glyph_patches {
+  key: 155
+  value {
+    values: 397
+  }
+}
+glyph_patches {
+  key: 156
+  value {
+    values: 399
+  }
+}
+glyph_patches {
+  key: 157
+  value {
+    values: 402
+  }
+}
+glyph_patches {
+  key: 158
+  value {
+    values: 1017
+  }
+}
+glyph_patches {
+  key: 159
+  value {
+    values: 418
+  }
+}
+glyph_patches {
+  key: 160
+  value {
+    values: 429
+  }
+}
+glyph_patches {
+  key: 161
+  value {
+    values: 430
+  }
+}
+glyph_patches {
+  key: 162
+  value {
+    values: 431
+  }
+}
+glyph_patches {
+  key: 163
+  value {
+    values: 446
+  }
+}
+glyph_patches {
+  key: 164
+  value {
+    values: 450
+  }
+}
+glyph_patches {
+  key: 165
+  value {
+    values: 455
+  }
+}
+glyph_patches {
+  key: 166
+  value {
+    values: 456
+  }
+}
+glyph_patches {
+  key: 167
+  value {
+    values: 457
+  }
+}
+glyph_patches {
+  key: 168
+  value {
+    values: 459
+  }
+}
+glyph_patches {
+  key: 169
+  value {
+    values: 460
+  }
+}
+glyph_patches {
+  key: 170
+  value {
+    values: 461
+  }
+}
+glyph_patches {
+  key: 171
+  value {
+    values: 462
+  }
+}
+glyph_patches {
+  key: 172
+  value {
+    values: 463
+  }
+}
+glyph_patches {
+  key: 173
+  value {
+    values: 467
+  }
+}
+glyph_patches {
+  key: 174
+  value {
+    values: 468
+  }
+}
+glyph_patches {
+  key: 175
+  value {
+    values: 1222
+    values: 1223
+  }
+}
+glyph_patches {
+  key: 176
+  value {
+    values: 67
+  }
+}
+glyph_patches {
+  key: 177
+  value {
+    values: 5
+  }
+}
+glyph_patches {
+  key: 178
+  value {
+    values: 95
+    values: 97
+  }
+}
+glyph_patches {
+  key: 179
+  value {
+    values: 712
+  }
+}
+glyph_patches {
+  key: 180
+  value {
+    values: 695
+  }
+}
+glyph_patches {
+  key: 181
+  value {
+    values: 120
+  }
+}
+glyph_patches {
+  key: 182
+  value {
+    values: 717
+  }
+}
+glyph_patches {
+  key: 183
+  value {
+    values: 694
+  }
+}
+glyph_patches {
+  key: 184
+  value {
+    values: 710
+  }
+}
+glyph_patches {
+  key: 185
+  value {
+    values: 32
+    values: 34
+  }
+}
+glyph_patches {
+  key: 186
+  value {
+    values: 387
+  }
+}
+glyph_patches {
+  key: 187
+  value {
+    values: 702
+  }
+}
+glyph_patches {
+  key: 188
+  value {
+    values: 676
+  }
+}
+glyph_patches {
+  key: 189
+  value {
+    values: 109
+    values: 124
+  }
+}
+glyph_patches {
+  key: 190
+  value {
+    values: 697
+  }
+}
+glyph_patches {
+  key: 191
+  value {
+    values: 714
+  }
+}
+glyph_patches {
+  key: 192
+  value {
+    values: 716
+  }
+}
+glyph_patches {
+  key: 193
+  value {
+    values: 690
+  }
+}
+glyph_patches {
+  key: 194
+  value {
+    values: 680
+  }
+}
+glyph_patches {
+  key: 195
+  value {
+    values: 685
+  }
+}
+glyph_patches {
+  key: 196
+  value {
+    values: 667
+  }
+}
+glyph_patches {
+  key: 197
+  value {
+    values: 720
+  }
+}
+glyph_patches {
+  key: 198
+  value {
+    values: 711
+  }
+}
+glyph_patches {
+  key: 199
+  value {
+    values: 729
+  }
+}
+glyph_patches {
+  key: 200
+  value {
+    values: 595
+  }
+}
+glyph_patches {
+  key: 201
+  value {
+    values: 801
+  }
+}
+glyph_patches {
+  key: 202
+  value {
+    values: 782
+  }
+}
+glyph_patches {
+  key: 203
+  value {
+    values: 834
+  }
+}
+glyph_patches {
+  key: 204
+  value {
+    values: 670
+  }
+}
+glyph_patches {
+  key: 205
+  value {
+    values: 1085
+  }
+}
+glyph_patches {
+  key: 206
+  value {
+    values: 1083
+  }
+}
+glyph_patches {
+  key: 207
+  value {
+    values: 1125
+  }
+}
+glyph_patches {
+  key: 208
+  value {
+    values: 1153
+  }
+}
+glyph_patches {
+  key: 209
+  value {
+    values: 1151
+  }
+}
+glyph_patches {
+  key: 210
+  value {
+    values: 1127
+  }
+}
+glyph_patches {
+  key: 211
+  value {
+    values: 675
+  }
+}
+glyph_patches {
+  key: 212
+  value {
+    values: 800
+  }
+}
+glyph_patches {
+  key: 213
+  value {
+    values: 1129
+  }
+}
+glyph_patches {
+  key: 214
+  value {
+    values: 1109
+  }
+}
+glyph_patches {
+  key: 215
+  value {
+    values: 817
+  }
+}
+glyph_patches {
+  key: 216
+  value {
+    values: 1111
+  }
+}
+glyph_patches {
+  key: 217
+  value {
+    values: 1107
+  }
+}
+glyph_patches {
+  key: 218
+  value {
+    values: 683
+  }
+}
+glyph_patches {
+  key: 219
+  value {
+    values: 1169
+  }
+}
+glyph_patches {
+  key: 220
+  value {
+    values: 1084
+  }
+}
+glyph_patches {
+  key: 221
+  value {
+    values: 1014
+  }
+}
+glyph_patches {
+  key: 222
+  value {
+    values: 687
+  }
+}
+glyph_patches {
+  key: 223
+  value {
+    values: 693
+  }
+}
+glyph_patches {
+  key: 224
+  value {
+    values: 811
+  }
+}
+glyph_patches {
+  key: 225
+  value {
+    values: 1082
+  }
+}
+glyph_patches {
+  key: 226
+  value {
+    values: 1167
+  }
+}
+glyph_patches {
+  key: 227
+  value {
+    values: 1150
+  }
+}
+glyph_patches {
+  key: 228
+  value {
+    values: 1152
+  }
+}
+glyph_patches {
+  key: 229
+  value {
+    values: 1124
+  }
+}
+glyph_patches {
+  key: 230
+  value {
+    values: 679
+  }
+}
+glyph_patches {
+  key: 231
+  value {
+    values: 728
+  }
+}
+glyph_patches {
+  key: 232
+  value {
+    values: 689
+  }
+}
+glyph_patches {
+  key: 233
+  value {
+    values: 684
+  }
+}
+glyph_patches {
+  key: 234
+  value {
+    values: 1126
+  }
+}
+glyph_patches {
+  key: 235
+  value {
+    values: 833
+  }
+}
+glyph_patches {
+  key: 236
+  value {
+    values: 118
+  }
+}
+glyph_patches {
+  key: 237
+  value {
+    values: 781
+  }
+}
+glyph_patches {
+  key: 238
+  value {
+    values: 1168
+  }
+}
+glyph_patches {
+  key: 239
+  value {
+    values: 1128
+  }
+}
+glyph_patches {
+  key: 240
+  value {
+    values: 1122
+  }
+}
+glyph_patches {
+  key: 241
+  value {
+    values: 1108
+  }
+}
+glyph_patches {
+  key: 242
+  value {
+    values: 1166
+  }
+}
+glyph_patches {
+  key: 243
+  value {
+    values: 774
+  }
+}
+glyph_patches {
+  key: 244
+  value {
+    values: 810
+  }
+}
+glyph_patches {
+  key: 245
+  value {
+    values: 795
+  }
+}
+glyph_patches {
+  key: 246
+  value {
+    values: 784
+  }
+}
+glyph_patches {
+  key: 247
+  value {
+    values: 776
+  }
+}
+glyph_patches {
+  key: 248
+  value {
+    values: 772
+  }
+}
+glyph_patches {
+  key: 249
+  value {
+    values: 771
+  }
+}
+glyph_patches {
+  key: 250
+  value {
+    values: 754
+  }
+}
+glyph_patches {
+  key: 251
+  value {
+    values: 775
+  }
+}
+glyph_patches {
+  key: 252
+  value {
+    values: 773
+  }
+}
+glyph_patches {
+  key: 253
+  value {
+    values: 783
+  }
+}
+glyph_patches {
+  key: 254
+  value {
+    values: 794
+  }
+}
+glyph_patches {
+  key: 255
+  value {
+    values: 796
+  }
+}
+glyph_patches {
+  key: 256
+  value {
+    values: 142
+  }
+}
+glyph_patches {
+  key: 257
+  value {
+    values: 797
+  }
+}
+glyph_patches {
+  key: 258
+  value {
+    values: 1021
+  }
+}
+glyph_patches {
+  key: 259
+  value {
+    values: 578
+  }
+}
+glyph_patches {
+  key: 260
+  value {
+    values: 1010
+  }
+}
+glyph_patches {
+  key: 261
+  value {
+    values: 1020
+  }
+}
+glyph_patches {
+  key: 262
+  value {
+    values: 1009
+  }
+}
+glyph_patches {
+  key: 263
+  value {
+    values: 246
+  }
+}
+glyph_patches {
+  key: 264
+  value {
+    values: 182
+  }
+}
+glyph_patches {
+  key: 265
+  value {
+    values: 243
+  }
+}
+glyph_patches {
+  key: 266
+  value {
+    values: 255
+  }
+}
+glyph_patches {
+  key: 267
+  value {
+    values: 231
+  }
+}
+glyph_patches {
+  key: 268
+  value {
+    values: 189
+  }
+}
+glyph_patches {
+  key: 269
+  value {
+    values: 344
+  }
+}
+glyph_patches {
+  key: 270
+  value {
+    values: 281
+  }
+}
+glyph_patches {
+  key: 271
+  value {
+    values: 282
+  }
+}
+glyph_patches {
+  key: 272
+  value {
+    values: 333
+  }
+}
+glyph_patches {
+  key: 273
+  value {
+    values: 332
+  }
+}
+glyph_patches {
+  key: 274
+  value {
+    values: 205
+  }
+}
+glyph_patches {
+  key: 275
+  value {
+    values: 185
+  }
+}
+glyph_patches {
+  key: 276
+  value {
+    values: 178
+  }
+}
+glyph_patches {
+  key: 277
+  value {
+    values: 493
+    values: 494
+    values: 495
+    values: 496
+    values: 497
+    values: 498
+    values: 499
+    values: 500
+    values: 501
+    values: 502
+    values: 503
+    values: 504
+    values: 505
+    values: 506
+    values: 507
+    values: 508
+    values: 509
+    values: 510
+    values: 511
+    values: 512
+    values: 513
+    values: 579
+    values: 587
+    values: 588
+    values: 589
+    values: 590
+  }
+}
+glyph_patches {
+  key: 278
+  value {
+    values: 1197
+    values: 1198
+  }
+}
+glyph_patches {
+  key: 279
+  value {
+    values: 630
+    values: 632
+  }
+}
+glyph_patches {
+  key: 280
+  value {
+    values: 419
+  }
+}
+glyph_patches {
+  key: 281
+  value {
+    values: 420
+  }
+}
+glyph_patches {
+  key: 282
+  value {
+    values: 421
+  }
+}
+glyph_patches {
+  key: 283
+  value {
+    values: 422
+  }
+}
+glyph_patches {
+  key: 284
+  value {
+    values: 423
+  }
+}
+glyph_patches {
+  key: 285
+  value {
+    values: 424
+  }
+}
+glyph_patches {
+  key: 286
+  value {
+    values: 425
+  }
+}
+glyph_patches {
+  key: 287
+  value {
+    values: 426
+  }
+}
+glyph_patches {
+  key: 288
+  value {
+    values: 427
+  }
+}
+glyph_patches {
+  key: 289
+  value {
+    values: 428
+  }
+}
+glyph_patches {
+  key: 290
+  value {
+    values: 406
+  }
+}
+glyph_patches {
+  key: 291
+  value {
+    values: 407
+  }
+}
+glyph_patches {
+  key: 292
+  value {
+    values: 408
+  }
+}
+glyph_patches {
+  key: 293
+  value {
+    values: 409
+  }
+}
+glyph_patches {
+  key: 294
+  value {
+    values: 410
+  }
+}
+glyph_patches {
+  key: 295
+  value {
+    values: 411
+  }
+}
+glyph_patches {
+  key: 296
+  value {
+    values: 412
+  }
+}
+glyph_patches {
+  key: 297
+  value {
+    values: 413
+  }
+}
+glyph_patches {
+  key: 298
+  value {
+    values: 414
+  }
+}
+glyph_patches {
+  key: 299
+  value {
+    values: 415
+  }
+}
+glyph_patches {
+  key: 300
+  value {
+    values: 416
+    values: 417
+  }
+}
+glyph_patches {
+  key: 301
+  value {
+    values: 432
+    values: 433
+  }
+}
+glyph_patches {
+  key: 302
+  value {
+    values: 464
+    values: 465
+  }
+}
+glyph_patches {
+  key: 303
+  value {
+    values: 390
+  }
+}
+glyph_patches {
+  key: 304
+  value {
+    values: 807
+  }
+}
+glyph_patches {
+  key: 305
+  value {
+    values: 806
+  }
+}
+glyph_patches {
+  key: 306
+  value {
+    values: 134
+  }
+}
+glyph_patches {
+  key: 307
+  value {
+    values: 157
+  }
+}
+glyph_patches {
+  key: 308
+  value {
+    values: 129
+  }
+}
+glyph_patches {
+  key: 309
+  value {
+    values: 167
+  }
+}
+glyph_patches {
+  key: 310
+  value {
+    values: 244
+  }
+}
+glyph_patches {
+  key: 311
+  value {
+    values: 583
+  }
+}
+glyph_patches {
+  key: 312
+  value {
+    values: 242
+  }
+}
+glyph_patches {
+  key: 313
+  value {
+    values: 241
+  }
+}
+glyph_patches {
+  key: 314
+  value {
+    values: 239
+  }
+}
+glyph_patches {
+  key: 315
+  value {
+    values: 219
+  }
+}
+glyph_patches {
+  key: 316
+  value {
+    values: 221
+  }
+}
+glyph_patches {
+  key: 317
+  value {
+    values: 279
+  }
+}
+glyph_patches {
+  key: 318
+  value {
+    values: 191
+  }
+}
+glyph_patches {
+  key: 319
+  value {
+    values: 172
+  }
+}
+glyph_patches {
+  key: 320
+  value {
+    values: 186
+  }
+}
+glyph_patches {
+  key: 321
+  value {
+    values: 121
+  }
+}
+glyph_patches {
+  key: 322
+  value {
+    values: 403
+    values: 404
+  }
+}
+glyph_patches {
+  key: 323
+  value {
+    values: 236
+  }
+}
+glyph_patches {
+  key: 324
+  value {
+    values: 249
+  }
+}
+glyph_patches {
+  key: 325
+  value {
+    values: 238
+  }
+}
+glyph_patches {
+  key: 326
+  value {
+    values: 225
+  }
+}
+glyph_patches {
+  key: 327
+  value {
+    values: 218
+  }
+}
+glyph_patches {
+  key: 328
+  value {
+    values: 164
+  }
+}
+glyph_patches {
+  key: 329
+  value {
+    values: 177
+  }
+}
+glyph_patches {
+  key: 330
+  value {
+    values: 222
+  }
+}
+glyph_patches {
+  key: 331
+  value {
+    values: 166
+  }
+}
+glyph_patches {
+  key: 332
+  value {
+    values: 155
+  }
+}
+glyph_patches {
+  key: 333
+  value {
+    values: 153
+  }
+}
+glyph_patches {
+  key: 334
+  value {
+    values: 154
+  }
+}
+glyph_patches {
+  key: 335
+  value {
+    values: 152
+  }
+}
+glyph_patches {
+  key: 336
+  value {
+    values: 240
+  }
+}
+glyph_patches {
+  key: 337
+  value {
+    values: 220
+  }
+}
+glyph_patches {
+  key: 338
+  value {
+    values: 623
+  }
+}
+glyph_patches {
+  key: 339
+  value {
+    values: 634
+    values: 636
+  }
+}
+glyph_patches {
+  key: 340
+  value {
+    values: 159
+  }
+}
+glyph_patches {
+  key: 341
+  value {
+    values: 112
+  }
+}
+glyph_patches {
+  key: 342
+  value {
+    values: 162
+  }
+}
+glyph_patches {
+  key: 343
+  value {
+    values: 156
+  }
+}
+glyph_patches {
+  key: 344
+  value {
+    values: 158
+  }
+}
+glyph_patches {
+  key: 345
+  value {
+    values: 620
+  }
+}
+glyph_patches {
+  key: 346
+  value {
+    values: 165
+  }
+}
+glyph_patches {
+  key: 347
+  value {
+    values: 171
+  }
+}
+glyph_patches {
+  key: 348
+  value {
+    values: 141
+  }
+}
+glyph_patches {
+  key: 349
+  value {
+    values: 173
+  }
+}
+glyph_patches {
+  key: 350
+  value {
+    values: 68
+  }
+}
+glyph_patches {
+  key: 351
+  value {
+    values: 161
+  }
+}
+glyph_patches {
+  key: 352
+  value {
+    values: 106
+  }
+}
+glyph_patches {
+  key: 353
+  value {
+    values: 653
+  }
+}
+glyph_patches {
+  key: 354
+  value {
+    values: 853
+  }
+}
+glyph_patches {
+  key: 355
+  value {
+    values: 514
+  }
+}
+glyph_patches {
+  key: 356
+  value {
+    values: 871
+  }
+}
+glyph_patches {
+  key: 357
+  value {
+    values: 567
+  }
+}
+glyph_patches {
+  key: 358
+  value {
+    values: 516
+  }
+}
+glyph_patches {
+  key: 359
+  value {
+    values: 928
+  }
+}
+glyph_patches {
+  key: 360
+  value {
+    values: 879
+  }
+}
+glyph_patches {
+  key: 361
+  value {
+    values: 884
+    values: 1320
+  }
+}
+glyph_patches {
+  key: 362
+  value {
+    values: 895
+  }
+}
+glyph_patches {
+  key: 363
+  value {
+    values: 913
+  }
+}
+glyph_patches {
+  key: 364
+  value {
+    values: 851
+    values: 921
+  }
+}
+glyph_patches {
+  key: 365
+  value {
+    values: 515
+  }
+}
+glyph_patches {
+  key: 366
+  value {
+    values: 1210
+  }
+}
+glyph_patches {
+  key: 367
+  value {
+    values: 843
+  }
+}
+glyph_patches {
+  key: 368
+  value {
+    values: 657
+    values: 1309
+  }
+}
+glyph_patches {
+  key: 369
+  value {
+    values: 1311
+  }
+}
+glyph_patches {
+  key: 370
+  value {
+    values: 593
+    values: 1236
+    values: 1245
+  }
+}
+glyph_patches {
+  key: 371
+  value {
+    values: 569
+  }
+}
+glyph_patches {
+  key: 372
+  value {
+    values: 926
+  }
+}
+glyph_patches {
+  key: 373
+  value {
+    values: 475
+  }
+}
+glyph_patches {
+  key: 374
+  value {
+    values: 566
+  }
+}
+glyph_patches {
+  key: 375
+  value {
+    values: 533
+    values: 534
+    values: 541
+    values: 543
+    values: 550
+    values: 1286
+    values: 1287
+    values: 1289
+    values: 1293
+    values: 1294
+    values: 1295
+    values: 1296
+    values: 1298
+    values: 1306
+  }
+}
+glyph_patches {
+  key: 376
+  value {
+    values: 568
+  }
+}
+glyph_patches {
+  key: 377
+  value {
+    values: 553
+  }
+}
+glyph_patches {
+  key: 378
+  value {
+    values: 1280
+  }
+}
+glyph_patches {
+  key: 379
+  value {
+    values: 552
+  }
+}
+glyph_patches {
+  key: 380
+  value {
+    values: 581
+  }
+}
+glyph_patches {
+  key: 381
+  value {
+    values: 519
+    values: 520
+    values: 521
+    values: 523
+    values: 1255
+    values: 1256
+    values: 1257
+    values: 1259
+    values: 1262
+    values: 1263
+    values: 1265
+    values: 1266
+    values: 1267
+    values: 1268
+    values: 1269
+    values: 1270
+    values: 1271
+    values: 1272
+    values: 1273
+    values: 1274
+    values: 1275
+    values: 1276
+  }
+}
+glyph_patches {
+  key: 382
+  value {
+    values: 1217
+  }
+}
+glyph_patches {
+  key: 383
+  value {
+    values: 707
+  }
+}
+glyph_patches {
+  key: 384
+  value {
+    values: 706
+  }
+}
+glyph_patches {
+  key: 385
+  value {
+    values: 1123
+  }
+}
+glyph_patches {
+  key: 386
+  value {
+    values: 759
+  }
+}
+glyph_patches {
+  key: 387
+  value {
+    values: 1163
+  }
+}
+glyph_patches {
+  key: 388
+  value {
+    values: 1155
+  }
+}
+glyph_patches {
+  key: 389
+  value {
+    values: 1159
+  }
+}
+glyph_patches {
+  key: 390
+  value {
+    values: 1161
+  }
+}
+glyph_patches {
+  key: 391
+  value {
+    values: 1157
+  }
+}
+glyph_patches {
+  key: 392
+  value {
+    values: 1141
+  }
+}
+glyph_patches {
+  key: 393
+  value {
+    values: 1143
+  }
+}
+glyph_patches {
+  key: 394
+  value {
+    values: 1321
+  }
+}
+glyph_patches {
+  key: 395
+  value {
+    values: 1149
+  }
+}
+glyph_patches {
+  key: 396
+  value {
+    values: 1145
+  }
+}
+glyph_patches {
+  key: 397
+  value {
+    values: 1147
+  }
+}
+glyph_patches {
+  key: 398
+  value {
+    values: 840
+  }
+}
+glyph_patches {
+  key: 399
+  value {
+    values: 1154
+  }
+}
+glyph_patches {
+  key: 400
+  value {
+    values: 1162
+  }
+}
+glyph_patches {
+  key: 401
+  value {
+    values: 1158
+  }
+}
+glyph_patches {
+  key: 402
+  value {
+    values: 1160
+  }
+}
+glyph_patches {
+  key: 403
+  value {
+    values: 1156
+  }
+}
+glyph_patches {
+  key: 404
+  value {
+    values: 1140
+  }
+}
+glyph_patches {
+  key: 405
+  value {
+    values: 1142
+  }
+}
+glyph_patches {
+  key: 406
+  value {
+    values: 1148
+  }
+}
+glyph_patches {
+  key: 407
+  value {
+    values: 1144
+  }
+}
+glyph_patches {
+  key: 408
+  value {
+    values: 1146
+  }
+}
+glyph_patches {
+  key: 409
+  value {
+    values: 839
+  }
+}
+glyph_patches {
+  key: 410
+  value {
+    values: 524
+  }
+}
+glyph_patches {
+  key: 411
+  value {
+    values: 847
+  }
+}
+glyph_patches {
+  key: 412
+  value {
+    values: 855
+  }
+}
+glyph_patches {
+  key: 413
+  value {
+    values: 174
+  }
+}
+glyph_patches {
+  key: 414
+  value {
+    values: 637
+  }
+}
+glyph_patches {
+  key: 415
+  value {
+    values: 638
+  }
+}
+glyph_patches {
+  key: 416
+  value {
+    values: 635
+  }
+}
+glyph_patches {
+  key: 417
+  value {
+    values: 469
+  }
+}
+glyph_patches {
+  key: 418
+  value {
+    values: 918
+  }
+}
+glyph_patches {
+  key: 419
+  value {
+    values: 1314
+  }
+}
+glyph_patches {
+  key: 420
+  value {
+    values: 887
+  }
+}
+glyph_patches {
+  key: 421
+  value {
+    values: 874
+  }
+}
+glyph_patches {
+  key: 422
+  value {
+    values: 850
+  }
+}
+glyph_patches {
+  key: 423
+  value {
+    values: 917
+  }
+}
+glyph_patches {
+  key: 424
+  value {
+    values: 856
+  }
+}
+glyph_patches {
+  key: 425
+  value {
+    values: 848
+    values: 865
+  }
+}
+glyph_patches {
+  key: 426
+  value {
+    values: 867
+  }
+}
+glyph_patches {
+  key: 427
+  value {
+    values: 654
+  }
+}
+glyph_patches {
+  key: 428
+  value {
+    values: 880
+  }
+}
+glyph_patches {
+  key: 429
+  value {
+    values: 885
+    values: 910
+  }
+}
+glyph_patches {
+  key: 430
+  value {
+    values: 900
+  }
+}
+glyph_patches {
+  key: 431
+  value {
+    values: 857
+  }
+}
+glyph_patches {
+  key: 432
+  value {
+    values: 861
+  }
+}
+glyph_patches {
+  key: 433
+  value {
+    values: 919
+  }
+}
+glyph_patches {
+  key: 434
+  value {
+    values: 916
+  }
+}
+glyph_patches {
+  key: 435
+  value {
+    values: 904
+  }
+}
+glyph_patches {
+  key: 436
+  value {
+    values: 639
+  }
+}
+glyph_patches {
+  key: 437
+  value {
+    values: 929
+  }
+}
+glyph_patches {
+  key: 438
+  value {
+    values: 914
+  }
+}
+glyph_patches {
+  key: 439
+  value {
+    values: 873
+  }
+}
+glyph_patches {
+  key: 440
+  value {
+    values: 860
+  }
+}
+glyph_patches {
+  key: 441
+  value {
+    values: 870
+  }
+}
+glyph_patches {
+  key: 442
+  value {
+    values: 875
+    values: 1319
+  }
+}
+glyph_patches {
+  key: 443
+  value {
+    values: 883
+  }
+}
+glyph_patches {
+  key: 444
+  value {
+    values: 907
+  }
+}
+glyph_patches {
+  key: 445
+  value {
+    values: 922
+  }
+}
+glyph_patches {
+  key: 446
+  value {
+    values: 923
+  }
+}
+glyph_patches {
+  key: 447
+  value {
+    values: 621
+  }
+}
+glyph_patches {
+  key: 448
+  value {
+    values: 905
+  }
+}
+glyph_patches {
+  key: 449
+  value {
+    values: 894
+  }
+}
+glyph_patches {
+  key: 450
+  value {
+    values: 881
+    values: 892
+  }
+}
+glyph_patches {
+  key: 451
+  value {
+    values: 844
+  }
+}
+glyph_patches {
+  key: 452
+  value {
+    values: 656
+  }
+}
+glyph_patches {
+  key: 453
+  value {
+    values: 659
+  }
+}
+glyph_patches {
+  key: 454
+  value {
+    values: 882
+    values: 906
+  }
+}
+glyph_patches {
+  key: 455
+  value {
+    values: 878
+  }
+}
+glyph_patches {
+  key: 456
+  value {
+    values: 845
+  }
+}
+glyph_patches {
+  key: 457
+  value {
+    values: 920
+  }
+}
+glyph_patches {
+  key: 458
+  value {
+    values: 658
+  }
+}
+glyph_patches {
+  key: 459
+  value {
+    values: 888
+  }
+}
+glyph_patches {
+  key: 460
+  value {
+    values: 912
+  }
+}
+glyph_patches {
+  key: 461
+  value {
+    values: 893
+  }
+}
+glyph_patches {
+  key: 462
+  value {
+    values: 925
+  }
+}
+glyph_patches {
+  key: 463
+  value {
+    values: 886
+  }
+}
+glyph_patches {
+  key: 464
+  value {
+    values: 924
+  }
+}
+glyph_patches {
+  key: 465
+  value {
+    values: 877
+  }
+}
+glyph_patches {
+  key: 466
+  value {
+    values: 896
+  }
+}
+glyph_patches {
+  key: 467
+  value {
+    values: 890
+  }
+}
+glyph_patches {
+  key: 468
+  value {
+    values: 1307
+  }
+}
+glyph_patches {
+  key: 469
+  value {
+    values: 901
+  }
+}
+glyph_patches {
+  key: 470
+  value {
+    values: 1313
+  }
+}
+glyph_patches {
+  key: 471
+  value {
+    values: 852
+  }
+}
+glyph_patches {
+  key: 472
+  value {
+    values: 1292
+  }
+}
+glyph_patches {
+  key: 473
+  value {
+    values: 1297
+  }
+}
+glyph_patches {
+  key: 474
+  value {
+    values: 538
+  }
+}
+glyph_patches {
+  key: 475
+  value {
+    values: 1291
+  }
+}
+glyph_patches {
+  key: 476
+  value {
+    values: 1288
+  }
+}
+glyph_patches {
+  key: 477
+  value {
+    values: 549
+    values: 1278
+  }
+}
+glyph_patches {
+  key: 478
+  value {
+    values: 546
+    values: 547
+    values: 1290
+  }
+}
+glyph_patches {
+  key: 479
+  value {
+    values: 544
+  }
+}
+glyph_patches {
+  key: 480
+  value {
+    values: 545
+  }
+}
+glyph_patches {
+  key: 481
+  value {
+    values: 539
+  }
+}
+glyph_patches {
+  key: 482
+  value {
+    values: 536
+  }
+}
+glyph_patches {
+  key: 483
+  value {
+    values: 542
+  }
+}
+glyph_patches {
+  key: 484
+  value {
+    values: 535
+  }
+}
+glyph_patches {
+  key: 485
+  value {
+    values: 548
+  }
+}
+glyph_patches {
+  key: 486
+  value {
+    values: 1281
+    values: 1282
+  }
+}
+glyph_patches {
+  key: 487
+  value {
+    values: 528
+  }
+}
+glyph_patches {
+  key: 488
+  value {
+    values: 565
+  }
+}
+glyph_patches {
+  key: 489
+  value {
+    values: 1302
+  }
+}
+glyph_patches {
+  key: 490
+  value {
+    values: 598
+  }
+}
+glyph_patches {
+  key: 491
+  value {
+    values: 1283
+  }
+}
+glyph_patches {
+  key: 492
+  value {
+    values: 530
+    values: 551
+  }
+}
+glyph_patches {
+  key: 493
+  value {
+    values: 1300
+  }
+}
+glyph_patches {
+  key: 494
+  value {
+    values: 563
+  }
+}
+glyph_patches {
+  key: 495
+  value {
+    values: 557
+  }
+}
+glyph_patches {
+  key: 496
+  value {
+    values: 529
+  }
+}
+glyph_patches {
+  key: 497
+  value {
+    values: 527
+    values: 531
+  }
+}
+glyph_patches {
+  key: 498
+  value {
+    values: 1285
+  }
+}
+glyph_patches {
+  key: 499
+  value {
+    values: 1284
+  }
+}
+glyph_patches {
+  key: 500
+  value {
+    values: 532
+  }
+}
+glyph_patches {
+  key: 501
+  value {
+    values: 1279
+  }
+}
+glyph_patches {
+  key: 502
+  value {
+    values: 1304
+  }
+}
+glyph_patches {
+  key: 503
+  value {
+    values: 558
+  }
+}
+glyph_patches {
+  key: 504
+  value {
+    values: 561
+  }
+}
+glyph_patches {
+  key: 505
+  value {
+    values: 555
+  }
+}
+glyph_patches {
+  key: 506
+  value {
+    values: 1305
+  }
+}
+glyph_patches {
+  key: 507
+  value {
+    values: 1299
+  }
+}
+glyph_patches {
+  key: 508
+  value {
+    values: 1301
+  }
+}
+glyph_patches {
+  key: 509
+  value {
+    values: 554
+  }
+}
+glyph_patches {
+  key: 510
+  value {
+    values: 556
+  }
+}
+glyph_patches {
+  key: 511
+  value {
+    values: 564
+  }
+}
+glyph_patches {
+  key: 512
+  value {
+    values: 560
+  }
+}
+glyph_patches {
+  key: 513
+  value {
+    values: 559
+  }
+}
+glyph_patches {
+  key: 514
+  value {
+    values: 1303
+  }
+}
+glyph_patches {
+  key: 515
+  value {
+    values: 1264
+  }
+}
+glyph_patches {
+  key: 516
+  value {
+    values: 525
+  }
+}
+glyph_patches {
+  key: 517
+  value {
+    values: 1258
+    values: 1260
+    values: 1261
+    values: 1277
+  }
+}
+glyph_patches {
+  key: 518
+  value {
+    values: 864
+  }
+}
+glyph_patches {
+  key: 519
+  value {
+    values: 869
+  }
+}
+glyph_patches {
+  key: 520
+  value {
+    values: 846
+  }
+}
+glyph_patches {
+  key: 521
+  value {
+    values: 862
+  }
+}
+glyph_patches {
+  key: 522
+  value {
+    values: 854
+  }
+}
+glyph_patches {
+  key: 523
+  value {
+    values: 849
+  }
+}
+glyph_patches {
+  key: 524
+  value {
+    values: 866
+  }
+}
+glyph_patches {
+  key: 525
+  value {
+    values: 868
+  }
+}
+glyph_patches {
+  key: 526
+  value {
+    values: 872
+  }
+}
+glyph_patches {
+  key: 527
+  value {
+    values: 863
+  }
+}
+glyph_patches {
+  key: 528
+  value {
+    values: 876
+  }
+}
+glyph_patches {
+  key: 529
+  value {
+    values: 911
+  }
+}
+glyph_patches {
+  key: 530
+  value {
+    values: 891
+  }
+}
+glyph_patches {
+  key: 531
+  value {
+    values: 902
+  }
+}
+glyph_patches {
+  key: 532
+  value {
+    values: 927
+  }
+}
+glyph_patches {
+  key: 533
+  value {
+    values: 915
+  }
+}
+glyph_patches {
+  key: 534
+  value {
+    values: 898
+  }
+}
+glyph_patches {
+  key: 535
+  value {
+    values: 908
+  }
+}
+glyph_patches {
+  key: 536
+  value {
+    values: 903
+  }
+}
+glyph_patches {
+  key: 537
+  value {
+    values: 899
+  }
+}
+glyph_patches {
+  key: 538
+  value {
+    values: 889
+  }
+}
+glyph_patches {
+  key: 539
+  value {
+    values: 897
+  }
+}
+glyph_patches {
+  key: 540
+  value {
+    values: 909
+  }
+}
+glyph_patches {
+  key: 541
+  value {
+    values: 1312
+  }
+}
+glyph_patches {
+  key: 542
+  value {
+    values: 522
+  }
+}
+glyph_patches {
+  key: 543
+  value {
+    values: 518
+  }
+}
+glyph_patches {
+  key: 544
+  value {
+    values: 1310
+  }
+}
+glyph_patches {
+  key: 545
+  value {
+    values: 655
+  }
+}
+glyph_patches {
+  key: 546
+  value {
+    values: 562
+  }
+}
+glyph_patches {
+  key: 547
+  value {
+    values: 526
+  }
+}
+glyph_patches {
+  key: 548
+  value {
+    values: 537
+  }
+}
+glyph_patches {
+  key: 549
+  value {
+    values: 517
+  }
+}
+glyph_patches {
+  key: 550
+  value {
+    values: 540
+  }
+}
+glyph_patches {
+  key: 551
+  value {
+    values: 577
+  }
+}
+glyph_patches {
+  key: 552
+  value {
+    values: 859
+  }
+}
+glyph_patches {
+  key: 553
+  value {
+    values: 858
+  }
+}
+glyph_patches {
+  key: 554
+  value {
+    values: 1308
+  }
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 14
+  }
+  activated_patch: 0
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 15
+  }
+  activated_patch: 1
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 16
+  }
+  activated_patch: 2
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 17
+  }
+  activated_patch: 3
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 22
+  }
+  activated_patch: 4
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 27
+  }
+  activated_patch: 5
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 30
+  }
+  activated_patch: 6
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 32
+  }
+  activated_patch: 7
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 34
+  }
+  activated_patch: 8
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 39
+  }
+  activated_patch: 9
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 41
+  }
+  activated_patch: 10
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 47
+  }
+  activated_patch: 11
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 57
+  }
+  activated_patch: 12
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 58
+  }
+  activated_patch: 13
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 59
+  }
+  activated_patch: 14
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 61
+  }
+  activated_patch: 15
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 67
+  }
+  activated_patch: 16
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 69
+  }
+  activated_patch: 17
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 70
+  }
+  activated_patch: 18
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 76
+  }
+  activated_patch: 19
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 77
+  }
+  activated_patch: 20
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 80
+  }
+  activated_patch: 21
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 88
+  }
+  activated_patch: 22
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 89
+  }
+  activated_patch: 23
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 91
+  }
+  activated_patch: 24
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 92
+  }
+  activated_patch: 25
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 95
+  }
+  activated_patch: 26
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 102
+  }
+  activated_patch: 27
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 106
+  }
+  activated_patch: 28
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 110
+  }
+  activated_patch: 29
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 149
+  }
+  activated_patch: 30
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 155
+  }
+  activated_patch: 31
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 167
+  }
+  activated_patch: 32
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+  }
+  activated_patch: 33
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 245
+  }
+  activated_patch: 34
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 256
+  }
+  activated_patch: 35
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 264
+  }
+  activated_patch: 36
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 272
+  }
+  activated_patch: 37
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 280
+  }
+  activated_patch: 38
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 285
+  }
+  activated_patch: 39
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 292
+  }
+  activated_patch: 40
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 304
+  }
+  activated_patch: 41
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 310
+  }
+  activated_patch: 42
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 316
+  }
+  activated_patch: 43
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 326
+  }
+  activated_patch: 44
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 331
+  }
+  activated_patch: 45
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 335
+  }
+  activated_patch: 46
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 340
+  }
+  activated_patch: 47
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 351
+  }
+  activated_patch: 48
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 358
+  }
+  activated_patch: 49
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 363
+  }
+  activated_patch: 50
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 367
+  }
+  activated_patch: 51
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 372
+  }
+  activated_patch: 52
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 377
+  }
+  activated_patch: 53
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 381
+  }
+  activated_patch: 54
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 387
+  }
+  activated_patch: 55
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 392
+  }
+  activated_patch: 56
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 397
+  }
+  activated_patch: 57
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 402
+  }
+  activated_patch: 58
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 409
+  }
+  activated_patch: 59
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 420
+  }
+  activated_patch: 60
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 422
+  }
+  activated_patch: 61
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 426
+  }
+  activated_patch: 62
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 427
+  }
+  activated_patch: 63
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 429
+  }
+  activated_patch: 64
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+  }
+  activated_patch: 65
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 494
+  }
+  activated_patch: 66
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 495
+  }
+  activated_patch: 67
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 497
+  }
+  activated_patch: 68
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 498
+  }
+  activated_patch: 69
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 504
+  }
+  activated_patch: 70
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 513
+  }
+  activated_patch: 71
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 517
+  }
+  activated_patch: 72
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 521
+  }
+  activated_patch: 73
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 526
+  }
+  activated_patch: 74
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 530
+  }
+  activated_patch: 75
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 534
+  }
+  activated_patch: 76
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 538
+  }
+  activated_patch: 77
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 542
+  }
+  activated_patch: 78
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 546
+  }
+  activated_patch: 79
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 550
+  }
+  activated_patch: 80
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 554
+  }
+  activated_patch: 81
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 558
+  }
+  activated_patch: 82
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 564
+  }
+  activated_patch: 83
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 568
+  }
+  activated_patch: 84
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 572
+  }
+  activated_patch: 85
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 577
+  }
+  activated_patch: 86
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 581
+  }
+  activated_patch: 87
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 586
+  }
+  activated_patch: 88
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 592
+  }
+  activated_patch: 89
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 596
+  }
+  activated_patch: 90
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 600
+  }
+  activated_patch: 91
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 604
+  }
+  activated_patch: 92
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 608
+  }
+  activated_patch: 93
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 612
+  }
+  activated_patch: 94
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 616
+  }
+  activated_patch: 95
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 620
+  }
+  activated_patch: 96
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 624
+  }
+  activated_patch: 97
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 628
+  }
+  activated_patch: 98
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 632
+  }
+  activated_patch: 99
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 636
+  }
+  activated_patch: 100
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 640
+  }
+  activated_patch: 101
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 645
+  }
+  activated_patch: 102
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 649
+  }
+  activated_patch: 103
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 653
+  }
+  activated_patch: 104
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 657
+  }
+  activated_patch: 105
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 662
+  }
+  activated_patch: 106
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 666
+  }
+  activated_patch: 107
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 670
+  }
+  activated_patch: 108
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 674
+  }
+  activated_patch: 109
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 678
+  }
+  activated_patch: 110
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 682
+  }
+  activated_patch: 111
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 686
+  }
+  activated_patch: 112
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 690
+  }
+  activated_patch: 113
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 694
+  }
+  activated_patch: 114
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 698
+  }
+  activated_patch: 115
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 762
+  }
+  activated_patch: 116
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 766
+  }
+  activated_patch: 117
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 772
+  }
+  activated_patch: 118
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 776
+  }
+  activated_patch: 119
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 846
+  }
+  activated_patch: 120
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 847
+  }
+  activated_patch: 121
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 848
+  }
+  activated_patch: 122
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 849
+  }
+  activated_patch: 123
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 850
+  }
+  activated_patch: 124
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 851
+  }
+  activated_patch: 125
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 853
+  }
+  activated_patch: 126
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 855
+  }
+  activated_patch: 127
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 856
+  }
+  activated_patch: 128
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 858
+  }
+  activated_patch: 129
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 860
+  }
+  activated_patch: 130
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 861
+  }
+  activated_patch: 131
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 862
+  }
+  activated_patch: 132
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 863
+  }
+  activated_patch: 133
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 864
+  }
+  activated_patch: 134
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 868
+  }
+  activated_patch: 135
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 869
+  }
+  activated_patch: 136
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 870
+  }
+  activated_patch: 137
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 874
+  }
+  activated_patch: 138
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 875
+  }
+  activated_patch: 139
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 876
+  }
+  activated_patch: 140
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 877
+  }
+  activated_patch: 141
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 878
+  }
+  activated_patch: 142
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 879
+  }
+  activated_patch: 143
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 880
+  }
+  activated_patch: 144
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 881
+  }
+  activated_patch: 145
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 882
+  }
+  activated_patch: 146
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 883
+  }
+  activated_patch: 147
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 884
+  }
+  activated_patch: 148
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 885
+  }
+  activated_patch: 149
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 886
+  }
+  activated_patch: 150
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 887
+  }
+  activated_patch: 151
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 888
+  }
+  activated_patch: 152
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 889
+  }
+  activated_patch: 153
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 890
+  }
+  activated_patch: 154
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 891
+  }
+  activated_patch: 155
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 892
+  }
+  activated_patch: 156
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 893
+  }
+  activated_patch: 157
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 894
+  }
+  activated_patch: 158
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 907
+  }
+  activated_patch: 159
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 918
+  }
+  activated_patch: 160
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 919
+  }
+  activated_patch: 161
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 920
+  }
+  activated_patch: 162
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 923
+  }
+  activated_patch: 163
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 925
+  }
+  activated_patch: 164
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 926
+  }
+  activated_patch: 165
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 928
+  }
+  activated_patch: 166
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 929
+  }
+  activated_patch: 167
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 930
+  }
+  activated_patch: 168
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 931
+  }
+  activated_patch: 169
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 932
+  }
+  activated_patch: 170
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 933
+  }
+  activated_patch: 171
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 934
+  }
+  activated_patch: 172
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 937
+  }
+  activated_patch: 173
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 938
+  }
+  activated_patch: 174
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 939
+  }
+  activated_patch: 175
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 11
+    values: 58
+  }
+  activated_patch: 176
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 13
+    values: 894
+  }
+  activated_patch: 177
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 23
+    values: 24
+  }
+  activated_patch: 178
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 29
+    values: 850
+  }
+  activated_patch: 179
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 31
+    values: 850
+  }
+  activated_patch: 180
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 35
+    values: 772
+  }
+  activated_patch: 181
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 36
+    values: 850
+  }
+  activated_patch: 182
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 38
+    values: 229
+  }
+  activated_patch: 183
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 40
+    values: 256
+  }
+  activated_patch: 184
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 42
+    values: 65
+  }
+  activated_patch: 185
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 44
+    values: 888
+  }
+  activated_patch: 186
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 46
+    values: 229
+  }
+  activated_patch: 187
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 50
+    values: 850
+  }
+  activated_patch: 188
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 51
+    values: 68
+  }
+  activated_patch: 189
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 52
+    values: 256
+  }
+  activated_patch: 190
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 56
+    values: 256
+  }
+  activated_patch: 191
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 60
+    values: 229
+  }
+  activated_patch: 192
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 62
+    values: 850
+  }
+  activated_patch: 193
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 64
+    values: 850
+  }
+  activated_patch: 194
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 66
+    values: 850
+  }
+  activated_patch: 195
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 74
+    values: 229
+  }
+  activated_patch: 196
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 78
+    values: 850
+  }
+  activated_patch: 197
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 79
+    values: 229
+  }
+  activated_patch: 198
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 87
+    values: 850
+  }
+  activated_patch: 199
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 92
+    values: 95
+  }
+  activated_patch: 200
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 93
+    values: 850
+  }
+  activated_patch: 201
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 99
+    values: 850
+  }
+  activated_patch: 202
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 104
+    values: 850
+  }
+  activated_patch: 203
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 105
+    values: 256
+  }
+  activated_patch: 204
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 111
+    values: 259
+  }
+  activated_patch: 205
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 112
+    values: 245
+  }
+  activated_patch: 206
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 119
+    values: 245
+  }
+  activated_patch: 207
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 122
+    values: 259
+  }
+  activated_patch: 208
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 127
+    values: 245
+  }
+  activated_patch: 209
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 128
+    values: 245
+  }
+  activated_patch: 210
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 134
+    values: 229
+  }
+  activated_patch: 211
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 136
+    values: 850
+  }
+  activated_patch: 212
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 148
+    values: 259
+  }
+  activated_patch: 213
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 164
+    values: 259
+  }
+  activated_patch: 214
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 165
+    values: 256
+  }
+  activated_patch: 215
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 170
+    values: 256
+  }
+  activated_patch: 216
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 173
+    values: 245
+  }
+  activated_patch: 217
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 175
+    values: 256
+  }
+  activated_patch: 218
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 176
+    values: 256
+  }
+  activated_patch: 219
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 178
+    values: 259
+  }
+  activated_patch: 220
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 183
+    values: 229
+  }
+  activated_patch: 221
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 187
+    values: 256
+  }
+  activated_patch: 222
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 188
+    values: 850
+  }
+  activated_patch: 223
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 194
+    values: 939
+  }
+  activated_patch: 224
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 197
+    values: 245
+  }
+  activated_patch: 225
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 203
+    values: 259
+  }
+  activated_patch: 226
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 214
+    values: 245
+  }
+  activated_patch: 227
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 218
+    values: 259
+  }
+  activated_patch: 228
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 219
+    values: 245
+  }
+  activated_patch: 229
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 223
+    values: 229
+  }
+  activated_patch: 230
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 224
+    values: 850
+  }
+  activated_patch: 231
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 241
+  }
+  activated_patch: 232
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 247
+  }
+  activated_patch: 233
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 236
+    values: 245
+  }
+  activated_patch: 234
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 242
+    values: 850
+  }
+  activated_patch: 235
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 243
+    values: 762
+  }
+  activated_patch: 236
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 253
+    values: 850
+  }
+  activated_patch: 237
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 256
+    values: 286
+  }
+  activated_patch: 238
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 259
+    values: 276
+  }
+  activated_patch: 239
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 259
+    values: 287
+  }
+  activated_patch: 240
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 259
+    values: 294
+  }
+  activated_patch: 241
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 259
+    values: 327
+  }
+  activated_patch: 242
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 265
+    values: 850
+  }
+  activated_patch: 243
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 266
+    values: 939
+  }
+  activated_patch: 244
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 290
+    values: 850
+  }
+  activated_patch: 245
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 298
+    values: 939
+  }
+  activated_patch: 246
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 300
+    values: 939
+  }
+  activated_patch: 247
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 312
+    values: 939
+  }
+  activated_patch: 248
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 343
+    values: 939
+  }
+  activated_patch: 249
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 347
+    values: 939
+  }
+  activated_patch: 250
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 348
+    values: 939
+  }
+  activated_patch: 251
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 350
+    values: 850
+  }
+  activated_patch: 252
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 352
+    values: 939
+  }
+  activated_patch: 253
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 370
+    values: 850
+  }
+  activated_patch: 254
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 382
+    values: 939
+  }
+  activated_patch: 255
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 383
+    values: 762
+  }
+  activated_patch: 256
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 394
+    values: 939
+  }
+  activated_patch: 257
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 407
+    values: 850
+  }
+  activated_patch: 258
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 409
+    values: 420
+  }
+  activated_patch: 259
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 415
+    values: 850
+  }
+  activated_patch: 260
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 416
+    values: 850
+  }
+  activated_patch: 261
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 418
+    values: 850
+  }
+  activated_patch: 262
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 436
+    values: 628
+  }
+  activated_patch: 263
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 727
+  }
+  activated_patch: 264
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 447
+    values: 884
+  }
+  activated_patch: 265
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 485
+    values: 698
+  }
+  activated_patch: 266
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 489
+    values: 662
+  }
+  activated_patch: 267
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 504
+    values: 718
+  }
+  activated_patch: 268
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 524
+    values: 608
+  }
+  activated_patch: 269
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 559
+    values: 662
+  }
+  activated_patch: 270
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 584
+    values: 876
+  }
+  activated_patch: 271
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 588
+    values: 628
+  }
+  activated_patch: 272
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 640
+    values: 641
+  }
+  activated_patch: 273
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 649
+    values: 753
+  }
+  activated_patch: 274
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 649
+    values: 761
+  }
+  activated_patch: 275
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 737
+    values: 927
+  }
+  activated_patch: 276
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 277
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 854
+    values: 856
+  }
+  activated_patch: 278
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 855
+    values: 867
+  }
+  activated_patch: 279
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 908
+  }
+  activated_patch: 280
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 909
+  }
+  activated_patch: 281
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 910
+  }
+  activated_patch: 282
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 911
+  }
+  activated_patch: 283
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 912
+  }
+  activated_patch: 284
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 913
+  }
+  activated_patch: 285
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 914
+  }
+  activated_patch: 286
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 915
+  }
+  activated_patch: 287
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 916
+  }
+  activated_patch: 288
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 865
+    values: 917
+  }
+  activated_patch: 289
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 895
+  }
+  activated_patch: 290
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 896
+  }
+  activated_patch: 291
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 897
+  }
+  activated_patch: 292
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 898
+  }
+  activated_patch: 293
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 899
+  }
+  activated_patch: 294
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 900
+  }
+  activated_patch: 295
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 866
+    values: 901
+  }
+  activated_patch: 296
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 902
+    values: 918
+  }
+  activated_patch: 297
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 903
+    values: 919
+  }
+  activated_patch: 298
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 904
+    values: 920
+  }
+  activated_patch: 299
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 905
+    values: 906
+  }
+  activated_patch: 300
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 921
+    values: 922
+  }
+  activated_patch: 301
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 935
+    values: 936
+  }
+  activated_patch: 302
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 19
+    values: 27
+    values: 310
+  }
+  activated_patch: 303
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 89
+    values: 189
+    values: 939
+  }
+  activated_patch: 304
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 89
+    values: 250
+    values: 939
+  }
+  activated_patch: 305
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 174
+    values: 411
+    values: 586
+  }
+  activated_patch: 306
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 246
+    values: 517
+    values: 604
+  }
+  activated_patch: 307
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 271
+    values: 412
+    values: 653
+  }
+  activated_patch: 308
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 391
+    values: 409
+    values: 420
+  }
+  activated_patch: 309
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 435
+    values: 513
+    values: 581
+  }
+  activated_patch: 310
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 498
+    values: 861
+  }
+  activated_patch: 311
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 440
+    values: 596
+    values: 883
+  }
+  activated_patch: 312
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 445
+    values: 498
+    values: 526
+  }
+  activated_patch: 313
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 449
+    values: 554
+    values: 600
+  }
+  activated_patch: 314
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 476
+    values: 592
+    values: 608
+  }
+  activated_patch: 315
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 481
+    values: 592
+    values: 666
+  }
+  activated_patch: 316
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 517
+    values: 573
+    values: 657
+  }
+  activated_patch: 317
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 653
+    values: 706
+    values: 762
+  }
+  activated_patch: 318
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 662
+    values: 776
+    values: 876
+  }
+  activated_patch: 319
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 755
+    values: 766
+    values: 924
+  }
+  activated_patch: 320
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 30
+    values: 89
+    values: 304
+    values: 341
+  }
+  activated_patch: 321
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 51
+    values: 68
+    values: 85
+    values: 145
+  }
+  activated_patch: 322
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 450
+    values: 534
+    values: 620
+    values: 698
+  }
+  activated_patch: 323
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 454
+    values: 542
+    values: 600
+    values: 686
+  }
+  activated_patch: 324
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 456
+    values: 564
+    values: 600
+    values: 882
+  }
+  activated_patch: 325
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 484
+    values: 550
+    values: 592
+    values: 620
+  }
+  activated_patch: 326
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 491
+    values: 564
+    values: 581
+    values: 666
+  }
+  activated_patch: 327
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 88
+    values: 155
+    values: 272
+    values: 280
+    values: 873
+  }
+  activated_patch: 328
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 538
+    values: 636
+    values: 674
+    values: 743
+  }
+  activated_patch: 329
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 478
+    values: 534
+    values: 558
+    values: 636
+    values: 662
+  }
+  activated_patch: 330
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 102
+    values: 264
+    values: 316
+    values: 362
+    values: 596
+    values: 662
+  }
+  activated_patch: 331
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 109
+    values: 129
+    values: 130
+    values: 139
+    values: 140
+    values: 143
+  }
+  activated_patch: 332
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 114
+    values: 118
+    values: 120
+    values: 125
+    values: 138
+    values: 182
+  }
+  activated_patch: 333
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 180
+    values: 208
+    values: 240
+    values: 252
+    values: 275
+    values: 283
+  }
+  activated_patch: 334
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 209
+    values: 216
+    values: 235
+    values: 237
+    values: 238
+    values: 325
+  }
+  activated_patch: 335
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 444
+    values: 530
+    values: 542
+    values: 596
+    values: 674
+  }
+  activated_patch: 336
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 479
+    values: 495
+    values: 558
+    values: 604
+    values: 657
+    values: 670
+  }
+  activated_patch: 337
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 577
+    values: 592
+    values: 596
+    values: 636
+    values: 653
+    values: 698
+  }
+  activated_patch: 338
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 256
+    values: 259
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  activated_patch: 339
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 47
+    values: 61
+    values: 67
+    values: 76
+    values: 110
+    values: 272
+    values: 304
+    values: 356
+    values: 397
+  }
+  activated_patch: 340
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 58
+    values: 70
+    values: 264
+    values: 272
+    values: 310
+    values: 318
+    values: 326
+    values: 377
+    values: 542
+    values: 550
+    values: 558
+  }
+  activated_patch: 341
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 59
+    values: 88
+    values: 89
+    values: 316
+    values: 358
+    values: 363
+    values: 372
+    values: 377
+    values: 392
+    values: 397
+    values: 872
+  }
+  activated_patch: 342
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 256
+    values: 259
+    values: 372
+    values: 397
+    values: 404
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  activated_patch: 343
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 34
+    values: 69
+    values: 77
+    values: 80
+    values: 149
+    values: 155
+    values: 335
+    values: 339
+    values: 363
+    values: 367
+    values: 372
+    values: 381
+    values: 387
+    values: 392
+    values: 397
+  }
+  activated_patch: 344
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 498
+    values: 513
+    values: 542
+    values: 546
+    values: 550
+    values: 554
+    values: 564
+    values: 608
+    values: 620
+    values: 624
+    values: 628
+    values: 640
+    values: 645
+    values: 674
+    values: 686
+  }
+  activated_patch: 345
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 40
+    values: 52
+    values: 56
+    values: 105
+    values: 140
+    values: 165
+    values: 170
+    values: 171
+    values: 175
+    values: 176
+    values: 182
+    values: 187
+    values: 256
+    values: 275
+    values: 286
+    values: 322
+    values: 325
+  }
+  activated_patch: 346
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 111
+    values: 122
+    values: 138
+    values: 139
+    values: 144
+    values: 148
+    values: 164
+    values: 178
+    values: 203
+    values: 218
+    values: 238
+    values: 252
+    values: 259
+    values: 276
+    values: 287
+    values: 294
+    values: 327
+  }
+  activated_patch: 347
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 33
+    values: 57
+    values: 80
+    values: 83
+    values: 94
+    values: 144
+    values: 171
+    values: 229
+    values: 256
+    values: 259
+    values: 272
+    values: 363
+    values: 497
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  activated_patch: 348
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 69
+    values: 106
+    values: 112
+    values: 119
+    values: 125
+    values: 127
+    values: 128
+    values: 129
+    values: 149
+    values: 155
+    values: 173
+    values: 197
+    values: 214
+    values: 219
+    values: 236
+    values: 237
+    values: 240
+    values: 245
+    values: 264
+  }
+  activated_patch: 349
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 38
+    values: 46
+    values: 60
+    values: 74
+    values: 79
+    values: 83
+    values: 118
+    values: 134
+    values: 143
+    values: 177
+    values: 183
+    values: 223
+    values: 229
+    values: 235
+    values: 241
+    values: 247
+    values: 283
+    values: 530
+    values: 550
+    values: 604
+  }
+  activated_patch: 350
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 22
+    values: 30
+    values: 34
+    values: 106
+    values: 264
+    values: 351
+    values: 358
+    values: 363
+    values: 397
+    values: 402
+    values: 437
+    values: 495
+    values: 526
+    values: 534
+    values: 554
+    values: 581
+    values: 657
+    values: 666
+    values: 670
+    values: 674
+    values: 871
+    values: 882
+  }
+  activated_patch: 351
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 27
+    values: 39
+    values: 57
+    values: 285
+    values: 306
+    values: 316
+    values: 340
+    values: 402
+    values: 409
+    values: 437
+    values: 494
+    values: 495
+    values: 497
+    values: 504
+    values: 554
+    values: 564
+    values: 577
+    values: 581
+    values: 592
+    values: 596
+    values: 600
+    values: 604
+    values: 608
+    values: 612
+    values: 616
+    values: 636
+    values: 657
+    values: 662
+    values: 670
+    values: 698
+    values: 762
+    values: 766
+  }
+  activated_patch: 352
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 15
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 353
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 30
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 354
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 32
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 355
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 39
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 356
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 47
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 357
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 58
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 358
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 59
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 359
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 67
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 360
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 88
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 361
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 89
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 362
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 89
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 363
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 91
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 364
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 92
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 365
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 94
+  }
+  required_segments {
+    values: 776
+  }
+  activated_patch: 366
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 106
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 367
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 167
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 368
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 369
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 256
+  }
+  required_segments {
+    values: 850
+  }
+  activated_patch: 370
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 331
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 371
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 340
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 372
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 377
+  }
+  required_segments {
+    values: 853
+  }
+  activated_patch: 373
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 392
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 374
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 375
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 498
+  }
+  required_segments {
+    values: 851
+  }
+  activated_patch: 376
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 498
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 377
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 538
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 378
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 564
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 379
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 762
+  }
+  required_segments {
+    values: 859
+  }
+  activated_patch: 380
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 762
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 381
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 850
+  }
+  required_segments {
+    values: 874
+  }
+  activated_patch: 382
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 33
+    values: 94
+  }
+  required_segments {
+    values: 33
+    values: 850
+  }
+  activated_patch: 383
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 83
+    values: 94
+  }
+  required_segments {
+    values: 83
+    values: 229
+  }
+  activated_patch: 384
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 94
+    values: 144
+  }
+  required_segments {
+    values: 144
+    values: 259
+  }
+  activated_patch: 385
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 94
+    values: 171
+  }
+  required_segments {
+    values: 171
+    values: 256
+  }
+  activated_patch: 386
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 109
+    values: 129
+  }
+  required_segments {
+    values: 129
+    values: 245
+  }
+  activated_patch: 387
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 109
+    values: 130
+  }
+  required_segments {
+    values: 130
+    values: 850
+  }
+  activated_patch: 388
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 109
+    values: 139
+  }
+  required_segments {
+    values: 139
+    values: 259
+  }
+  activated_patch: 389
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 109
+    values: 140
+  }
+  required_segments {
+    values: 140
+    values: 256
+  }
+  activated_patch: 390
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 109
+    values: 143
+  }
+  required_segments {
+    values: 143
+    values: 229
+  }
+  activated_patch: 391
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 114
+    values: 120
+  }
+  required_segments {
+    values: 114
+    values: 850
+  }
+  activated_patch: 392
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 118
+    values: 120
+  }
+  required_segments {
+    values: 118
+    values: 229
+  }
+  activated_patch: 393
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 119
+    values: 245
+  }
+  required_segments {
+    values: 229
+    values: 256
+    values: 259
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  activated_patch: 394
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 120
+    values: 125
+  }
+  required_segments {
+    values: 125
+    values: 245
+  }
+  activated_patch: 395
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 120
+    values: 138
+  }
+  required_segments {
+    values: 138
+    values: 259
+  }
+  activated_patch: 396
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 120
+    values: 182
+  }
+  required_segments {
+    values: 182
+    values: 256
+  }
+  activated_patch: 397
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 174
+    values: 411
+  }
+  required_segments {
+    values: 411
+    values: 850
+  }
+  activated_patch: 398
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 180
+    values: 208
+  }
+  required_segments {
+    values: 208
+    values: 850
+  }
+  activated_patch: 399
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 180
+    values: 240
+  }
+  required_segments {
+    values: 240
+    values: 245
+  }
+  activated_patch: 400
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 180
+    values: 252
+  }
+  required_segments {
+    values: 252
+    values: 259
+  }
+  activated_patch: 401
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 180
+    values: 275
+  }
+  required_segments {
+    values: 256
+    values: 275
+  }
+  activated_patch: 402
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 180
+    values: 283
+  }
+  required_segments {
+    values: 229
+    values: 283
+  }
+  activated_patch: 403
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 209
+    values: 216
+  }
+  required_segments {
+    values: 209
+    values: 850
+  }
+  activated_patch: 404
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 216
+    values: 235
+  }
+  required_segments {
+    values: 229
+    values: 235
+  }
+  activated_patch: 405
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 216
+    values: 237
+  }
+  required_segments {
+    values: 237
+    values: 245
+  }
+  activated_patch: 406
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 216
+    values: 238
+  }
+  required_segments {
+    values: 238
+    values: 259
+  }
+  activated_patch: 407
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 216
+    values: 325
+  }
+  required_segments {
+    values: 256
+    values: 325
+  }
+  activated_patch: 408
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 271
+    values: 412
+  }
+  required_segments {
+    values: 412
+    values: 850
+  }
+  activated_patch: 409
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 762
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 410
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 31
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 411
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 50
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 412
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 762
+    values: 766
+    values: 768
+    values: 850
+  }
+  required_segments {
+    values: 762
+    values: 766
+    values: 768
+    values: 874
+  }
+  activated_patch: 413
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 256
+    values: 259
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  required_segments {
+    values: 272
+  }
+  activated_patch: 414
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 256
+    values: 259
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  required_segments {
+    values: 497
+  }
+  activated_patch: 415
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 229
+    values: 256
+    values: 259
+    values: 568
+    values: 686
+    values: 776
+    values: 850
+    values: 879
+  }
+  required_segments {
+    values: 513
+  }
+  activated_patch: 416
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 57
+    values: 61
+    values: 89
+    values: 189
+    values: 194
+    values: 250
+    values: 264
+    values: 266
+    values: 298
+    values: 300
+    values: 310
+    values: 312
+    values: 343
+    values: 347
+    values: 348
+    values: 352
+    values: 382
+    values: 387
+    values: 394
+    values: 939
+  }
+  required_segments {
+    values: 57
+    values: 61
+    values: 89
+    values: 189
+    values: 194
+    values: 250
+    values: 264
+    values: 266
+    values: 298
+    values: 300
+    values: 312
+    values: 343
+    values: 347
+    values: 348
+    values: 352
+    values: 382
+    values: 387
+    values: 394
+    values: 857
+    values: 939
+  }
+  activated_patch: 417
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 165
+    values: 256
+  }
+  required_segments {
+    values: 256
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 418
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 183
+    values: 229
+  }
+  required_segments {
+    values: 229
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 419
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 22
+    values: 30
+  }
+  required_segments {
+    values: 22
+    values: 857
+  }
+  required_segments {
+    values: 30
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 420
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 22
+    values: 34
+  }
+  required_segments {
+    values: 22
+    values: 857
+  }
+  required_segments {
+    values: 34
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 421
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 27
+    values: 39
+  }
+  required_segments {
+    values: 27
+    values: 857
+  }
+  required_segments {
+    values: 39
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 422
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 30
+    values: 304
+  }
+  required_segments {
+    values: 30
+    values: 851
+  }
+  required_segments {
+    values: 304
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 423
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 34
+    values: 77
+  }
+  required_segments {
+    values: 34
+    values: 851
+  }
+  required_segments {
+    values: 77
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 424
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 34
+    values: 80
+  }
+  required_segments {
+    values: 34
+    values: 851
+  }
+  required_segments {
+    values: 80
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 425
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 39
+    values: 57
+  }
+  required_segments {
+    values: 39
+    values: 851
+  }
+  required_segments {
+    values: 57
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 426
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 41
+    values: 59
+  }
+  required_segments {
+    values: 41
+    values: 851
+  }
+  required_segments {
+    values: 59
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 427
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 47
+    values: 61
+  }
+  required_segments {
+    values: 47
+    values: 857
+  }
+  required_segments {
+    values: 61
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 428
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 47
+    values: 76
+  }
+  required_segments {
+    values: 47
+    values: 857
+  }
+  required_segments {
+    values: 76
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 429
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 57
+    values: 264
+  }
+  required_segments {
+    values: 57
+    values: 851
+  }
+  required_segments {
+    values: 264
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 430
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 57
+    values: 285
+  }
+  required_segments {
+    values: 57
+    values: 851
+  }
+  required_segments {
+    values: 285
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 431
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 57
+    values: 316
+  }
+  required_segments {
+    values: 57
+    values: 851
+  }
+  required_segments {
+    values: 316
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 432
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 58
+    values: 310
+  }
+  required_segments {
+    values: 58
+    values: 851
+  }
+  required_segments {
+    values: 310
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 433
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 61
+    values: 272
+  }
+  required_segments {
+    values: 61
+    values: 851
+  }
+  required_segments {
+    values: 272
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 434
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 61
+    values: 304
+  }
+  required_segments {
+    values: 61
+    values: 851
+  }
+  required_segments {
+    values: 304
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 435
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 61
+    values: 358
+  }
+  required_segments {
+    values: 61
+    values: 851
+  }
+  required_segments {
+    values: 358
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 436
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 67
+    values: 76
+  }
+  required_segments {
+    values: 67
+    values: 851
+  }
+  required_segments {
+    values: 76
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 437
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 67
+    values: 110
+  }
+  required_segments {
+    values: 67
+    values: 851
+  }
+  required_segments {
+    values: 110
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 438
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 70
+    values: 310
+  }
+  required_segments {
+    values: 70
+    values: 851
+  }
+  required_segments {
+    values: 310
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 439
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 77
+    values: 80
+  }
+  required_segments {
+    values: 77
+    values: 857
+  }
+  required_segments {
+    values: 80
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 440
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 77
+    values: 335
+  }
+  required_segments {
+    values: 77
+    values: 851
+  }
+  required_segments {
+    values: 335
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 441
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 88
+    values: 155
+  }
+  required_segments {
+    values: 88
+    values: 851
+  }
+  required_segments {
+    values: 155
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 442
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 88
+    values: 316
+  }
+  required_segments {
+    values: 88
+    values: 851
+  }
+  required_segments {
+    values: 316
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 443
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 102
+    values: 264
+  }
+  required_segments {
+    values: 102
+    values: 851
+  }
+  required_segments {
+    values: 264
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 444
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 102
+    values: 316
+  }
+  required_segments {
+    values: 102
+    values: 851
+  }
+  required_segments {
+    values: 316
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 445
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 110
+    values: 335
+  }
+  required_segments {
+    values: 110
+    values: 851
+  }
+  required_segments {
+    values: 335
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 446
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 155
+    values: 292
+  }
+  required_segments {
+    values: 155
+    values: 851
+  }
+  required_segments {
+    values: 292
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 447
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 264
+    values: 326
+  }
+  required_segments {
+    values: 264
+    values: 851
+  }
+  required_segments {
+    values: 326
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 448
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 272
+    values: 280
+  }
+  required_segments {
+    values: 272
+    values: 851
+  }
+  required_segments {
+    values: 280
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 449
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 272
+    values: 326
+  }
+  required_segments {
+    values: 272
+    values: 851
+  }
+  required_segments {
+    values: 326
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 450
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 304
+    values: 331
+  }
+  required_segments {
+    values: 304
+    values: 851
+  }
+  required_segments {
+    values: 331
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 451
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 326
+    values: 331
+  }
+  required_segments {
+    values: 326
+    values: 851
+  }
+  required_segments {
+    values: 331
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 452
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 340
+    values: 387
+  }
+  required_segments {
+    values: 340
+    values: 851
+  }
+  required_segments {
+    values: 387
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 453
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 351
+    values: 402
+  }
+  required_segments {
+    values: 351
+    values: 851
+  }
+  required_segments {
+    values: 402
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 454
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 358
+    values: 377
+  }
+  required_segments {
+    values: 358
+    values: 851
+  }
+  required_segments {
+    values: 377
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 455
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 358
+    values: 381
+  }
+  required_segments {
+    values: 358
+    values: 851
+  }
+  required_segments {
+    values: 381
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 456
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 358
+    values: 402
+  }
+  required_segments {
+    values: 358
+    values: 851
+  }
+  required_segments {
+    values: 402
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 457
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 363
+    values: 367
+  }
+  required_segments {
+    values: 363
+    values: 851
+  }
+  required_segments {
+    values: 367
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 458
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 363
+    values: 372
+  }
+  required_segments {
+    values: 363
+    values: 851
+  }
+  required_segments {
+    values: 372
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 459
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 363
+    values: 381
+  }
+  required_segments {
+    values: 363
+    values: 851
+  }
+  required_segments {
+    values: 381
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 460
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 363
+    values: 397
+  }
+  required_segments {
+    values: 363
+    values: 851
+  }
+  required_segments {
+    values: 397
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 461
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 367
+    values: 381
+  }
+  required_segments {
+    values: 367
+    values: 851
+  }
+  required_segments {
+    values: 381
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 462
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 367
+    values: 392
+  }
+  required_segments {
+    values: 367
+    values: 851
+  }
+  required_segments {
+    values: 392
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 463
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 367
+    values: 397
+  }
+  required_segments {
+    values: 367
+    values: 851
+  }
+  required_segments {
+    values: 397
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 464
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 372
+    values: 381
+  }
+  required_segments {
+    values: 372
+    values: 851
+  }
+  required_segments {
+    values: 381
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 465
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 372
+    values: 387
+  }
+  required_segments {
+    values: 372
+    values: 851
+  }
+  required_segments {
+    values: 387
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 466
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 372
+    values: 392
+  }
+  required_segments {
+    values: 372
+    values: 851
+  }
+  required_segments {
+    values: 392
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 467
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 377
+    values: 387
+  }
+  required_segments {
+    values: 377
+    values: 851
+  }
+  required_segments {
+    values: 387
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 468
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 392
+    values: 397
+  }
+  required_segments {
+    values: 392
+    values: 851
+  }
+  required_segments {
+    values: 397
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 469
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 402
+    values: 409
+  }
+  required_segments {
+    values: 402
+    values: 857
+  }
+  required_segments {
+    values: 409
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 470
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 409
+    values: 420
+  }
+  required_segments {
+    values: 409
+    values: 857
+  }
+  required_segments {
+    values: 420
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 471
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 435
+    values: 437
+  }
+  required_segments {
+    values: 435
+    values: 851
+  }
+  required_segments {
+    values: 437
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 472
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 436
+    values: 437
+  }
+  required_segments {
+    values: 436
+    values: 851
+  }
+  required_segments {
+    values: 437
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 473
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 445
+  }
+  required_segments {
+    values: 437
+    values: 857
+  }
+  required_segments {
+    values: 445
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 474
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 447
+  }
+  required_segments {
+    values: 437
+    values: 857
+  }
+  required_segments {
+    values: 447
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 475
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 450
+  }
+  required_segments {
+    values: 437
+    values: 857
+  }
+  required_segments {
+    values: 450
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 476
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 494
+  }
+  required_segments {
+    values: 437
+    values: 851
+  }
+  required_segments {
+    values: 494
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 477
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 495
+  }
+  required_segments {
+    values: 437
+    values: 851
+  }
+  required_segments {
+    values: 495
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 478
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 497
+  }
+  required_segments {
+    values: 437
+    values: 851
+  }
+  required_segments {
+    values: 497
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 479
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 498
+  }
+  required_segments {
+    values: 437
+    values: 851
+  }
+  required_segments {
+    values: 498
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 480
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 440
+    values: 481
+  }
+  required_segments {
+    values: 440
+    values: 851
+  }
+  required_segments {
+    values: 481
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 481
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 449
+    values: 476
+  }
+  required_segments {
+    values: 449
+    values: 851
+  }
+  required_segments {
+    values: 476
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 482
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 454
+    values: 484
+  }
+  required_segments {
+    values: 454
+    values: 851
+  }
+  required_segments {
+    values: 484
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 483
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 456
+    values: 491
+  }
+  required_segments {
+    values: 456
+    values: 851
+  }
+  required_segments {
+    values: 491
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 484
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 485
+    values: 489
+  }
+  required_segments {
+    values: 485
+    values: 851
+  }
+  required_segments {
+    values: 489
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 485
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 494
+    values: 497
+  }
+  required_segments {
+    values: 494
+    values: 857
+  }
+  required_segments {
+    values: 497
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 486
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 497
+    values: 504
+  }
+  required_segments {
+    values: 497
+    values: 851
+  }
+  required_segments {
+    values: 504
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 487
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 504
+    values: 517
+  }
+  required_segments {
+    values: 504
+    values: 851
+  }
+  required_segments {
+    values: 517
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 488
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 504
+    values: 521
+  }
+  required_segments {
+    values: 504
+    values: 851
+  }
+  required_segments {
+    values: 521
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 489
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 504
+    values: 526
+  }
+  required_segments {
+    values: 504
+    values: 851
+  }
+  required_segments {
+    values: 526
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 490
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 513
+    values: 521
+  }
+  required_segments {
+    values: 513
+    values: 851
+  }
+  required_segments {
+    values: 521
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 491
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 513
+    values: 530
+  }
+  required_segments {
+    values: 513
+    values: 851
+  }
+  required_segments {
+    values: 530
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 492
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 513
+    values: 542
+  }
+  required_segments {
+    values: 513
+    values: 851
+  }
+  required_segments {
+    values: 542
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 493
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 517
+    values: 524
+  }
+  required_segments {
+    values: 517
+    values: 851
+  }
+  required_segments {
+    values: 524
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 494
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 517
+    values: 526
+  }
+  required_segments {
+    values: 517
+    values: 851
+  }
+  required_segments {
+    values: 526
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 495
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 517
+    values: 538
+  }
+  required_segments {
+    values: 517
+    values: 851
+  }
+  required_segments {
+    values: 538
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 496
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 521
+    values: 534
+  }
+  required_segments {
+    values: 521
+    values: 851
+  }
+  required_segments {
+    values: 534
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 497
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 526
+    values: 534
+  }
+  required_segments {
+    values: 526
+    values: 851
+  }
+  required_segments {
+    values: 534
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 498
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 526
+    values: 546
+  }
+  required_segments {
+    values: 526
+    values: 851
+  }
+  required_segments {
+    values: 546
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 499
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 530
+    values: 542
+  }
+  required_segments {
+    values: 530
+    values: 851
+  }
+  required_segments {
+    values: 542
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 500
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 534
+    values: 538
+  }
+  required_segments {
+    values: 534
+    values: 851
+  }
+  required_segments {
+    values: 538
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 501
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 542
+    values: 558
+  }
+  required_segments {
+    values: 542
+    values: 851
+  }
+  required_segments {
+    values: 558
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 502
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 546
+    values: 550
+  }
+  required_segments {
+    values: 546
+    values: 851
+  }
+  required_segments {
+    values: 550
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 503
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 546
+    values: 558
+  }
+  required_segments {
+    values: 546
+    values: 851
+  }
+  required_segments {
+    values: 558
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 504
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 546
+    values: 572
+  }
+  required_segments {
+    values: 546
+    values: 851
+  }
+  required_segments {
+    values: 572
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 505
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 550
+    values: 558
+  }
+  required_segments {
+    values: 550
+    values: 851
+  }
+  required_segments {
+    values: 558
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 506
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 554
+    values: 608
+  }
+  required_segments {
+    values: 554
+    values: 851
+  }
+  required_segments {
+    values: 608
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 507
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 564
+    values: 624
+  }
+  required_segments {
+    values: 564
+    values: 851
+  }
+  required_segments {
+    values: 624
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 508
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 577
+    values: 632
+  }
+  required_segments {
+    values: 577
+    values: 857
+  }
+  required_segments {
+    values: 632
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 509
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 586
+    values: 640
+  }
+  required_segments {
+    values: 586
+    values: 851
+  }
+  required_segments {
+    values: 640
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 510
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 612
+    values: 657
+  }
+  required_segments {
+    values: 612
+    values: 851
+  }
+  required_segments {
+    values: 657
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 511
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 624
+    values: 632
+  }
+  required_segments {
+    values: 624
+    values: 857
+  }
+  required_segments {
+    values: 632
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 512
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 628
+    values: 636
+  }
+  required_segments {
+    values: 628
+    values: 851
+  }
+  required_segments {
+    values: 636
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 513
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 628
+    values: 640
+  }
+  required_segments {
+    values: 628
+    values: 851
+  }
+  required_segments {
+    values: 640
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 514
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 706
+    values: 762
+  }
+  required_segments {
+    values: 706
+    values: 851
+  }
+  required_segments {
+    values: 762
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 515
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 753
+    values: 761
+  }
+  required_segments {
+    values: 753
+    values: 851
+  }
+  required_segments {
+    values: 761
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 516
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 762
+    values: 766
+  }
+  required_segments {
+    values: 762
+    values: 851
+  }
+  required_segments {
+    values: 766
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 517
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 29
+    values: 66
+    values: 850
+  }
+  required_segments {
+    values: 29
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 66
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 518
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 36
+    values: 62
+    values: 850
+  }
+  required_segments {
+    values: 36
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 62
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 519
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 38
+    values: 74
+    values: 229
+  }
+  required_segments {
+    values: 38
+    values: 229
+    values: 851
+  }
+  required_segments {
+    values: 74
+    values: 229
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 520
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 40
+    values: 175
+    values: 256
+  }
+  required_segments {
+    values: 40
+    values: 256
+    values: 851
+  }
+  required_segments {
+    values: 175
+    values: 256
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 521
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 46
+    values: 134
+    values: 229
+  }
+  required_segments {
+    values: 46
+    values: 229
+    values: 851
+  }
+  required_segments {
+    values: 134
+    values: 229
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 522
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 52
+    values: 105
+    values: 256
+  }
+  required_segments {
+    values: 52
+    values: 256
+    values: 851
+  }
+  required_segments {
+    values: 105
+    values: 256
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 523
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 56
+    values: 187
+    values: 256
+  }
+  required_segments {
+    values: 56
+    values: 256
+    values: 851
+  }
+  required_segments {
+    values: 187
+    values: 256
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 524
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 60
+    values: 229
+    values: 241
+  }
+  required_segments {
+    values: 60
+    values: 229
+    values: 851
+  }
+  required_segments {
+    values: 229
+    values: 241
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 525
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 78
+    values: 188
+    values: 850
+  }
+  required_segments {
+    values: 78
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 188
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 526
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 79
+    values: 229
+    values: 247
+  }
+  required_segments {
+    values: 79
+    values: 229
+    values: 851
+  }
+  required_segments {
+    values: 229
+    values: 247
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 527
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 87
+    values: 224
+    values: 850
+  }
+  required_segments {
+    values: 87
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 224
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 528
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 93
+    values: 136
+    values: 850
+  }
+  required_segments {
+    values: 93
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 136
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 529
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 94
+    values: 171
+    values: 851
+  }
+  required_segments {
+    values: 171
+    values: 256
+  }
+  required_segments {
+    values: 256
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 530
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 99
+    values: 253
+    values: 850
+  }
+  required_segments {
+    values: 99
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 253
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 531
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 104
+    values: 242
+    values: 850
+  }
+  required_segments {
+    values: 104
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 242
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 532
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 194
+    values: 266
+    values: 939
+  }
+  required_segments {
+    values: 194
+    values: 851
+    values: 939
+  }
+  required_segments {
+    values: 266
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 533
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 265
+    values: 350
+    values: 850
+  }
+  required_segments {
+    values: 265
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 350
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 534
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 290
+    values: 370
+    values: 850
+  }
+  required_segments {
+    values: 290
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 370
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 535
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 298
+    values: 352
+    values: 939
+  }
+  required_segments {
+    values: 298
+    values: 851
+    values: 939
+  }
+  required_segments {
+    values: 352
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 536
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 300
+    values: 348
+    values: 939
+  }
+  required_segments {
+    values: 300
+    values: 851
+    values: 939
+  }
+  required_segments {
+    values: 348
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 537
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 310
+    values: 347
+    values: 939
+  }
+  required_segments {
+    values: 310
+    values: 851
+  }
+  required_segments {
+    values: 347
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 538
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 312
+    values: 343
+    values: 939
+  }
+  required_segments {
+    values: 312
+    values: 851
+    values: 939
+  }
+  required_segments {
+    values: 343
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 539
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 382
+    values: 394
+    values: 939
+  }
+  required_segments {
+    values: 382
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 394
+    values: 851
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 540
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 415
+    values: 418
+    values: 850
+  }
+  required_segments {
+    values: 415
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 418
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 541
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 727
+    values: 762
+  }
+  required_segments {
+    values: 437
+    values: 727
+    values: 857
+  }
+  required_segments {
+    values: 437
+    values: 762
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 542
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 737
+    values: 762
+    values: 927
+  }
+  required_segments {
+    values: 737
+    values: 857
+    values: 927
+  }
+  required_segments {
+    values: 762
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 543
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 89
+    values: 189
+    values: 250
+    values: 939
+  }
+  required_segments {
+    values: 89
+    values: 189
+    values: 851
+    values: 939
+  }
+  required_segments {
+    values: 89
+    values: 250
+    values: 857
+    values: 939
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 544
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 174
+    values: 271
+    values: 411
+    values: 412
+  }
+  required_segments {
+    values: 174
+    values: 411
+    values: 851
+  }
+  required_segments {
+    values: 271
+    values: 412
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 545
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 588
+    values: 628
+    values: 640
+    values: 641
+  }
+  required_segments {
+    values: 588
+    values: 628
+    values: 851
+  }
+  required_segments {
+    values: 640
+    values: 641
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 546
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 755
+    values: 762
+    values: 766
+    values: 924
+  }
+  required_segments {
+    values: 755
+    values: 766
+    values: 857
+    values: 924
+  }
+  required_segments {
+    values: 762
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 547
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 444
+    values: 479
+    values: 495
+    values: 542
+    values: 558
+  }
+  required_segments {
+    values: 437
+    values: 444
+    values: 542
+    values: 851
+  }
+  required_segments {
+    values: 479
+    values: 495
+    values: 558
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 548
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 450
+    values: 534
+    values: 538
+    values: 718
+    values: 743
+  }
+  required_segments {
+    values: 437
+    values: 538
+    values: 743
+    values: 857
+  }
+  required_segments {
+    values: 450
+    values: 534
+    values: 718
+    values: 851
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 549
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 437
+    values: 478
+    values: 526
+    values: 534
+    values: 550
+    values: 558
+  }
+  required_segments {
+    values: 437
+    values: 526
+    values: 550
+    values: 851
+  }
+  required_segments {
+    values: 478
+    values: 534
+    values: 558
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 550
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 58
+    values: 106
+    values: 304
+    values: 331
+    values: 351
+    values: 358
+    values: 381
+    values: 517
+    values: 526
+    values: 636
+    values: 698
+  }
+  required_segments {
+    values: 58
+    values: 106
+    values: 304
+    values: 351
+    values: 358
+    values: 517
+    values: 636
+    values: 698
+    values: 851
+  }
+  required_segments {
+    values: 58
+    values: 106
+    values: 331
+    values: 351
+    values: 381
+    values: 526
+    values: 636
+    values: 698
+    values: 857
+  }
+  required_segments {
+    values: 58
+    values: 351
+    values: 636
+    values: 698
+    values: 851
+    values: 857
+  }
+  activated_patch: 551
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 33
+    values: 64
+    values: 850
+  }
+  required_segments {
+    values: 33
+    values: 94
+    values: 851
+  }
+  required_segments {
+    values: 33
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 64
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 552
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 83
+    values: 94
+    values: 851
+  }
+  required_segments {
+    values: 83
+    values: 223
+    values: 229
+  }
+  required_segments {
+    values: 83
+    values: 229
+    values: 851
+  }
+  required_segments {
+    values: 223
+    values: 229
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 553
+}
+glyph_patch_conditions {
+  required_segments {
+    values: 174
+    values: 271
+    values: 411
+    values: 412
+  }
+  required_segments {
+    values: 174
+    values: 411
+    values: 851
+  }
+  required_segments {
+    values: 271
+    values: 412
+    values: 857
+  }
+  required_segments {
+    values: 411
+    values: 412
+    values: 850
+  }
+  required_segments {
+    values: 411
+    values: 850
+    values: 851
+  }
+  required_segments {
+    values: 412
+    values: 850
+    values: 857
+  }
+  required_segments {
+    values: 851
+    values: 857
+  }
+  activated_patch: 554
+}
+jump_ahead: 2
+use_prefetch_lists: true
+initial_codepoints {
+  values: 32
+  values: 34
+  values: 39
+  values: 40
+  values: 41
+  values: 44
+  values: 45
+  values: 46
+  values: 47
+  values: 48
+  values: 49
+  values: 50
+  values: 51
+  values: 52
+  values: 53
+  values: 54
+  values: 55
+  values: 56
+  values: 57
+  values: 58
+  values: 59
+  values: 61
+  values: 63
+  values: 65
+  values: 66
+  values: 67
+  values: 68
+  values: 69
+  values: 70
+  values: 71
+  values: 72
+  values: 73
+  values: 74
+  values: 75
+  values: 76
+  values: 77
+  values: 78
+  values: 79
+  values: 80
+  values: 81
+  values: 82
+  values: 83
+  values: 84
+  values: 85
+  values: 86
+  values: 87
+  values: 88
+  values: 89
+  values: 90
+  values: 97
+  values: 98
+  values: 99
+  values: 100
+  values: 101
+  values: 102
+  values: 103
+  values: 104
+  values: 105
+  values: 106
+  values: 107
+  values: 108
+  values: 109
+  values: 110
+  values: 111
+  values: 112
+  values: 113
+  values: 114
+  values: 115
+  values: 116
+  values: 117
+  values: 118
+  values: 119
+  values: 120
+  values: 121
+  values: 122
+  values: 178
+  values: 179
+  values: 180
+  values: 185
+  values: 193
+  values: 233
+  values: 8260
+  values: 64257
+  values: 64258
+  values: 64259
+  values: 64260
+}
+initial_features {
+}
+non_glyph_segments {
+  values: 940
+}
+non_glyph_segments {
+  values: 941
+}
+non_glyph_segments {
+  values: 942
+}
+non_glyph_segments {
+  values: 943
+}
+non_glyph_segments {
+  values: 944
+}
+initial_glyphs {
+  values: 0
+  values: 4
+  values: 6
+  values: 11
+  values: 12
+  values: 13
+  values: 16
+  values: 17
+  values: 18
+  values: 19
+  values: 20
+  values: 21
+  values: 22
+  values: 23
+  values: 24
+  values: 25
+  values: 26
+  values: 27
+  values: 28
+  values: 29
+  values: 30
+  values: 31
+  values: 33
+  values: 35
+  values: 37
+  values: 38
+  values: 39
+  values: 40
+  values: 41
+  values: 42
+  values: 43
+  values: 44
+  values: 45
+  values: 46
+  values: 47
+  values: 48
+  values: 49
+  values: 50
+  values: 51
+  values: 52
+  values: 53
+  values: 54
+  values: 55
+  values: 56
+  values: 57
+  values: 58
+  values: 59
+  values: 60
+  values: 61
+  values: 62
+  values: 69
+  values: 70
+  values: 71
+  values: 72
+  values: 73
+  values: 74
+  values: 75
+  values: 76
+  values: 77
+  values: 78
+  values: 79
+  values: 80
+  values: 81
+  values: 82
+  values: 83
+  values: 84
+  values: 85
+  values: 86
+  values: 87
+  values: 88
+  values: 89
+  values: 90
+  values: 91
+  values: 92
+  values: 93
+  values: 94
+  values: 115
+  values: 116
+  values: 117
+  values: 122
+  values: 405
+  values: 471
+  values: 472
+  values: 473
+  values: 474
+  values: 480
+  values: 481
+  values: 482
+  values: 570
+  values: 571
+  values: 572
+  values: 573
+  values: 574
+  values: 575
+  values: 576
+  values: 601
+  values: 602
+  values: 603
+  values: 604
+  values: 605
+  values: 606
+  values: 607
+  values: 668
+  values: 703
+  values: 1196
+  values: 1199
+}

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -132,6 +132,7 @@ cc_library(
     deps = [
         ":common",
         "//ift/freq",
+        "//ift/proto",
     ],
     visibility = [
         "//visibility:public",

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -386,3 +386,22 @@ cc_test(
         "@googletest//:gtest_main",
     ],
 )
+
+cc_test(
+    name = "entry_graph_equivalence_test",
+    size = "small",
+    srcs = [
+        "entry_graph_equivalence_test.cc",
+    ],
+    data = [
+        "//ift/common:testdata",
+    ],
+    deps = [
+        ":activation_condition",
+        "//ift/common",
+        "//ift/config:segmentation_plan_cc_proto",
+        "//ift/proto",
+        "@googletest//:gtest_main",
+        "@protobuf//:protobuf",
+    ],
+)

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -27,9 +27,9 @@ using absl::StrCat;
 using ift::common::IntSet;
 using ift::common::SegmentSet;
 using ift::freq::ProbabilityCalculator;
+using ift::proto::GLYPH_KEYED;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
-using ift::proto::GLYPH_KEYED;
 
 namespace ift::encoder {
 
@@ -286,7 +286,6 @@ StatusOr<std::vector<PatchMap::Entry>>
 ActivationCondition::ActivationConditionsToPatchMapEntries(
     Span<const ActivationCondition> conditions,
     const flat_hash_map<segment_index_t, SubsetDefinition>& segments) {
-
   // Set whichever encoding occurs the most to be the default
   PatchEncoding default_encoding = GLYPH_KEYED;
   uint32_t max_count = 0;

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -305,6 +305,7 @@ ActivationCondition::ActivationConditionsToPatchMapEntries(
   }
 
   EntryGraph graph = TRY(EntryGraph::Create(conditions, segments));
+  TRYV(graph.Optimize());
   return graph.ToPatchMapEntries(default_encoding);
 }
 

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -33,54 +33,36 @@ TEST(ActivationConditionTest, ActivationConditionsToEncoderConditions) {
       ActivationCondition::composite_condition({{1, 3}, {2, 4}}, 6),
   };
 
+  // Entry generation optimizes the entries, by combining segments
+  // where possible.
   std::vector<PatchMap::Entry> expected;
 
-  // entry[0] {{4}} ignored
+  // Entry 0: s1 OR s3 -> 5
   {
-    PatchMap::Entry condition({'g'}, 1, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry({'a', 'b', 'd', 'e', 'f'}, 5, PatchEncoding::GLYPH_KEYED);
+    expected.push_back(entry);
   }
 
-  // entry[1] {{2}} -> 2,
-  expected.push_back(
-      PatchMap::Entry({'c'}, 2, proto::PatchEncoding::GLYPH_KEYED));
-
-  // entry[2] {{1}} ignored
+  // Entry 1: (s1 OR s3) AND (s2 OR s4) -> 6
   {
-    PatchMap::Entry condition({'a', 'b'}, 3, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry;
+    entry.coverage.codepoints = {'c', 'g'};
+    entry.coverage.child_indices = {0};
+    entry.coverage.conjunctive = true;
+    entry.patch_indices = {6};
+    expected.push_back(entry);
   }
 
-  // entry[3] {{3}} -> 4
-  expected.push_back(
-      PatchMap::Entry({'d', 'e', 'f'}, 4, proto::PatchEncoding::GLYPH_KEYED));
-
-  // entry[4] {{2 OR 4}} ignored
+  // Entry 2: s3 -> 4
   {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {0, 1};  // entry[0], entry[1]
-    condition.patch_indices.push_back(5);
-    condition.ignored = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry({'d', 'e', 'f'}, 4, PatchEncoding::GLYPH_KEYED);
+    expected.push_back(entry);
   }
 
-  // entry[5] {{1 OR 3}} -> 5
+  // Entry 3: s2 -> 2
   {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {2, 3};
-    condition.patch_indices.push_back(5);
-    expected.push_back(condition);
-  }
-
-  // entry[6] {{1 OR 3} AND {2 OR 4}} -> 6
-  {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {4, 5};  // entry[4], entry[5]
-    condition.patch_indices.push_back(6);
-    condition.coverage.conjunctive = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry({'c'}, 2, PatchEncoding::GLYPH_KEYED);
+    expected.push_back(entry);
   }
 
   auto entries = ActivationCondition::ActivationConditionsToPatchMapEntries(
@@ -115,57 +97,33 @@ TEST(ActivationConditionTest,
 
   std::vector<PatchMap::Entry> expected;
 
-  // entry[0] {{4}} ignored
+  // Entry 0: s1 OR s3 -> 5
   {
-    PatchMap::Entry condition({'g'}, 1, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry({'a', 'b', 'd', 'e', 'f'}, 5, PatchEncoding::GLYPH_KEYED);
+    expected.push_back(entry);
   }
 
-  // entry[1] {{2}} -> 2,
-  expected.push_back(
-      PatchMap::Entry({'c'}, 2, proto::PatchEncoding::GLYPH_KEYED));
-
-  // entry[2] {{1}} ignored
+  // Entry 1: (s1 OR s3) AND (s2 OR s4) -> 6
   {
-    PatchMap::Entry condition({'a', 'b'}, 3, PatchEncoding::GLYPH_KEYED);
-    condition.ignored = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry;
+    entry.coverage.codepoints = {'c', 'g'};
+    entry.coverage.child_indices = {0};
+    entry.coverage.conjunctive = true;
+    entry.patch_indices = {6};
+    expected.push_back(entry);
   }
 
-  // entry[2] {{3}} -> 4
+  // Entry 2: s3 -> 4
   {
-    PatchMap::Entry condition({'d', 'e', 'f'}, 4,
+    PatchMap::Entry entry({'d', 'e', 'f'}, {4, 13, 12},
                               proto::PatchEncoding::TABLE_KEYED_FULL);
-    condition.patch_indices.push_back(13);
-    condition.patch_indices.push_back(12);
-    expected.push_back(condition);
+    expected.push_back(entry);
   }
 
-  // entry[3] {{2 OR 4}} ignored
+  // Entry 3: s2 -> 2
   {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {0, 1};  // entry[0], entry[1]
-    condition.patch_indices.push_back(13);
-    condition.ignored = true;
-    expected.push_back(condition);
-  }
-
-  // entry[4] {{1 OR 3}} -> 5
-  {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {2, 3};
-    condition.patch_indices.push_back(5);
-    expected.push_back(condition);
-  }
-
-  // entry[6] {{1 OR 3} AND {2 OR 4}} -> 6
-  {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {4, 5};  // entry[4], entry[5]
-    condition.patch_indices.push_back(6);
-    condition.coverage.conjunctive = true;
-    expected.push_back(condition);
+    PatchMap::Entry entry({'c'}, 2, PatchEncoding::GLYPH_KEYED);
+    expected.push_back(entry);
   }
 
   auto entries = ActivationCondition::ActivationConditionsToPatchMapEntries(
@@ -193,7 +151,7 @@ TEST(ActivationConditionTest,
 
   std::vector<PatchMap::Entry> expected;
 
-  // entry[0] {{dlig}} -> 1,
+  // Entry 0: dlig (ignored)
   {
     PatchMap::Entry condition;
     condition.coverage.features = {HB_TAG('d', 'l', 'i', 'g')};
@@ -203,7 +161,7 @@ TEST(ActivationConditionTest,
     expected.push_back(condition);
   }
 
-  // entry[1] {{d, e, f}} -> 2,
+  // Entry 1: {d, e, f} (ignored)
   {
     PatchMap::Entry condition;
     condition.coverage.codepoints = {'d', 'e', 'f'};
@@ -213,7 +171,7 @@ TEST(ActivationConditionTest,
     expected.push_back(condition);
   }
 
-  // entry[3] {e0 OR e1} -> 3,
+  // Entry 2: dlig OR {d, e, f} (ignored)
   {
     PatchMap::Entry condition;
     condition.coverage.child_indices = {0, 1};
@@ -223,22 +181,13 @@ TEST(ActivationConditionTest,
     expected.push_back(condition);
   }
 
-  // entry[4] {{smcp}} -> 4,
+  // Entry 3: smcp AND Entry 2 -> 5
   {
     PatchMap::Entry condition;
     condition.coverage.features = {HB_TAG('s', 'm', 'c', 'p')};
-    condition.ignored = true;
-    condition.patch_indices = {4};
-    condition.encoding = PatchEncoding::GLYPH_KEYED;
-    expected.push_back(condition);
-  }
-
-  // entry[2] s1 AND s2 -> 5,
-  {
-    PatchMap::Entry condition;
-    condition.coverage.child_indices = {3, 4};
-    condition.patch_indices = {5};
+    condition.coverage.child_indices = {2};
     condition.coverage.conjunctive = true;
+    condition.patch_indices = {5};
     condition.encoding = PatchEncoding::GLYPH_KEYED;
     expected.push_back(condition);
   }

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -39,7 +39,8 @@ TEST(ActivationConditionTest, ActivationConditionsToEncoderConditions) {
 
   // Entry 0: s1 OR s3 -> 5
   {
-    PatchMap::Entry entry({'a', 'b', 'd', 'e', 'f'}, 5, PatchEncoding::GLYPH_KEYED);
+    PatchMap::Entry entry({'a', 'b', 'd', 'e', 'f'}, 5,
+                          PatchEncoding::GLYPH_KEYED);
     expected.push_back(entry);
   }
 
@@ -99,7 +100,8 @@ TEST(ActivationConditionTest,
 
   // Entry 0: s1 OR s3 -> 5
   {
-    PatchMap::Entry entry({'a', 'b', 'd', 'e', 'f'}, 5, PatchEncoding::GLYPH_KEYED);
+    PatchMap::Entry entry({'a', 'b', 'd', 'e', 'f'}, 5,
+                          PatchEncoding::GLYPH_KEYED);
     expected.push_back(entry);
   }
 
@@ -116,7 +118,7 @@ TEST(ActivationConditionTest,
   // Entry 2: s3 -> 4
   {
     PatchMap::Entry entry({'d', 'e', 'f'}, {4, 13, 12},
-                              proto::PatchEncoding::TABLE_KEYED_FULL);
+                          proto::PatchEncoding::TABLE_KEYED_FULL);
     expected.push_back(entry);
   }
 

--- a/ift/encoder/dependency_closure_test.cc
+++ b/ift/encoder/dependency_closure_test.cc
@@ -1016,12 +1016,14 @@ TEST_F(DependencyClosureTest, SegmentsToAffected) {
                   /* 5 */ {{0xC1 /* Aacute */}, ProbabilityBound::Zero()},
               });
 
-  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({0}), (GlyphSet{69 /* a */}));
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({0}),
+            (GlyphSet{69 /* a */}));
   EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({1}),
             (GlyphSet{74 /* f */, 444 /* fi */, 446 /* ffi */}));
   EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({2}),
             (GlyphSet{77 /* i */, 444 /* fi */, 446 /* ffi */}));
-  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({4}), (GlyphSet{37 /* A */}));
+  EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({4}),
+            (GlyphSet{37 /* A */}));
   EXPECT_EQ(dependency_closure->SegmentsToAffectedGlyphs({5}),
             (GlyphSet{37 /* A */, 117 /* acute */, 640 /* Aacute */}));
 
@@ -1029,13 +1031,9 @@ TEST_F(DependencyClosureTest, SegmentsToAffected) {
             (GlyphSet{74, 77, 444, 446}));
 
   auto nodes = dependency_closure->SegmentsToAffectedNodeConditions({1});
-  EXPECT_EQ(nodes, (flat_hash_set<Node>{
-    Node::Segment(1),
-    Node::Unicode('f'),
-    Node::Glyph(74),
-    Node::Glyph(444),
-    Node::Glyph(446)
-  }));
+  EXPECT_EQ(nodes, (flat_hash_set<Node>{Node::Segment(1), Node::Unicode('f'),
+                                        Node::Glyph(74), Node::Glyph(444),
+                                        Node::Glyph(446)}));
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -473,9 +473,7 @@ static DisjunctiveSummary GetDisjunctiveSummary(
 }
 
 static absl::StatusOr<int64_t> SavedCostIfEdgeToRemoved(
-    uint32_t node_id,
-    std::vector<uint32_t>&
-        edge_counts,
+    uint32_t node_id, std::vector<uint32_t>& edge_counts,
     const std::vector<EntryNode>& nodes) {
   if (edge_counts[node_id] == 0) return 0;
   edge_counts[node_id]--;

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -7,6 +7,7 @@
 #include "ift/common/axis_range.h"
 #include "ift/common/try.h"
 #include "ift/encoder/activation_condition.h"
+#include "ift/proto/format_2_patch_map.h"
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
 
@@ -19,6 +20,7 @@ using absl::StatusOr;
 using ift::common::AxisRange;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
+using ift::proto::Format2PatchMap;
 
 namespace ift::encoder {
 
@@ -319,6 +321,7 @@ StatusOr<uint32_t> EntryGraph::CreateNode() {
   nodes.push_back({
       .and_codepoints = {},
       .and_features = {},
+      .and_design_space = {},
       .child_mode = NONE,
       .children_ids = {},
   });
@@ -326,9 +329,20 @@ StatusOr<uint32_t> EntryGraph::CreateNode() {
   return node_id;
 }
 
-int64_t EntryNode::EncodingCost() const {
-  // TODO XXXX
-  return 0;
+absl::StatusOr<int64_t> EntryNode::EncodingCost() const {
+  proto::PatchMap::Entry entry;
+  entry.coverage.codepoints = and_codepoints;
+  entry.coverage.features.insert(and_features.begin(), and_features.end());
+  entry.coverage.design_space.insert(and_design_space.begin(),
+                                     and_design_space.end());
+  entry.coverage.conjunctive = (child_mode == AND);
+
+  uint32_t fake_id = 1;
+  for (size_t i = 0; i < children_ids.size(); ++i) {
+    entry.coverage.child_indices.insert(fake_id++);
+  }
+
+  return TRY(Format2PatchMap::EstimateEncodingCost(entry));
 }
 
 void EntryGraph::Optimize() {

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -70,7 +70,9 @@ StatusOr<std::vector<PatchMap::Entry>> EntryGraph::ToPatchMapEntries(
   for (const auto& [condition, _] : patch_mappings) {
     auto it = condition_to_node_id.find(condition);
     if (it != condition_to_node_id.end()) {
-      node_to_condition.insert({it->second, condition});
+      if (!node_to_condition.insert({it->second, condition}).second) {
+        return absl::InternalError("Duplicate condtion.");
+      }
     } else {
       return absl::InternalError("Unexpected missing node.");
     }

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -364,8 +364,24 @@ absl::StatusOr<int64_t> EntryNode::EncodingCost() const {
   return TRY(Format2PatchMap::EstimateEncodingCost(entry));
 }
 
-void EntryGraph::Optimize() {
-  // TODO XXXXX
+Status EntryGraph::Optimize() {
+  bool changed = true;
+  while (changed) {
+    changed = false;
+    std::vector<uint32_t> sorted = TRY(TopologicalSort());
+    std::reverse(sorted.begin(), sorted.end());
+    // Iterate in reverse topological order so that changes
+    // made to the graph don't impact the following nodes
+    // in the iteration.
+    for (uint32_t node_id : sorted) {
+      auto result = TRY(CalculateSubsumptionCostDelta(node_id));
+      if (result.cost_delta < 0) {
+        TRYV(ActuateSubsumption(node_id, result));
+        changed = true;
+      }
+    }
+  }
+  return absl::OkStatus();
 }
 
 static absl::Status UnionAxisRanges(

--- a/ift/encoder/entry_graph.cc
+++ b/ift/encoder/entry_graph.cc
@@ -5,6 +5,7 @@
 
 #include "absl/strings/str_cat.h"
 #include "ift/common/axis_range.h"
+#include "ift/common/int_set.h"
 #include "ift/common/try.h"
 #include "ift/encoder/activation_condition.h"
 #include "ift/proto/format_2_patch_map.h"
@@ -16,11 +17,14 @@ using absl::btree_set;
 using absl::flat_hash_map;
 using absl::flat_hash_set;
 using absl::Span;
+using absl::Status;
 using absl::StatusOr;
 using ift::common::AxisRange;
+using ift::common::CodepointSet;
+using ift::common::IntSet;
+using ift::proto::Format2PatchMap;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
-using ift::proto::Format2PatchMap;
 
 namespace ift::encoder {
 
@@ -58,13 +62,12 @@ StatusOr<EntryGraph> EntryGraph::Create(
 
 StatusOr<std::vector<PatchMap::Entry>> EntryGraph::ToPatchMapEntries(
     proto::PatchEncoding default_encoding) const {
+  IntSet reachable = ReachableNodes();
   std::vector<PatchMap::Entry> entries;
-  entries.reserve(nodes.size());
+  entries.reserve(reachable.size());
 
-  flat_hash_map<uint32_t, uint32_t> node_id_to_entry_index;
   flat_hash_map<uint32_t, ActivationCondition> node_to_condition;
-
-  for (const auto& [condition, patches] : patch_mappings) {
+  for (const auto& [condition, _] : patch_mappings) {
     auto it = condition_to_node_id.find(condition);
     if (it != condition_to_node_id.end()) {
       node_to_condition.insert({it->second, condition});
@@ -76,7 +79,10 @@ StatusOr<std::vector<PatchMap::Entry>> EntryGraph::ToPatchMapEntries(
   uint32_t last_patch_id = 0;
   std::vector<uint32_t> sorted_nodes = TRY(TopologicalSort());
   std::reverse(sorted_nodes.begin(), sorted_nodes.end());
+  flat_hash_map<uint32_t, uint32_t> node_id_to_entry_index;
   for (uint32_t node_id : sorted_nodes) {
+    if (!reachable.contains(node_id)) continue;
+
     const auto& node = nodes[node_id];
 
     PatchMap::Entry entry;
@@ -119,8 +125,6 @@ StatusOr<std::vector<PatchMap::Entry>> EntryGraph::ToPatchMapEntries(
 
 StatusOr<std::vector<uint32_t>> EntryGraph::TopologicalSort() const {
   std::vector<uint32_t> edge_count = incoming_edge_count;
-  std::vector<uint32_t> sorted;
-  sorted.reserve(nodes.size());
 
   // Each top level condition generates an incoming edge we need to remove these
   // prior to sorting. patch_mappings stores a list of them.
@@ -134,8 +138,13 @@ StatusOr<std::vector<uint32_t>> EntryGraph::TopologicalSort() const {
           "Edge count underflow for top-level condition.");
     }
     edge_count[it->second]--;
-    if (edge_count[it->second] == 0) {
-      sorted.push_back(it->second);
+  }
+
+  std::vector<uint32_t> sorted;
+  sorted.reserve(nodes.size());
+  for (uint32_t i = 0; i < edge_count.size(); i++) {
+    if (edge_count[i] == 0) {
+      sorted.push_back(i);
     }
   }
 
@@ -235,8 +244,8 @@ StatusOr<uint32_t> EntryGraph::AddMapping(
   nodes[node_id].child_mode = AND;
   std::vector<uint32_t> children;
   for (const auto& or_segments : normalized.conditions()) {
-    children.push_back(TRY(
-        AddMapping(ActivationCondition::or_segments(or_segments, 0), segments)));
+    children.push_back(TRY(AddMapping(
+        ActivationCondition::or_segments(or_segments, 0), segments)));
   }
   TRYV(AddChildrenToNode(node_id, AND, children));
 
@@ -244,7 +253,7 @@ StatusOr<uint32_t> EntryGraph::AddMapping(
 }
 
 absl::Status EntryGraph::AddChildrenToNode(uint32_t node_id, ChildMode mode,
-                                             Span<const uint32_t> children_ids) {
+                                           Span<const uint32_t> children_ids) {
   while (children_ids.size() > 127) {
     for (size_t i = 0; i < 126; ++i) {
       nodes[node_id].children_ids.insert(children_ids[i]);
@@ -329,6 +338,16 @@ StatusOr<uint32_t> EntryGraph::CreateNode() {
   return node_id;
 }
 
+IntSet EntryGraph::ReachableNodes() const {
+  IntSet reachable;
+  for (uint32_t n = 0; n < nodes.size(); n++) {
+    if (incoming_edge_count[n] > 0) {
+      reachable.insert(n);
+    }
+  }
+  return reachable;
+}
+
 absl::StatusOr<int64_t> EntryNode::EncodingCost() const {
   proto::PatchMap::Entry entry;
   entry.coverage.codepoints = and_codepoints;
@@ -347,6 +366,375 @@ absl::StatusOr<int64_t> EntryNode::EncodingCost() const {
 
 void EntryGraph::Optimize() {
   // TODO XXXXX
+}
+
+static absl::Status UnionAxisRanges(
+    flat_hash_map<hb_tag_t, AxisRange>& result,
+    const flat_hash_map<hb_tag_t, AxisRange>& other) {
+  for (const auto& [tag, other_range] : other) {
+    auto [it, inserted] = result.insert({tag, other_range});
+    if (inserted) {
+      continue;
+    }
+
+    if (it->second == other_range) {
+      continue;
+    }
+
+    if (!it->second.Intersects(other_range) &&
+        it->second.end() != other_range.start() &&
+        other_range.end() != it->second.start()) {
+      return absl::InvalidArgumentError("Cannot union non-contiguous ranges.");
+    }
+
+    float start = std::min(it->second.start(), other_range.start());
+    float end = std::max(it->second.end(), other_range.end());
+    it->second = TRY(AxisRange::Range(start, end));
+  }
+
+  return absl::OkStatus();
+}
+
+struct DisjunctiveSummary {
+  common::CodepointSet codepoints;
+  flat_hash_set<hb_tag_t> features;
+  flat_hash_map<hb_tag_t, AxisRange> design_space;
+  bool is_purely_disjunctive = true;
+
+  void Clear() {
+    codepoints.clear();
+    features.clear();
+    design_space.clear();
+    is_purely_disjunctive = false;
+  }
+};
+
+static DisjunctiveSummary GetDisjunctiveSummary(
+    uint32_t node_id, const std::vector<EntryNode>& nodes) {
+  const auto& node = nodes[node_id];
+  DisjunctiveSummary summary;
+  summary.is_purely_disjunctive = true;
+
+  if (!node.children_ids.empty() &&
+      (node.child_mode != OR || !node.and_codepoints.empty() ||
+       !node.and_design_space.empty() || !node.and_features.empty())) {
+    summary.is_purely_disjunctive = false;
+    return summary;
+  }
+
+  uint32_t non_empty_sets = !node.and_codepoints.empty() +
+                            !node.and_features.empty() +
+                            !node.and_design_space.empty();
+  if (non_empty_sets > 1) {
+    summary.is_purely_disjunctive = false;
+    return summary;
+  }
+
+  summary.codepoints = node.and_codepoints;
+  summary.features = node.and_features;
+  summary.design_space = node.and_design_space;
+
+  for (uint32_t child_id : node.children_ids) {
+    DisjunctiveSummary child_summary = GetDisjunctiveSummary(child_id, nodes);
+    if (!child_summary.is_purely_disjunctive) {
+      summary.Clear();
+      return summary;
+    }
+    summary.codepoints.union_set(child_summary.codepoints);
+    summary.features.insert(child_summary.features.begin(),
+                            child_summary.features.end());
+    auto status =
+        UnionAxisRanges(summary.design_space, child_summary.design_space);
+    if (!status.ok()) {
+      summary.Clear();
+      return summary;
+    }
+  }
+
+  return summary;
+}
+
+static absl::StatusOr<int64_t> SavedCostIfEdgeToRemoved(
+    uint32_t node_id,
+    std::vector<uint32_t>&
+        edge_counts,
+    const std::vector<EntryNode>& nodes) {
+  if (edge_counts[node_id] == 0) return 0;
+  edge_counts[node_id]--;
+  if (edge_counts[node_id] > 0) return 0;
+
+  const auto& node = nodes[node_id];
+  int64_t cost = TRY(node.EncodingCost());
+  for (uint32_t child_id : node.children_ids) {
+    cost += TRY(SavedCostIfEdgeToRemoved(child_id, edge_counts, nodes));
+  }
+  return cost;
+}
+
+StatusOr<SubsumptionResult> EntryGraph::CalculateSubsumptionCostDelta(
+    uint32_t node_id) const {
+  const auto& node = nodes[node_id];
+  if (node.child_mode == OR || node.child_mode == NONE) {
+    return CalculateDisjunctiveSubsumption(node_id);
+  } else if (node.child_mode == AND) {
+    return CalculateConjunctiveSubsumption(node_id);
+  }
+  SubsumptionResult result;
+  result.cost_delta = 0;
+  return result;
+}
+
+StatusOr<SubsumptionResult> EntryGraph::CalculateDisjunctiveSubsumption(
+    uint32_t node_id) const {
+  const auto& node = nodes[node_id];
+  SubsumptionResult result;
+  result.cost_delta = 0;
+
+  int64_t current_node_cost = TRY(node.EncodingCost());
+
+  DisjunctiveSummary summary = GetDisjunctiveSummary(node_id, nodes);
+  if (!summary.is_purely_disjunctive || node.children_ids.empty()) {
+    return result;
+  }
+
+  EntryNode test_node;
+  int64_t extra_child_cost = 0;
+  int non_empty_sets = (!summary.codepoints.empty()) +
+                       (!summary.features.empty()) +
+                       (!summary.design_space.empty());
+
+  if (non_empty_sets <= 1) {
+    // The single set case can be fully encoded in just the test
+    // node
+    test_node.and_codepoints = summary.codepoints;
+    test_node.and_features = summary.features;
+    test_node.and_design_space = summary.design_space;
+    test_node.child_mode = NONE;
+  } else {
+    // Otherwise one child node is needed per non-empty set.
+    test_node.child_mode = OR;
+    if (!summary.codepoints.empty()) {
+      EntryNode child;
+      child.and_codepoints = summary.codepoints;
+      extra_child_cost += TRY(child.EncodingCost());
+      test_node.children_ids.insert(0);
+    }
+    if (!summary.features.empty()) {
+      EntryNode child;
+      child.and_features = summary.features;
+      extra_child_cost += TRY(child.EncodingCost());
+      test_node.children_ids.insert(1);
+    }
+    if (!summary.design_space.empty()) {
+      EntryNode child;
+      child.and_design_space = summary.design_space;
+      extra_child_cost += TRY(child.EncodingCost());
+      test_node.children_ids.insert(2);
+    }
+  }
+
+  int64_t new_cost = TRY(test_node.EncodingCost()) + extra_child_cost;
+  std::vector<uint32_t> edge_counts = incoming_edge_count;
+  int64_t saved_cost = 0;
+  for (uint32_t child_id : node.children_ids) {
+    saved_cost += TRY(SavedCostIfEdgeToRemoved(child_id, edge_counts, nodes));
+  }
+
+  result.cost_delta = new_cost - current_node_cost - saved_cost;
+  result.subsumed_children.union_set(node.children_ids);
+  if (!summary.codepoints.empty()) {
+    result.codepoints = summary.codepoints;
+  }
+  if (!summary.features.empty()) {
+    result.features = summary.features;
+  }
+  if (!summary.design_space.empty()) {
+    result.design_space = summary.design_space;
+  }
+
+  return result;
+}
+
+StatusOr<SubsumptionResult> EntryGraph::CalculateConjunctiveSubsumption(
+    uint32_t node_id) const {
+  const auto& node = nodes[node_id];
+  SubsumptionResult best_result;
+  best_result.cost_delta = INT64_MAX;
+
+  if (!node.and_codepoints.empty() && !node.and_features.empty() &&
+      !node.and_design_space.empty()) {
+    // Must have at least one free set to subsume a child node into.
+    return best_result;
+  }
+
+  int64_t current_node_cost = TRY(node.EncodingCost());
+
+  struct ChildCandidate {
+    uint32_t id;
+    CodepointSet codepoints;
+    flat_hash_set<hb_tag_t> features;
+    flat_hash_map<hb_tag_t, AxisRange> design_space;
+  };
+
+  std::vector<ChildCandidate> candidates;
+  for (uint32_t child_id : node.children_ids) {
+    DisjunctiveSummary s = GetDisjunctiveSummary(child_id, nodes);
+    if (!s.is_purely_disjunctive) continue;
+
+    uint32_t non_empty_sets = (!s.codepoints.empty()) + (!s.features.empty()) +
+                              (!s.design_space.empty());
+    if (non_empty_sets != 1) {
+      continue;
+    }
+
+    // Filter out candidates where there isn't an empty set to subsume into.
+    if (!s.codepoints.empty() && !node.and_codepoints.empty()) {
+      continue;
+    }
+    if (!s.features.empty() && !node.and_features.empty()) {
+      continue;
+    }
+    if (!s.design_space.empty() && !node.and_design_space.empty()) {
+      continue;
+    }
+
+    candidates.push_back({child_id, s.codepoints, s.features, s.design_space});
+  }
+
+  std::vector<const ChildCandidate*> cps = {nullptr};
+  std::vector<const ChildCandidate*> feats = {nullptr};
+  std::vector<const ChildCandidate*> dss = {nullptr};
+  for (const auto& c : candidates) {
+    if (!c.codepoints.empty()) {
+      cps.push_back(&c);
+    }
+    if (!c.features.empty()) {
+      feats.push_back(&c);
+    }
+    if (!c.design_space.empty()) {
+      dss.push_back(&c);
+    }
+  }
+
+  auto test_combo = [&](const ChildCandidate* cp, const ChildCandidate* feat,
+                        const ChildCandidate* ds) -> absl::Status {
+    EntryNode test_node = node;
+    IntSet subsumed;
+    if (cp) {
+      test_node.and_codepoints = cp->codepoints;
+      test_node.children_ids.erase(cp->id);
+      subsumed.insert(cp->id);
+    }
+    if (feat) {
+      test_node.and_features = feat->features;
+      test_node.children_ids.erase(feat->id);
+      subsumed.insert(feat->id);
+    }
+    if (ds) {
+      test_node.and_design_space = ds->design_space;
+      test_node.children_ids.erase(ds->id);
+      subsumed.insert(ds->id);
+    }
+
+    if (subsumed.empty()) return absl::OkStatus();
+
+    int64_t new_cost = TRY(test_node.EncodingCost());
+    std::vector<uint32_t> edge_counts = incoming_edge_count;
+    int64_t saved_cost = 0;
+    for (uint32_t id : subsumed) {
+      saved_cost += TRY(SavedCostIfEdgeToRemoved(id, edge_counts, nodes));
+    }
+
+    int64_t delta = new_cost - current_node_cost - saved_cost;
+    if (delta < best_result.cost_delta) {
+      best_result.cost_delta = delta;
+      best_result.subsumed_children = subsumed;
+      best_result.codepoints = test_node.and_codepoints;
+      best_result.features = test_node.and_features;
+      best_result.design_space = test_node.and_design_space;
+    }
+    return absl::OkStatus();
+  };
+
+  for (auto cp : cps) {
+    for (auto feat : feats) {
+      for (auto ds : dss) {
+        TRYV(test_combo(cp, feat, ds));
+      }
+    }
+  }
+
+  return best_result;
+}
+
+static void DecrementIncomingEdges(uint32_t node_id,
+                                   std::vector<uint32_t>& edge_counts,
+                                   std::vector<EntryNode>& nodes) {
+  if (edge_counts[node_id] == 0) {
+    return;
+  }
+
+  edge_counts[node_id]--;
+  if (edge_counts[node_id] == 0) {
+    for (uint32_t child_id : nodes[node_id].children_ids) {
+      DecrementIncomingEdges(child_id, edge_counts, nodes);
+    }
+    nodes[node_id] = EntryNode();  // node is removed, clear it's data.
+  }
+}
+
+Status EntryGraph::ActuateSubsumption(uint32_t node_id,
+                                      const SubsumptionResult& result) {
+  if (result.subsumed_children.empty()) return absl::OkStatus();
+
+  for (uint32_t child_id : result.subsumed_children) {
+    DecrementIncomingEdges(child_id, incoming_edge_count, nodes);
+    nodes[node_id].children_ids.erase(child_id);
+  }
+
+  auto& node = nodes[node_id];
+  if (node.child_mode == OR || node.child_mode == NONE) {
+    int non_empty = result.codepoints.has_value() +
+                    result.features.has_value() +
+                    result.design_space.has_value();
+    if (non_empty <= 1) {
+      node.and_codepoints = result.codepoints.value_or(common::CodepointSet());
+      node.and_features = result.features.value_or(flat_hash_set<hb_tag_t>());
+      node.and_design_space =
+          result.design_space.value_or(flat_hash_map<hb_tag_t, AxisRange>());
+      node.child_mode = NONE;
+    } else {
+      node.and_codepoints = {};
+      node.and_features = {};
+      node.and_design_space = {};
+      node.child_mode = OR;
+
+      if (result.codepoints) {
+        uint32_t id = TRY(CreateNode());
+        nodes[id].and_codepoints = *result.codepoints;
+        incoming_edge_count[id]++;
+        nodes[node_id].children_ids.insert(id);
+      }
+      if (result.features) {
+        uint32_t id = TRY(CreateNode());
+        nodes[id].and_features = *result.features;
+        incoming_edge_count[id]++;
+        nodes[node_id].children_ids.insert(id);
+      }
+      if (result.design_space) {
+        uint32_t id = TRY(CreateNode());
+        nodes[id].and_design_space = *result.design_space;
+        incoming_edge_count[id]++;
+        nodes[node_id].children_ids.insert(id);
+      }
+    }
+  } else if (node.child_mode == AND) {
+    if (result.codepoints) node.and_codepoints = *result.codepoints;
+    if (result.features) node.and_features = *result.features;
+    if (result.design_space) node.and_design_space = *result.design_space;
+  }
+
+  return absl::OkStatus();
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/entry_graph.h
+++ b/ift/encoder/entry_graph.h
@@ -27,7 +27,9 @@ struct EntryNode {
   ChildMode child_mode;
   common::IntSet children_ids;
 
-  int64_t EncodingCost() const;
+  // Generate an estimated encoding cost, ignores the impact of last patch index
+  // and the default format selection on final encoding size.
+  absl::StatusOr<int64_t> EncodingCost() const;
 };
 
 // Models the condition graph formed by the patch map entries of an IFT

--- a/ift/encoder/entry_graph.h
+++ b/ift/encoder/entry_graph.h
@@ -55,7 +55,7 @@ class EntryGraph {
 
   // Modify this entry graph where possible to reduce the overall encoding cost
   // without changing it's functionality.
-  void Optimize();
+  absl::Status Optimize();
 
   // Returns the cost delta of subsuming child nodes for 'node_id'.
   absl::StatusOr<SubsumptionResult> CalculateSubsumptionCostDelta(

--- a/ift/encoder/entry_graph.h
+++ b/ift/encoder/entry_graph.h
@@ -16,20 +16,31 @@ enum ChildMode {
   OR,
 };
 
-// TODO(garretrieger): better optimize patch id encodings by ordering entries by patch ids
-// where possible.
+// TODO(garretrieger): better optimize patch id encodings by ordering entries by
+// patch ids where possible.
 
 struct EntryNode {
   common::CodepointSet and_codepoints;
   absl::flat_hash_set<hb_tag_t> and_features;
   absl::flat_hash_map<hb_tag_t, ift::common::AxisRange> and_design_space;
 
-  ChildMode child_mode;
+  ChildMode child_mode = NONE;
   common::IntSet children_ids;
 
   // Generate an estimated encoding cost, ignores the impact of last patch index
   // and the default format selection on final encoding size.
   absl::StatusOr<int64_t> EncodingCost() const;
+};
+
+struct SubsumptionResult {
+  int64_t cost_delta = 0;  // negative indicates savings
+  common::IntSet subsumed_children;
+
+  // The final sets to be applied to the node or instantiated as new children.
+  std::optional<common::CodepointSet> codepoints;
+  std::optional<absl::flat_hash_set<hb_tag_t>> features;
+  std::optional<absl::flat_hash_map<hb_tag_t, ift::common::AxisRange>>
+      design_space;
 };
 
 // Models the condition graph formed by the patch map entries of an IFT
@@ -46,6 +57,14 @@ class EntryGraph {
   // without changing it's functionality.
   void Optimize();
 
+  // Returns the cost delta of subsuming child nodes for 'node_id'.
+  absl::StatusOr<SubsumptionResult> CalculateSubsumptionCostDelta(
+      uint32_t node_id) const;
+
+  // Actuates the subsumption for 'node_id' based on 'result'.
+  absl::Status ActuateSubsumption(uint32_t node_id,
+                                  const SubsumptionResult& result);
+
   // Convert this entry graph into an list of patch map entries, with child
   // indices fully resolved.
   absl::StatusOr<std::vector<proto::PatchMap::Entry>> ToPatchMapEntries(
@@ -56,6 +75,11 @@ class EntryGraph {
 
  private:
   EntryGraph() = default;
+
+  absl::StatusOr<SubsumptionResult> CalculateDisjunctiveSubsumption(
+      uint32_t node_id) const;
+  absl::StatusOr<SubsumptionResult> CalculateConjunctiveSubsumption(
+      uint32_t node_id) const;
 
   // Returns node id. De-dups if possible.
   absl::StatusOr<uint32_t> AddMapping(
@@ -77,9 +101,10 @@ class EntryGraph {
 
   absl::StatusOr<uint32_t> CreateNode();
 
-  absl::Status AddChildrenToNode(
-      uint32_t node_id, ChildMode mode,
-      absl::Span<const uint32_t> children_ids);
+  common::IntSet ReachableNodes() const;
+
+  absl::Status AddChildrenToNode(uint32_t node_id, ChildMode mode,
+                                 absl::Span<const uint32_t> children_ids);
 
   absl::flat_hash_map<ActivationCondition, std::vector<uint32_t>>
       patch_mappings;
@@ -88,8 +113,8 @@ class EntryGraph {
 
   std::vector<EntryNode> nodes;
   std::vector<uint32_t> incoming_edge_count;
-  // TODO(garretrieger): track which nodes are fully disjunctive after being fully
-  // resolved (ie. including children)
+  // TODO(garretrieger): track which nodes are fully disjunctive after being
+  // fully resolved (ie. including children)
 
   absl::flat_hash_map<ActivationCondition, uint32_t> condition_to_node_id;
   absl::flat_hash_map<common::CodepointSet, uint32_t> codepoints_to_node_id;

--- a/ift/encoder/entry_graph_equivalence_test.cc
+++ b/ift/encoder/entry_graph_equivalence_test.cc
@@ -1,0 +1,258 @@
+#include <fstream>
+#include <string>
+#include <vector>
+#include <set>
+
+#include "gtest/gtest.h"
+#include "google/protobuf/text_format.h"
+#include "ift/common/int_set.h"
+#include "ift/config/segmentation_plan.pb.h"
+#include "ift/encoder/activation_condition.h"
+#include "ift/encoder/entry_graph.h"
+#include "ift/encoder/subset_definition.h"
+#include "ift/proto/patch_encoding.h"
+#include "ift/proto/format_2_patch_map.h"
+
+using ift::config::SegmentationPlan;
+using ift::config::ActivationConditionProto;
+using ift::common::SegmentSet;
+using ift::common::CodepointSet;
+using absl::flat_hash_map;
+using absl::flat_hash_set;
+using ift::proto::Format2PatchMap;
+using ift::proto::PatchMap;
+
+// This tests the entry graph generation and optimization to ensure
+// that it's maintaining equivalence to input conditions on a realistic
+// example.
+//
+// Conditions from a real segmentation of Roboto VF are converted to
+// entries via the entry graph and then those are checked for equivalence
+// against the original conditions.
+//
+// Both the optimized and unoptimized versions are checked as both cases
+// should preserve the original conditions.
+
+namespace ift::encoder {
+
+static ActivationCondition FromProto(const ActivationConditionProto& condition) {
+  std::vector<SegmentSet> groups;
+  for (const auto& group : condition.required_segments()) {
+    SegmentSet set;
+    set.insert(group.values().begin(), group.values().end());
+    groups.push_back(set);
+  }
+
+  return ActivationCondition::composite_condition(groups,
+                                                  condition.activated_patch());
+}
+
+static ActivationCondition Normalize(const ActivationCondition& condition) {
+  return ActivationCondition::composite_condition(condition.conditions(), 0);
+}
+
+static ActivationCondition RealToVirtual(
+    const ActivationCondition& real_cond,
+    const flat_hash_map<segment_index_t, ActivationCondition>& segment_to_virtual) {
+  std::vector<SegmentSet> virtual_groups;
+  for (const auto& real_group : real_cond.conditions()) {
+    SegmentSet virt_group;
+    for (segment_index_t s_id : real_group) {
+      virt_group.union_set(segment_to_virtual.at(s_id).conditions()[0]);
+    }
+    virtual_groups.push_back(virt_group);
+  }
+  return ActivationCondition::composite_condition(virtual_groups, 0);
+}
+
+static int64_t TotalEncodingCost(const std::vector<proto::PatchMap::Entry>& entries) {
+  int64_t total = 0;
+  for (const auto& entry : entries) {
+    auto cost = Format2PatchMap::EstimateEncodingCost(entry);
+    if (cost.ok()) {
+      total += *cost;
+    }
+  }
+  return total;
+}
+
+
+struct VirtualMaps {
+  flat_hash_map<hb_codepoint_t, uint32_t> cp_to_virtual;
+  flat_hash_map<hb_tag_t, uint32_t> feature_to_virtual;
+};
+
+static ActivationCondition ResolveVirtualCondition(
+    const PatchMap::Entry& entry,
+    const std::vector<PatchMap::Entry>& all_entries,
+    const VirtualMaps& maps) {
+
+  std::vector<ActivationCondition> direct_conditions;
+  if (!entry.coverage.codepoints.empty()) {
+    SegmentSet s;
+    for (hb_codepoint_t cp : entry.coverage.codepoints) {
+      s.insert(maps.cp_to_virtual.at(cp));
+    }
+    if (!s.empty()) {
+      direct_conditions.push_back(ActivationCondition::or_segments(s, 0));
+    }
+  }
+
+  if (!entry.coverage.features.empty()) {
+    SegmentSet s;
+    for (hb_tag_t tag : entry.coverage.features) {
+      s.insert(maps.feature_to_virtual.at(tag));
+    }
+    if (!s.empty()) {
+      direct_conditions.push_back(ActivationCondition::or_segments(s, 0));
+    }
+  }
+
+  std::vector<ActivationCondition> children;
+  for (uint32_t child_idx : entry.coverage.child_indices) {
+    children.push_back(ResolveVirtualCondition(all_entries[child_idx], all_entries,
+                                               maps));
+  }
+
+  if (entry.coverage.conjunctive) {
+    ActivationCondition result = ActivationCondition::True(0);
+    for (const auto& c : direct_conditions) result = ActivationCondition::And(result, c);
+    for (const auto& c : children) result = ActivationCondition::And(result, c);
+    return result;
+  } else {
+    ActivationCondition result = ActivationCondition::True(0);
+    for (const auto& c : direct_conditions) {
+      result = ActivationCondition::And(result, c);
+    }
+    if (!children.empty()) {
+      ActivationCondition children_condition = children[0];
+      for (size_t i = 1; i < children.size(); ++i) {
+        children_condition = ActivationCondition::Or(children_condition, children[i]);
+      }
+      result = ActivationCondition::And(result, children_condition);
+    }
+    return result;
+  }
+}
+
+class EntryGraphEquivalenceTest : public ::testing::Test {
+ protected:
+  void SetUp() override {
+    std::string path = "ift/common/testdata/roboto_vf_seg_plan.txtpb";
+    std::ifstream file(path);
+    ASSERT_TRUE(file.is_open()) << "Could not open " << path;
+
+    std::string content((std::istreambuf_iterator<char>(file)),
+                         std::istreambuf_iterator<char>());
+    ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &plan_));
+  }
+
+  SegmentationPlan plan_;
+};
+
+static VirtualMaps CreateVirtualMaps(const SegmentationPlan& plan) {
+  std::set<hb_codepoint_t> all_cps;
+  std::set<hb_tag_t> all_tags;
+  for (const auto& [id, set] : plan.segments()) {
+    for (hb_codepoint_t cp : set.codepoints().values()) {
+      all_cps.insert(cp);
+    }
+    for (const auto& tag_str : set.features().values()) {
+      all_tags.insert(hb_tag_from_string(tag_str.c_str(), -1));
+    }
+  }
+
+  VirtualMaps maps;
+  uint32_t next_virt = 0;
+  for (hb_codepoint_t cp : all_cps) {
+    maps.cp_to_virtual[cp] = next_virt++;
+  }
+  for (hb_tag_t tag : all_tags) {
+    maps.feature_to_virtual[tag] = next_virt++;
+  }
+  return maps;
+}
+
+struct SegmentData {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments;
+  flat_hash_map<segment_index_t, ActivationCondition> segment_to_virtual;
+};
+
+static SegmentData CreateSegments(const SegmentationPlan& plan, const VirtualMaps& maps) {
+  SegmentData data;
+  for (const auto& [id, set] : plan.segments()) {
+    auto& segment = data.segments[id];
+    SegmentSet virtual_indices;
+    for (hb_codepoint_t cp : set.codepoints().values()) {
+      segment.codepoints.insert(cp);
+      virtual_indices.insert(maps.cp_to_virtual.at(cp));
+    }
+    for (const auto& tag_str : set.features().values()) {
+      hb_tag_t tag = hb_tag_from_string(tag_str.c_str(), -1);
+      segment.feature_tags.insert(tag);
+      virtual_indices.insert(maps.feature_to_virtual.at(tag));
+    }
+    data.segment_to_virtual.emplace(id, ActivationCondition::or_segments(virtual_indices, 0));
+  }
+  return data;
+}
+
+TEST_F(EntryGraphEquivalenceTest, OptimizePreservesConditions) {
+  VirtualMaps virtual_maps = CreateVirtualMaps(plan_);
+  SegmentData segment_data = CreateSegments(plan_, virtual_maps);
+
+  std::vector<ActivationCondition> conditions;
+  flat_hash_map<std::vector<patch_id_t>, ActivationCondition> expected_virtual_conditions;
+  for (const auto& c_proto : plan_.glyph_patch_conditions()) {
+    ActivationCondition c = FromProto(c_proto);
+    conditions.push_back(c);
+
+    std::vector<patch_id_t> patches = {c.activated()};
+    patches.insert(patches.end(), c.prefetches().begin(), c.prefetches().end());
+    expected_virtual_conditions.emplace(std::move(patches), RealToVirtual(Normalize(c), segment_data.segment_to_virtual));
+  }
+
+  auto graph = EntryGraph::Create(conditions, segment_data.segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  auto unoptimized_entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(unoptimized_entries.ok()) << unoptimized_entries.status();
+
+  auto check_equivalence = [&](const std::vector<PatchMap::Entry>& entries) {
+    for (const auto& entry : entries) {
+      if (entry.ignored) {
+        continue;
+      }
+      ActivationCondition resolved = ResolveVirtualCondition(
+          entry, entries, virtual_maps);
+
+      auto it = expected_virtual_conditions.find(entry.patch_indices);
+      ASSERT_NE(it, expected_virtual_conditions.end())
+          << "No expected condition for patches starting with " << entry.patch_indices[0];
+      EXPECT_EQ(resolved, it->second)
+          << "Condition mismatch for patches starting with " << entry.patch_indices[0]
+          << "\nResolved: " << resolved.ToString()
+          << "\nExpected: " << it->second.ToString();
+    }
+  };
+
+  check_equivalence(*unoptimized_entries);
+
+  ASSERT_TRUE(graph->Optimize().ok());
+  auto optimized_entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(optimized_entries.ok()) << optimized_entries.status();
+
+  check_equivalence(*optimized_entries);
+
+  // Check cost
+  int64_t unoptimized_cost = TotalEncodingCost(*unoptimized_entries);
+  int64_t optimized_cost = TotalEncodingCost(*optimized_entries);
+  std::cout << "Unoptimized cost: " << unoptimized_cost << " bytes" << std::endl;
+  std::cout << "Optimized cost:   " << optimized_cost << " bytes" << std::endl;
+  std::cout << "Savings:          " << unoptimized_cost - optimized_cost << " bytes ("
+            << (100.0 * (unoptimized_cost - optimized_cost) / unoptimized_cost) << "%)" << std::endl;
+
+  EXPECT_LT(optimized_cost, unoptimized_cost);
+}
+
+}  // namespace ift::encoder

--- a/ift/encoder/entry_graph_equivalence_test.cc
+++ b/ift/encoder/entry_graph_equivalence_test.cc
@@ -1,24 +1,24 @@
 #include <fstream>
+#include <set>
 #include <string>
 #include <vector>
-#include <set>
 
-#include "gtest/gtest.h"
 #include "google/protobuf/text_format.h"
+#include "gtest/gtest.h"
 #include "ift/common/int_set.h"
 #include "ift/config/segmentation_plan.pb.h"
 #include "ift/encoder/activation_condition.h"
 #include "ift/encoder/entry_graph.h"
 #include "ift/encoder/subset_definition.h"
-#include "ift/proto/patch_encoding.h"
 #include "ift/proto/format_2_patch_map.h"
+#include "ift/proto/patch_encoding.h"
 
-using ift::config::SegmentationPlan;
-using ift::config::ActivationConditionProto;
-using ift::common::SegmentSet;
-using ift::common::CodepointSet;
 using absl::flat_hash_map;
 using absl::flat_hash_set;
+using ift::common::CodepointSet;
+using ift::common::SegmentSet;
+using ift::config::ActivationConditionProto;
+using ift::config::SegmentationPlan;
 using ift::proto::Format2PatchMap;
 using ift::proto::PatchMap;
 
@@ -35,7 +35,8 @@ using ift::proto::PatchMap;
 
 namespace ift::encoder {
 
-static ActivationCondition FromProto(const ActivationConditionProto& condition) {
+static ActivationCondition FromProto(
+    const ActivationConditionProto& condition) {
   std::vector<SegmentSet> groups;
   for (const auto& group : condition.required_segments()) {
     SegmentSet set;
@@ -53,7 +54,8 @@ static ActivationCondition Normalize(const ActivationCondition& condition) {
 
 static ActivationCondition RealToVirtual(
     const ActivationCondition& real_cond,
-    const flat_hash_map<segment_index_t, ActivationCondition>& segment_to_virtual) {
+    const flat_hash_map<segment_index_t, ActivationCondition>&
+        segment_to_virtual) {
   std::vector<SegmentSet> virtual_groups;
   for (const auto& real_group : real_cond.conditions()) {
     SegmentSet virt_group;
@@ -65,7 +67,8 @@ static ActivationCondition RealToVirtual(
   return ActivationCondition::composite_condition(virtual_groups, 0);
 }
 
-static int64_t TotalEncodingCost(const std::vector<proto::PatchMap::Entry>& entries) {
+static int64_t TotalEncodingCost(
+    const std::vector<proto::PatchMap::Entry>& entries) {
   int64_t total = 0;
   for (const auto& entry : entries) {
     auto cost = Format2PatchMap::EstimateEncodingCost(entry);
@@ -76,7 +79,6 @@ static int64_t TotalEncodingCost(const std::vector<proto::PatchMap::Entry>& entr
   return total;
 }
 
-
 struct VirtualMaps {
   flat_hash_map<hb_codepoint_t, uint32_t> cp_to_virtual;
   flat_hash_map<hb_tag_t, uint32_t> feature_to_virtual;
@@ -84,9 +86,7 @@ struct VirtualMaps {
 
 static ActivationCondition ResolveVirtualCondition(
     const PatchMap::Entry& entry,
-    const std::vector<PatchMap::Entry>& all_entries,
-    const VirtualMaps& maps) {
-
+    const std::vector<PatchMap::Entry>& all_entries, const VirtualMaps& maps) {
   std::vector<ActivationCondition> direct_conditions;
   if (!entry.coverage.codepoints.empty()) {
     SegmentSet s;
@@ -110,13 +110,14 @@ static ActivationCondition ResolveVirtualCondition(
 
   std::vector<ActivationCondition> children;
   for (uint32_t child_idx : entry.coverage.child_indices) {
-    children.push_back(ResolveVirtualCondition(all_entries[child_idx], all_entries,
-                                               maps));
+    children.push_back(
+        ResolveVirtualCondition(all_entries[child_idx], all_entries, maps));
   }
 
   if (entry.coverage.conjunctive) {
     ActivationCondition result = ActivationCondition::True(0);
-    for (const auto& c : direct_conditions) result = ActivationCondition::And(result, c);
+    for (const auto& c : direct_conditions)
+      result = ActivationCondition::And(result, c);
     for (const auto& c : children) result = ActivationCondition::And(result, c);
     return result;
   } else {
@@ -127,7 +128,8 @@ static ActivationCondition ResolveVirtualCondition(
     if (!children.empty()) {
       ActivationCondition children_condition = children[0];
       for (size_t i = 1; i < children.size(); ++i) {
-        children_condition = ActivationCondition::Or(children_condition, children[i]);
+        children_condition =
+            ActivationCondition::Or(children_condition, children[i]);
       }
       result = ActivationCondition::And(result, children_condition);
     }
@@ -143,7 +145,7 @@ class EntryGraphEquivalenceTest : public ::testing::Test {
     ASSERT_TRUE(file.is_open()) << "Could not open " << path;
 
     std::string content((std::istreambuf_iterator<char>(file)),
-                         std::istreambuf_iterator<char>());
+                        std::istreambuf_iterator<char>());
     ASSERT_TRUE(google::protobuf::TextFormat::ParseFromString(content, &plan_));
   }
 
@@ -178,7 +180,8 @@ struct SegmentData {
   flat_hash_map<segment_index_t, ActivationCondition> segment_to_virtual;
 };
 
-static SegmentData CreateSegments(const SegmentationPlan& plan, const VirtualMaps& maps) {
+static SegmentData CreateSegments(const SegmentationPlan& plan,
+                                  const VirtualMaps& maps) {
   SegmentData data;
   for (const auto& [id, set] : plan.segments()) {
     auto& segment = data.segments[id];
@@ -192,7 +195,8 @@ static SegmentData CreateSegments(const SegmentationPlan& plan, const VirtualMap
       segment.feature_tags.insert(tag);
       virtual_indices.insert(maps.feature_to_virtual.at(tag));
     }
-    data.segment_to_virtual.emplace(id, ActivationCondition::or_segments(virtual_indices, 0));
+    data.segment_to_virtual.emplace(
+        id, ActivationCondition::or_segments(virtual_indices, 0));
   }
   return data;
 }
@@ -202,14 +206,17 @@ TEST_F(EntryGraphEquivalenceTest, OptimizePreservesConditions) {
   SegmentData segment_data = CreateSegments(plan_, virtual_maps);
 
   std::vector<ActivationCondition> conditions;
-  flat_hash_map<std::vector<patch_id_t>, ActivationCondition> expected_virtual_conditions;
+  flat_hash_map<std::vector<patch_id_t>, ActivationCondition>
+      expected_virtual_conditions;
   for (const auto& c_proto : plan_.glyph_patch_conditions()) {
     ActivationCondition c = FromProto(c_proto);
     conditions.push_back(c);
 
     std::vector<patch_id_t> patches = {c.activated()};
     patches.insert(patches.end(), c.prefetches().begin(), c.prefetches().end());
-    expected_virtual_conditions.emplace(std::move(patches), RealToVirtual(Normalize(c), segment_data.segment_to_virtual));
+    expected_virtual_conditions.emplace(
+        std::move(patches),
+        RealToVirtual(Normalize(c), segment_data.segment_to_virtual));
   }
 
   auto graph = EntryGraph::Create(conditions, segment_data.segments);
@@ -223,15 +230,16 @@ TEST_F(EntryGraphEquivalenceTest, OptimizePreservesConditions) {
       if (entry.ignored) {
         continue;
       }
-      ActivationCondition resolved = ResolveVirtualCondition(
-          entry, entries, virtual_maps);
+      ActivationCondition resolved =
+          ResolveVirtualCondition(entry, entries, virtual_maps);
 
       auto it = expected_virtual_conditions.find(entry.patch_indices);
       ASSERT_NE(it, expected_virtual_conditions.end())
-          << "No expected condition for patches starting with " << entry.patch_indices[0];
+          << "No expected condition for patches starting with "
+          << entry.patch_indices[0];
       EXPECT_EQ(resolved, it->second)
-          << "Condition mismatch for patches starting with " << entry.patch_indices[0]
-          << "\nResolved: " << resolved.ToString()
+          << "Condition mismatch for patches starting with "
+          << entry.patch_indices[0] << "\nResolved: " << resolved.ToString()
           << "\nExpected: " << it->second.ToString();
     }
   };
@@ -247,10 +255,13 @@ TEST_F(EntryGraphEquivalenceTest, OptimizePreservesConditions) {
   // Check cost
   int64_t unoptimized_cost = TotalEncodingCost(*unoptimized_entries);
   int64_t optimized_cost = TotalEncodingCost(*optimized_entries);
-  std::cout << "Unoptimized cost: " << unoptimized_cost << " bytes" << std::endl;
+  std::cout << "Unoptimized cost: " << unoptimized_cost << " bytes"
+            << std::endl;
   std::cout << "Optimized cost:   " << optimized_cost << " bytes" << std::endl;
-  std::cout << "Savings:          " << unoptimized_cost - optimized_cost << " bytes ("
-            << (100.0 * (unoptimized_cost - optimized_cost) / unoptimized_cost) << "%)" << std::endl;
+  std::cout << "Savings:          " << unoptimized_cost - optimized_cost
+            << " bytes ("
+            << (100.0 * (unoptimized_cost - optimized_cost) / unoptimized_cost)
+            << "%)" << std::endl;
 
   EXPECT_LT(optimized_cost, unoptimized_cost);
 }

--- a/ift/encoder/entry_graph_test.cc
+++ b/ift/encoder/entry_graph_test.cc
@@ -5,10 +5,12 @@
 #include "absl/container/flat_hash_map.h"
 #include "gmock/gmock.h"
 #include "gtest/gtest.h"
+#include "ift/common/int_set.h"
 #include "ift/encoder/activation_condition.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/proto/patch_encoding.h"
 
+using ::ift::common::SegmentSet;
 using ::ift::proto::PatchEncoding;
 using ::testing::UnorderedElementsAre;
 using ::ift::common::CodepointSet;
@@ -17,7 +19,7 @@ using ::absl::flat_hash_map;
 namespace ift::encoder {
 
 TEST(EntryGraphTest, ToPatchMapEntries) {
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {1, {'a'}},
       {2, {'b'}},
       {3, {'c'}},
@@ -47,8 +49,8 @@ TEST(EntryGraphTest, ToPatchMapEntries) {
   // (s3) -> ignored
   EXPECT_EQ(entries.size(), 6);
 
-  absl::flat_hash_map<uint32_t, size_t> codepoint_to_index;
-  absl::flat_hash_map<uint32_t, size_t> patch_to_index;
+  flat_hash_map<uint32_t, size_t> codepoint_to_index;
+  flat_hash_map<uint32_t, size_t> patch_to_index;
 
   for (size_t i = 0; i < entries.size(); ++i) {
     const auto& entry = entries[i];
@@ -117,7 +119,7 @@ TEST(EntryGraphTest, SplitSegment) {
   SubsetDefinition s1;
   s1.codepoints = {'a'};
   s1.feature_tags = {HB_TAG('f', '1', ' ', ' ')};
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {1, s1},
   };
 
@@ -173,7 +175,7 @@ TEST(EntryGraphTest, SplitSegment) {
 }
 
 TEST(EntryGraphTest, TopologicalSort_SharedChildren) {
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {1, {'a'}},
       {2, {'b'}},
       {3, {'c'}},
@@ -214,8 +216,8 @@ TEST(EntryGraphTest, TopologicalSort_SharedChildren) {
 }
 
 TEST(EntryGraphTest, SplitLargeNode) {
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments;
-  ift::common::SegmentSet segment_ids;
+  flat_hash_map<segment_index_t, SubsetDefinition> segments;
+  SegmentSet segment_ids;
   for (int i = 1; i <= 130; ++i) {
     segments[i].codepoints = {static_cast<hb_codepoint_t>(i)};
     segment_ids.insert(i);
@@ -281,7 +283,7 @@ TEST(EntryGraphTest, NodeEncodingCost) {
 TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Disjunctive) {
   // s0 = {a}, s1 = {b}, s2 = {c}
   // (s0 or s1 or s2) -> {g1}
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, {'a'}},
       {1, {'b'}},
       {2, {'c'}},
@@ -353,7 +355,7 @@ TEST(EntryGraphTest,
 }
 
 TEST(EntryGraphTest, ActuateSubsumption_Disjunctive) {
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, {'a'}},
       {1, {'b'}},
       {2, {'c'}},
@@ -388,7 +390,7 @@ TEST(EntryGraphTest, ActuateSubsumption_Disjunctive_Mixed) {
   s2.feature_tags = {HB_TAG('f', 'o', 'o', ' ')};
   s3.feature_tags = {HB_TAG('b', 'a', 'r', ' ')};
 
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, s0},
       {1, s1},
       {2, s2},
@@ -449,7 +451,7 @@ TEST(EntryGraphTest, ActuateSubsumption_Disjunctive_Mixed) {
 
 TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Conjunctive) {
   // node = {x} AND child1, child1 = {a} OR {b}
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, {'a'}},
       {1, {'b'}},
       {2, {'x'}},
@@ -471,7 +473,7 @@ TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Conjunctive) {
 }
 
 TEST(EntryGraphTest, ActuateSubsumption_Conjunctive) {
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, {'a'}},
       {1, {'b'}},
       {2, {'x'}},
@@ -506,7 +508,7 @@ TEST(EntryGraphTest, ActuateSubsumption_Conjunctive_Multi) {
   s1.feature_tags = {HB_TAG('f', 'o', 'o', ' ')};
   s2.codepoints = {'x'};
 
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, s0},
       {1, s1},
       {2, s2},
@@ -564,7 +566,7 @@ TEST(EntryGraphTest,
   SubsetDefinition s3;
   s3.feature_tags = {HB_TAG('b', 'a', 'r', ' ')};
 
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, s0},
       {1, s1},
       {2, s2},
@@ -601,7 +603,7 @@ TEST(EntryGraphTest,
   for (int i = 0; i < 100; i++) s0.codepoints.insert(i * 2);
   for (int i = 100; i < 200; i++) s1.codepoints.insert(i * 2);
 
-  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, s0},
       {1, s1},
   };
@@ -631,6 +633,54 @@ TEST(EntryGraphTest,
     }
   }
   ASSERT_TRUE(found_children);
+}
+
+TEST(EntryGraphTest, Optimize_Disjunctive) {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, {'a'}},
+      {1, {'b'}},
+      {2, {'c'}},
+  };
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({0, 1, 2}, 10),
+  };
+  auto graph_or = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph_or.ok());
+  EntryGraph graph = std::move(*graph_or);
+
+  ASSERT_TRUE(graph.Optimize().ok());
+
+  auto entries = graph.ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+  // Should now have only 1 entry with all codepoints
+  EXPECT_EQ(entries->size(), 1);
+  EXPECT_THAT(entries->at(0).coverage.codepoints,
+              UnorderedElementsAre('a', 'b', 'c'));
+  EXPECT_TRUE(entries->at(0).coverage.child_indices.empty());
+}
+
+TEST(EntryGraphTest, Optimize_Conjunctive) {
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, {'a'}},
+      {1, {'b'}},
+      {2, {'x'}},
+  };
+  // (s0 OR s1) AND (s2)
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::composite_condition({{0, 1}, {2}}, 10),
+  };
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  ASSERT_TRUE(graph->Optimize().ok());
+
+  auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+
+  EXPECT_EQ(entries->size(), 2);
+  const auto& root_entry = entries->back();
+  EXPECT_THAT(root_entry.coverage.codepoints, UnorderedElementsAre('a', 'b'));
+  EXPECT_EQ(root_entry.coverage.child_indices.size(), 1);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/entry_graph_test.cc
+++ b/ift/encoder/entry_graph_test.cc
@@ -11,6 +11,8 @@
 
 using ::ift::proto::PatchEncoding;
 using ::testing::UnorderedElementsAre;
+using ::ift::common::CodepointSet;
+using ::absl::flat_hash_map;
 
 namespace ift::encoder {
 
@@ -182,13 +184,11 @@ TEST(EntryGraphTest, TopologicalSort_SharedChildren) {
       ActivationCondition::or_segments({2, 3}, 11),
   };
 
-  auto graph_or_status = EntryGraph::Create(activation_conditions, segments);
-  ASSERT_TRUE(graph_or_status.ok()) << graph_or_status.status();
-  EntryGraph graph = std::move(graph_or_status).value();
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
 
-  auto r = graph.TopologicalSort();
-  ASSERT_TRUE(r.ok()) << r.status();
-  std::vector<uint32_t> sorted = *r;
+  auto sorted = graph->TopologicalSort();
+  ASSERT_TRUE(sorted.ok()) << sorted.status();
 
   // The graph should have 5 nodes:
   // 0: (s1 OR s2)
@@ -196,13 +196,13 @@ TEST(EntryGraphTest, TopologicalSort_SharedChildren) {
   // 2: (s2) shared
   // 3: (s2 or s3)
   // 4: (s3)
-  EXPECT_THAT(sorted, UnorderedElementsAre(0, 1, 2, 3, 4));
+  EXPECT_THAT(*sorted, UnorderedElementsAre(0, 1, 2, 3, 4));
 
-  auto n0 = std::find(sorted.begin(), sorted.end(), 0);
-  auto n1 = std::find(sorted.begin(), sorted.end(), 1);
-  auto n2 = std::find(sorted.begin(), sorted.end(), 2);
-  auto n3 = std::find(sorted.begin(), sorted.end(), 3);
-  auto n4 = std::find(sorted.begin(), sorted.end(), 4);
+  auto n0 = std::find(sorted->begin(), sorted->end(), 0);
+  auto n1 = std::find(sorted->begin(), sorted->end(), 1);
+  auto n2 = std::find(sorted->begin(), sorted->end(), 2);
+  auto n3 = std::find(sorted->begin(), sorted->end(), 3);
+  auto n4 = std::find(sorted->begin(), sorted->end(), 4);
 
   // n0 comes before it's children
   EXPECT_LT(n0, n1);
@@ -239,9 +239,11 @@ TEST(EntryGraphTest, SplitLargeNode) {
 
   for (size_t i = 0; i < entries->size(); i++) {
     const auto& entry = (*entries)[i];
-    if (!entry.ignored && !entry.patch_indices.empty() && entry.patch_indices[0] == 10) {
+    if (!entry.ignored && !entry.patch_indices.empty() &&
+        entry.patch_indices[0] == 10) {
       root_id = i;
-    } else if (entry.ignored && entry.coverage.codepoints.empty() && !entry.coverage.child_indices.empty()) {
+    } else if (entry.ignored && entry.coverage.codepoints.empty() &&
+               !entry.coverage.child_indices.empty()) {
       split_node_id = i;
     }
   }
@@ -251,7 +253,8 @@ TEST(EntryGraphTest, SplitLargeNode) {
 
   // The root node gets the first 126 children + the split node (total 127).
   EXPECT_EQ((*entries)[root_id].coverage.child_indices.size(), 127);
-  EXPECT_TRUE((*entries)[root_id].coverage.child_indices.contains(split_node_id));
+  EXPECT_TRUE(
+      (*entries)[root_id].coverage.child_indices.contains(split_node_id));
 
   // The split node gets the remaining 4 children.
   EXPECT_EQ((*entries)[split_node_id].coverage.child_indices.size(), 4);
@@ -263,18 +266,371 @@ TEST(EntryGraphTest, NodeEncodingCost) {
   node.and_codepoints.insert(2);
   node.child_mode = NONE;
 
-  auto cost1_or = node.EncodingCost();
-  ASSERT_TRUE(cost1_or.ok()) << cost1_or.status();
-  int64_t cost1 = *cost1_or;
-  EXPECT_GT(cost1, 0);
+  auto cost1 = node.EncodingCost();
+  ASSERT_TRUE(cost1.ok()) << cost1.status();
+  EXPECT_GT(*cost1, 0);
 
   node.children_ids.insert(1);
   node.children_ids.insert(2);
 
-  auto cost2_or = node.EncodingCost();
-  ASSERT_TRUE(cost2_or.ok()) << cost2_or.status();
-  int64_t cost2 = *cost2_or;
-  EXPECT_GT(cost2, cost1);
+  auto cost2 = node.EncodingCost();
+  ASSERT_TRUE(cost2.ok()) << cost2.status();
+  EXPECT_GT(*cost2, *cost1);
+}
+
+TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Disjunctive) {
+  // s0 = {a}, s1 = {b}, s2 = {c}
+  // (s0 or s1 or s2) -> {g1}
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, {'a'}},
+      {1, {'b'}},
+      {2, {'c'}},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({0, 1, 2}, 10),
+  };
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  // Find the root OR node.
+  auto sorted = graph->TopologicalSort();
+  ASSERT_TRUE(sorted.ok());
+  uint32_t root_id = sorted->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result.ok()) << result.status();
+
+  // Combining 4 entries into one should lower cost by eliminating
+  // per entry overhead.
+  EXPECT_LT(result->cost_delta, 0);
+  EXPECT_EQ(result->subsumed_children.size(), 3);
+  EXPECT_EQ(result->codepoints, (CodepointSet{'a', 'b', 'c'}));
+}
+
+TEST(EntryGraphTest,
+     CalculateSubsumptionCostDelta_Disjunctive_PositiveDelta) {
+  // Children are shared and large. Subsuming them into the parent adds to the
+  // outweights entry cost savings due to duplicating the codepoint sets.
+
+  SubsetDefinition s0, s1;
+  // Insert non-continous codepoints to ensure the sparse bit sets take up
+  // a sizable amount of bytes
+  for (int i = 0; i < 100; i++) s0.codepoints.insert(i * 2);
+  for (int i = 100; i < 200; i++) s1.codepoints.insert(i * 2);
+
+  flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, s0},
+      {1, s1},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({0, 1}, 100),
+      ActivationCondition::exclusive_segment(0, 101),
+      ActivationCondition::exclusive_segment(1, 102),
+  };
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  auto sorted = graph->TopologicalSort();
+  ASSERT_TRUE(sorted.ok()) << sorted.status();
+
+  // all nodes should have a positive/zero cost since the current configuration
+  // is optimal
+  bool found_children = false;
+  for (uint32_t id : *sorted) {
+    auto res = graph->CalculateSubsumptionCostDelta(id);
+    ASSERT_TRUE(res.ok());
+    ASSERT_GE(res->cost_delta, 0);
+    if (res->subsumed_children.size() == 2) {
+      found_children = true;
+      ASSERT_GT(res->cost_delta, 0);
+    }
+  }
+  ASSERT_TRUE(found_children);
+}
+
+TEST(EntryGraphTest, ActuateSubsumption_Disjunctive) {
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, {'a'}},
+      {1, {'b'}},
+      {2, {'c'}},
+  };
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({0, 1, 2}, 10),
+  };
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  uint32_t root_id = graph->TopologicalSort()->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result->cost_delta < 0);
+
+  ASSERT_TRUE(graph->ActuateSubsumption(root_id, *result).ok());
+
+  auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+  // Should now have only 1 entry with all codepoints
+  EXPECT_EQ(entries->size(), 1);
+  EXPECT_THAT(entries->at(0).coverage.codepoints,
+              UnorderedElementsAre('a', 'b', 'c'));
+  EXPECT_TRUE(entries->at(0).coverage.child_indices.empty());
+}
+
+TEST(EntryGraphTest, ActuateSubsumption_Disjunctive_Mixed) {
+  // s0, s1 = codepoints
+  // s2, s3 = feature tags
+  // (s0 or s1 or s2 or s3) -> {g1}
+  SubsetDefinition s0, s1, s2, s3;
+  s0.codepoints = {'a'};
+  s1.codepoints = {'b'};
+  s2.feature_tags = {HB_TAG('f', 'o', 'o', ' ')};
+  s3.feature_tags = {HB_TAG('b', 'a', 'r', ' ')};
+
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, s0},
+      {1, s1},
+      {2, s2},
+      {3, s3},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::or_segments({0, 1, 2, 3}, 10),
+  };
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  auto sorted = graph->TopologicalSort();
+  ASSERT_TRUE(sorted.ok()) << sorted.status();
+  uint32_t root_id = sorted->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result.ok()) << result.status();
+  ASSERT_LT(result->cost_delta, 0);
+
+  ASSERT_TRUE(graph->ActuateSubsumption(root_id, *result).ok());
+
+  auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+
+  // Result should have:
+  // E0: {a, b}
+  // E1: features {'foo ', 'bar '}
+  // E2: OR children {E0, E1}
+  EXPECT_EQ(entries->size(), 3);
+
+  const auto& root_entry = entries->back();
+  EXPECT_TRUE(root_entry.coverage.codepoints.empty());
+  EXPECT_TRUE(root_entry.coverage.features.empty());
+  EXPECT_EQ(root_entry.coverage.child_indices.size(), 2);
+
+  bool found_cp = false;
+  bool found_feat = false;
+  for (uint32_t child_idx : root_entry.coverage.child_indices) {
+    const auto& child = entries->at(child_idx);
+    if (!child.coverage.codepoints.empty()) {
+      EXPECT_THAT(child.coverage.codepoints, UnorderedElementsAre('a', 'b'));
+      EXPECT_TRUE(child.coverage.features.empty());
+      found_cp = true;
+    }
+    if (!child.coverage.features.empty()) {
+      EXPECT_THAT(child.coverage.features,
+                  UnorderedElementsAre(HB_TAG('f', 'o', 'o', ' '),
+                                       HB_TAG('b', 'a', 'r', ' ')));
+      EXPECT_TRUE(child.coverage.codepoints.empty());
+      found_feat = true;
+    }
+  }
+  EXPECT_TRUE(found_cp);
+  EXPECT_TRUE(found_feat);
+}
+
+TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Conjunctive) {
+  // node = {x} AND child1, child1 = {a} OR {b}
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, {'a'}},
+      {1, {'b'}},
+      {2, {'x'}},
+  };
+  // (s0 OR s1) AND (s2)
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::composite_condition({{0, 1}, {2}}, 10),
+  };
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  uint32_t root_id = graph->TopologicalSort()->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result.ok()) << result.status();
+  EXPECT_LT(result->cost_delta, 0);
+  EXPECT_EQ(result->codepoints, (CodepointSet{'a', 'b'}));
+  EXPECT_EQ(result->subsumed_children.size(), 1);
+}
+
+TEST(EntryGraphTest, ActuateSubsumption_Conjunctive) {
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, {'a'}},
+      {1, {'b'}},
+      {2, {'x'}},
+  };
+  // (s0 OR s1) AND (s2)
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::composite_condition({{0, 1}, {2}}, 10),
+  };
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+  uint32_t root_id = graph->TopologicalSort()->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result->cost_delta < 0);
+
+  ASSERT_TRUE(graph->ActuateSubsumption(root_id, *result).ok());
+
+  auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+
+  EXPECT_EQ(entries->size(), 2);
+  const auto& root_entry = entries->back();
+  EXPECT_FALSE(root_entry.coverage.codepoints.empty());
+  EXPECT_EQ(root_entry.coverage.child_indices.size(), 1);
+}
+
+TEST(EntryGraphTest, ActuateSubsumption_Conjunctive_Multi) {
+  // Conjunctive node with one purely disjunctive codepoint child and one
+  // purely disjunctive feature child. Both should be subsumed.
+  SubsetDefinition s0, s1, s2;
+  s0.codepoints = {'a', 'b'};
+  s1.feature_tags = {HB_TAG('f', 'o', 'o', ' ')};
+  s2.codepoints = {'x'};
+
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, s0},
+      {1, s1},
+      {2, s2},
+  };
+
+  // (s0 AND s1 AND s2) -> 10
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::and_segments({0, 1, 2}, 10),
+  };
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  auto sorted = graph->TopologicalSort();
+  ASSERT_TRUE(sorted.ok());
+  uint32_t root_id = sorted->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result.ok()) << result.status();
+  ASSERT_LT(result->cost_delta, 0);
+  EXPECT_EQ(result->subsumed_children.size(), 2);
+
+  ASSERT_TRUE(graph->ActuateSubsumption(root_id, *result).ok());
+
+  auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
+  ASSERT_TRUE(entries.ok()) << entries.status();
+
+  // Should have 2 entries now: root (AND node) and the remaining child s2.
+  EXPECT_EQ(entries->size(), 2);
+  const auto& root_entry = entries->back();
+  EXPECT_THAT(root_entry.coverage.codepoints, UnorderedElementsAre('a', 'b'));
+  EXPECT_THAT(root_entry.coverage.features,
+              UnorderedElementsAre(HB_TAG('f', 'o', 'o', ' ')));
+  EXPECT_EQ(root_entry.coverage.child_indices.size(), 1);
+
+  // Verify the remaining child is s2 ({'x'})
+  uint32_t s2_idx = *root_entry.coverage.child_indices.begin();
+  EXPECT_THAT(entries->at(s2_idx).coverage.codepoints,
+              UnorderedElementsAre('x'));
+}
+
+TEST(EntryGraphTest,
+     CalculateSubsumptionCostDelta_Conjunctive_MixedChild_NoSubsume) {
+  // Conjunctive node has a children which are mixed (codepoints + feature).
+  // Effectively forming conditions like (a or foo) AND (b or  bar)
+  // These mixed conditions can't be pulled up into the parent condition.
+
+  SubsetDefinition s0{'a'};
+
+  SubsetDefinition s1;
+  s1.feature_tags = {HB_TAG('f', 'o', 'o', ' ')};
+
+  SubsetDefinition s2{'b'};
+
+  SubsetDefinition s3;
+  s3.feature_tags = {HB_TAG('b', 'a', 'r', ' ')};
+
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, s0},
+      {1, s1},
+      {2, s2},
+      {3, s3},
+  };
+
+  // Condition: (s0 OR s1) AND (s2 OR s3) => 10
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::composite_condition({{
+                                                    0,
+                                                    1,
+                                                },
+                                                {2, 3}},
+                                               10)};
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  uint32_t root_id = graph->TopologicalSort()->at(0);
+
+  auto result = graph->CalculateSubsumptionCostDelta(root_id);
+  ASSERT_TRUE(result.ok());
+
+  // No subsuming should happen, nothing is eligible
+  EXPECT_GE(result->cost_delta, 0);
+  EXPECT_TRUE(result->subsumed_children.empty());
+  EXPECT_FALSE(result->codepoints.has_value());
+  EXPECT_FALSE(result->features.has_value());
+}
+
+TEST(EntryGraphTest,
+     CalculateSubsumptionCostDelta_Conjunctive_PositiveDelta) {
+  SubsetDefinition s0, s1;
+  for (int i = 0; i < 100; i++) s0.codepoints.insert(i * 2);
+  for (int i = 100; i < 200; i++) s1.codepoints.insert(i * 2);
+
+  absl::flat_hash_map<segment_index_t, SubsetDefinition> segments = {
+      {0, s0},
+      {1, s1},
+  };
+
+  std::vector<ActivationCondition> activation_conditions = {
+      ActivationCondition::and_segments({0, 1}, 100),
+      ActivationCondition::exclusive_segment(0, 101),
+      ActivationCondition::exclusive_segment(1, 102),
+  };
+
+  auto graph = EntryGraph::Create(activation_conditions, segments);
+  ASSERT_TRUE(graph.ok()) << graph.status();
+
+  auto sorted = graph->TopologicalSort();
+  ASSERT_TRUE(sorted.ok());
+
+  // all nodes should have a positive/zero cost since the current configuration
+  // is optimal
+  bool found_children = false;
+  for (uint32_t id : *sorted) {
+    auto res = graph->CalculateSubsumptionCostDelta(id);
+    ASSERT_TRUE(res.ok());
+    ASSERT_GE(res->cost_delta, 0);
+    if (res->subsumed_children.size() == 1) {
+      found_children = true;
+      ASSERT_GT(res->cost_delta, 0);
+    }
+  }
+  ASSERT_TRUE(found_children);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/entry_graph_test.cc
+++ b/ift/encoder/entry_graph_test.cc
@@ -257,4 +257,24 @@ TEST(EntryGraphTest, SplitLargeNode) {
   EXPECT_EQ((*entries)[split_node_id].coverage.child_indices.size(), 4);
 }
 
+TEST(EntryGraphTest, NodeEncodingCost) {
+  EntryNode node;
+  node.and_codepoints.insert(1);
+  node.and_codepoints.insert(2);
+  node.child_mode = NONE;
+
+  auto cost1_or = node.EncodingCost();
+  ASSERT_TRUE(cost1_or.ok()) << cost1_or.status();
+  int64_t cost1 = *cost1_or;
+  EXPECT_GT(cost1, 0);
+
+  node.children_ids.insert(1);
+  node.children_ids.insert(2);
+
+  auto cost2_or = node.EncodingCost();
+  ASSERT_TRUE(cost2_or.ok()) << cost2_or.status();
+  int64_t cost2 = *cost2_or;
+  EXPECT_GT(cost2, cost1);
+}
+
 }  // namespace ift::encoder

--- a/ift/encoder/entry_graph_test.cc
+++ b/ift/encoder/entry_graph_test.cc
@@ -10,11 +10,11 @@
 #include "ift/encoder/subset_definition.h"
 #include "ift/proto/patch_encoding.h"
 
+using ::absl::flat_hash_map;
+using ::ift::common::CodepointSet;
 using ::ift::common::SegmentSet;
 using ::ift::proto::PatchEncoding;
 using ::testing::UnorderedElementsAre;
-using ::ift::common::CodepointSet;
-using ::absl::flat_hash_map;
 
 namespace ift::encoder {
 
@@ -311,10 +311,9 @@ TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Disjunctive) {
   EXPECT_EQ(result->codepoints, (CodepointSet{'a', 'b', 'c'}));
 }
 
-TEST(EntryGraphTest,
-     CalculateSubsumptionCostDelta_Disjunctive_PositiveDelta) {
-  // Children are shared and large. Subsuming them into the parent adds to the
-  // outweights entry cost savings due to duplicating the codepoint sets.
+TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Disjunctive_PositiveDelta) {
+  // Children are shared and large. Subsuming them into the parent will duplicate
+  // them. Cost of duplication outweights entry cost savings.
 
   SubsetDefinition s0, s1;
   // Insert non-continous codepoints to ensure the sparse bit sets take up
@@ -450,7 +449,6 @@ TEST(EntryGraphTest, ActuateSubsumption_Disjunctive_Mixed) {
 }
 
 TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Conjunctive) {
-  // node = {x} AND child1, child1 = {a} OR {b}
   flat_hash_map<segment_index_t, SubsetDefinition> segments = {
       {0, {'a'}},
       {1, {'b'}},
@@ -494,6 +492,7 @@ TEST(EntryGraphTest, ActuateSubsumption_Conjunctive) {
   auto entries = graph->ToPatchMapEntries(proto::GLYPH_KEYED);
   ASSERT_TRUE(entries.ok()) << entries.status();
 
+  // One of the codepoint sets should be pulled up into the root node.
   EXPECT_EQ(entries->size(), 2);
   const auto& root_entry = entries->back();
   EXPECT_FALSE(root_entry.coverage.codepoints.empty());
@@ -597,8 +596,7 @@ TEST(EntryGraphTest,
   EXPECT_FALSE(result->features.has_value());
 }
 
-TEST(EntryGraphTest,
-     CalculateSubsumptionCostDelta_Conjunctive_PositiveDelta) {
+TEST(EntryGraphTest, CalculateSubsumptionCostDelta_Conjunctive_PositiveDelta) {
   SubsetDefinition s0, s1;
   for (int i = 0; i < 100; i++) s0.codepoints.insert(i * 2);
   for (int i = 100; i < 200; i++) s1.codepoints.insert(i * 2);

--- a/ift/proto/format_2_patch_map.cc
+++ b/ift/proto/format_2_patch_map.cc
@@ -172,6 +172,20 @@ StatusOr<std::string> Format2PatchMap::Serialize(
   return out;
 }
 
+StatusOr<size_t> Format2PatchMap::EstimateEncodingCost(
+    const PatchMap::Entry& entry) {
+  PatchMap::Entry dummy_entry = entry;
+  if (dummy_entry.patch_indices.empty()) {
+    dummy_entry.patch_indices.push_back(1);
+  }
+  // Ignore the impact of last_entry_index and default_encoding on the cost
+  // estimates by using fixed values.
+  std::string out;
+  TRYV(EncodeEntry(dummy_entry, /*last_entry_index=*/0,
+                       /*default_encoding=*/TABLE_KEYED_FULL, out));
+  return out.size();
+}
+
 Status DecodeAxisSegment(absl::string_view data, hb_tag_t& tag,
                          AxisRange& range) {
   READ_UINT32(tag_v, data, 0);

--- a/ift/proto/format_2_patch_map.h
+++ b/ift/proto/format_2_patch_map.h
@@ -13,6 +13,11 @@ class Format2PatchMap {
   static absl::StatusOr<std::string> Serialize(
       const IFTTable& ift_table, std::optional<uint32_t> cff_charstrings_offset,
       std::optional<uint32_t> cff2_charstrings_offset);
+
+  // Generate an estimated encoding cost, ignores the impact of last patch index
+  // and the default format selection on final encoding size.
+  static absl::StatusOr<size_t> EstimateEncodingCost(
+      const PatchMap::Entry& entry);
 };
 
 }  // namespace ift::proto

--- a/ift/proto/format_2_patch_map_test.cc
+++ b/ift/proto/format_2_patch_map_test.cc
@@ -518,4 +518,24 @@ TEST_F(Format2PatchMapTest, MultipleIndexDeltas) {
   ASSERT_EQ(*encoded, absl::StrCat(header, entry_0, entry_1, entry_2));
 }
 
+TEST_F(Format2PatchMapTest, EstimateEncodingCost) {
+  PatchMap::Entry entry;
+  entry.coverage.codepoints.insert(1);
+  entry.coverage.codepoints.insert(2);
+  entry.coverage.codepoints.insert(3);
+  entry.patch_indices = {1};
+  entry.encoding = TABLE_KEYED_FULL;
+
+  // From Format2PatchMapTest.Simple:
+  // entry_0 = {
+  //     0x10,                   // format = 00010000 = Codepoints
+  //     0b00000101, 0b00001110  // codepoints (BF4, depth 1)= {1, 2, 3}
+  // };
+  // Total 3 bytes.
+
+  auto cost = Format2PatchMap::EstimateEncodingCost(entry);
+  ASSERT_TRUE(cost.ok()) << cost.status();
+  EXPECT_EQ(*cost, 3);
+}
+
 }  // namespace ift::proto


### PR DESCRIPTION
- Per node evaluates whether it's better, in terms of encoded size, to (where possible) directly encode the sets vs refering to shared sets via child indices.
- For fully disjunctive conditions we can pull up the union of the sub-graph for the node.
- For conjunctive conditions we can pull up to one codepoint, feature, and design space set into the node.
- Adds an equivalence test that verifies the optimized, unoptimized, and original conditions are all equivalent.

For #205 