### PR TITLE
Fix segmentation analysis "total cost" output

### DIFF
--- a/ift/config/load_codepoints.cc
+++ b/ift/config/load_codepoints.cc
@@ -29,6 +29,7 @@ using ift::common::FontData;
 using ift::common::hb_blob_unique_ptr;
 using ift::common::make_hb_blob;
 using ift::freq::UnicodeFrequencies;
+using ift::freq::UnicodeFrequenciesBuilder;
 using ift_encoder_data::CodepointCount;
 using ift_encoder_data::DatasetMetadata;
 
@@ -178,7 +179,7 @@ StatusOr<std::vector<std::string>> ExpandShardedPath(const char* path) {
 }
 
 static Status LoadFrequenciesFromRiegeliIndividual(
-    const char* path, UnicodeFrequencies& frequencies) {
+    const char* path, UnicodeFrequenciesBuilder& frequencies) {
   riegeli::RecordReader reader{riegeli::FdReader(path)};
   if (!reader.ok()) {
     return absl::InvalidArgumentError(
@@ -204,11 +205,11 @@ static Status LoadFrequenciesFromRiegeliIndividual(
 
 StatusOr<UnicodeFrequencies> LoadFrequenciesFromRiegeli(const char* path) {
   auto paths = TRY(ExpandShardedPath(path));
-  UnicodeFrequencies frequencies;
+  UnicodeFrequenciesBuilder builder;
   for (const auto& path : paths) {
-    TRYV(LoadFrequenciesFromRiegeliIndividual(path.c_str(), frequencies));
+    TRYV(LoadFrequenciesFromRiegeliIndividual(path.c_str(), builder));
   }
-  return frequencies;
+  return builder.Build();
 }
 
 StatusOr<UnicodeFrequencies> LoadBuiltInFrequencies(const char* name) {

--- a/ift/config/segmenter_config_util_test.cc
+++ b/ift/config/segmenter_config_util_test.cc
@@ -21,6 +21,7 @@ using ift::config::SegmenterConfigUtil;
 using ift::encoder::MergeStrategy;
 using ift::encoder::SubsetDefinition;
 using ift::freq::UnicodeFrequencies;
+using ift::freq::UnicodeFrequenciesBuilder;
 
 class SegmenterConfigUtilTest : public ::testing::Test {
  protected:
@@ -36,10 +37,10 @@ void AddSegment(SegmenterConfig& config, uint32_t id, CodepointSet codepoints) {
 MergeStrategy ExpectedCostStrategy(
     unsigned net_overhead,
     std::optional<int> init_font_threshold = std::nullopt) {
-  UnicodeFrequencies freq;
-  freq.Add(1, 1, 1);
+  UnicodeFrequenciesBuilder freq_builder;
+  freq_builder.Add(1, 1, 1);
 
-  MergeStrategy s = *MergeStrategy::CostBased(std::move(freq), net_overhead, 1);
+  MergeStrategy s = *MergeStrategy::CostBased(freq_builder.Build(), net_overhead, 1);
   s.SetOptimizationCutoffFraction(0.001);
   s.SetInitFontMergeThreshold(init_font_threshold);
 

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -657,7 +657,7 @@ StatusOr<SegmentationCost> ClosureGlyphSegmenter::TotalCost(
   //                     may want to use the IFT compiler to produce the
   //                     complete encoding then compute table keyed costs from
   //                     that (in conjunction) with probability calculations.
-  double total_cost = init_font_size;
+  double total_cost = 0;
 
   // Use highest quality so we get the true cost.
   PatchSizeCacheImpl patch_sizer(original_face, 11);
@@ -671,15 +671,21 @@ StatusOr<SegmentationCost> ClosureGlyphSegmenter::TotalCost(
   double ideal_cost = 0.0;
   double incremental_size =
       non_ift_font_size / (double)non_ift.codepoints.size();
+  double init_font_ideal_size = incremental_size * segmentation.InitialFontSegment().codepoints.size();
   for (unsigned cp : non_ift.codepoints) {
+    if (segmentation.InitialFontSegment().codepoints.contains(cp)) {
+      continue;
+    }
     double Pcp = probability_calculator.ComputeProbability({cp}).Average();
     ideal_cost += Pcp * incremental_size;
   }
 
   return SegmentationCost{
-      .total_cost = total_cost,
-      .cost_for_non_segmented = non_ift_font_size,
-      .ideal_cost = ideal_cost,
+      .ift_init_cost = init_font_size,
+      .ift_patch_cost = total_cost,
+      .non_ift_total_cost = non_ift_font_size,
+      .ideal_init_cost = init_font_ideal_size,
+      .ideal_patch_cost = ideal_cost,
   };
 }
 

--- a/ift/encoder/closure_glyph_segmenter.h
+++ b/ift/encoder/closure_glyph_segmenter.h
@@ -17,9 +17,14 @@
 namespace ift::encoder {
 
 struct SegmentationCost {
-  double total_cost;
-  double cost_for_non_segmented;
-  double ideal_cost;
+  double ift_init_cost;
+  double ift_patch_cost;
+
+  double non_ift_total_cost;
+
+  double ideal_init_cost;
+  double ideal_patch_cost;
+
 };
 
 /*

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -1105,9 +1105,9 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
   ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY);
   SegmentationCost base_cost =
       *segmenter.TotalCost(roboto.get(), segmentation1, calculator);
-  ASSERT_GT(base_cost.total_cost, 1000);
-  ASSERT_EQ(base_cost.total_cost, base_cost.cost_for_non_segmented);
-  ASSERT_LT(base_cost.ideal_cost, base_cost.total_cost);
+  ASSERT_GT(base_cost.ift_init_cost, 1000);
+  ASSERT_EQ(base_cost.ift_init_cost, base_cost.non_ift_total_cost);
+  ASSERT_EQ(base_cost.ift_init_cost, base_cost.ideal_init_cost);
 
   // Add some patches
   GlyphSegmentation segmentation2({'a', 'b', 'c'}, {}, {});
@@ -1127,8 +1127,8 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
 
   SegmentationCost with_patches_cost =
       *segmenter.TotalCost(roboto.get(), segmentation2, calculator);
-  ASSERT_GT(with_patches_cost.total_cost, base_cost.total_cost + 400);
-  ASSERT_LT(with_patches_cost.ideal_cost, with_patches_cost.total_cost);
+  ASSERT_GT(with_patches_cost.ift_patch_cost, base_cost.ift_patch_cost);
+  ASSERT_LT(with_patches_cost.ideal_patch_cost, with_patches_cost.ift_patch_cost);
 }
 
 TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {

--- a/ift/encoder/merge_strategy.h
+++ b/ift/encoder/merge_strategy.h
@@ -44,7 +44,7 @@ class MergeStrategy {
     MergeStrategy strategy(false, 0, 0, patch_size_min_bytes,
                            patch_size_max_bytes);
     strategy.probability_calculator_ =
-        std::make_unique<ift::freq::NoopProbabilityCalculator>();
+        std::make_shared<ift::freq::NoopProbabilityCalculator>();
     return strategy;
   }
 
@@ -69,7 +69,7 @@ class MergeStrategy {
     MergeStrategy strategy(true, network_overhead_cost, min_group_size, 0,
                            UINT32_MAX);
     strategy.probability_calculator_ =
-        std::make_unique<ift::freq::UnigramProbabilityCalculator>(
+        std::make_shared<ift::freq::UnigramProbabilityCalculator>(
             std::move(frequency_data));
     return strategy;
   }
@@ -96,7 +96,7 @@ class MergeStrategy {
     MergeStrategy strategy(true, network_overhead_cost, min_group_size, 0,
                            UINT32_MAX);
     strategy.probability_calculator_ =
-        std::make_unique<ift::freq::BigramProbabilityCalculator>(
+        std::make_shared<ift::freq::BigramProbabilityCalculator>(
             std::move(frequency_data));
     return strategy;
   }

--- a/ift/freq/unicode_frequencies.cc
+++ b/ift/freq/unicode_frequencies.cc
@@ -9,14 +9,6 @@ using ift::common::CodepointSet;
 
 namespace ift::freq {
 
-UnicodeFrequencies::UnicodeFrequencies(
-    std::initializer_list<std::pair<std::pair<uint32_t, uint32_t>, uint64_t>>
-        frequencies) {
-  for (const auto& pair : frequencies) {
-    Add(pair.first.first, pair.first.second, pair.second);
-  }
-}
-
 static uint64_t ToKey(uint32_t cp1, uint32_t cp2) {
   if (cp1 < cp2) {
     return (((uint64_t)cp1) << 32) | ((uint64_t)cp2);
@@ -25,19 +17,35 @@ static uint64_t ToKey(uint32_t cp1, uint32_t cp2) {
   }
 }
 
-void UnicodeFrequencies::Add(uint32_t cp1, uint32_t cp2, uint64_t count) {
+void UnicodeFrequenciesBuilder::Add(uint32_t cp1, uint32_t cp2, uint64_t count) {
   uint64_t key = ToKey(cp1, cp2);
   uint64_t& freq = frequencies_[key];
   freq += count;
   if (freq > max_count_) {
     max_count_ = freq;
-    unknown_probability = 1.0 / (double)max_count_;
-    for (auto it = frequencies_.begin(); it != frequencies_.end(); it++) {
-      probabilities_[it->first] = (double)it->second / (double)max_count_;
-    }
-  } else {
-    probabilities_[key] = (double)freq / (double)max_count_;
   }
+}
+
+UnicodeFrequencies UnicodeFrequenciesBuilder::Build() {
+  UnicodeFrequencies result;
+  result.max_count_ = max_count_;
+  if (max_count_ > 0) {
+    result.unknown_probability_ = 1.0 / (double)max_count_;
+    for (const auto& [key, count] : frequencies_) {
+      result.probabilities_[key] = (double)count / (double)max_count_;
+    }
+  }
+  return result;
+}
+
+UnicodeFrequencies::UnicodeFrequencies(
+    std::initializer_list<std::pair<std::pair<uint32_t, uint32_t>, uint64_t>>
+        frequencies) {
+  UnicodeFrequenciesBuilder builder;
+  for (const auto& pair : frequencies) {
+    builder.Add(pair.first.first, pair.first.second, pair.second);
+  }
+  *this = std::move(builder.Build());
 }
 
 double UnicodeFrequencies::ProbabilityFor(uint32_t cp) const {
@@ -48,7 +56,7 @@ double UnicodeFrequencies::ProbabilityFor(uint32_t cp) const {
   if (it != probabilities_.end()) {
     return it->second;
   }
-  return unknown_probability;
+  return unknown_probability_;
 }
 
 double UnicodeFrequencies::ProbabilityFor(uint32_t cp1, uint32_t cp2) const {
@@ -70,7 +78,7 @@ double UnicodeFrequencies::ProbabilityFor(uint32_t cp1, uint32_t cp2, double p1,
     return it->second;
   }
 
-  // Since we don't have data  on P(cp1 n cp2), just assume the probabilities
+  // Since we don't have data on P(cp1 n cp2), just assume the probabilities
   // for P(cp1) and P(cp2) are independent:
   return p1 * p2;
 }

--- a/ift/freq/unicode_frequencies.h
+++ b/ift/freq/unicode_frequencies.h
@@ -6,7 +6,6 @@
 #include "absl/container/flat_hash_map.h"
 #include "hb.h"
 #include "ift/common/int_set.h"
-#include "ift/encoder/subset_definition.h"
 
 namespace ift::freq {
 
@@ -14,6 +13,8 @@ class UnicodeFrequencies {
  public:
   UnicodeFrequencies() = default;
   UnicodeFrequencies(UnicodeFrequencies&& other) = default;
+  UnicodeFrequencies& operator=(UnicodeFrequencies&& other) = default;
+
   UnicodeFrequencies(
       std::initializer_list<std::pair<std::pair<uint32_t, uint32_t>, uint64_t>>
           frequencies);
@@ -51,10 +52,25 @@ class UnicodeFrequencies {
   ift::common::CodepointSet CoveredCodepoints() const;
 
  private:
-  absl::flat_hash_map<uint64_t, uint64_t> frequencies_;
+  friend class UnicodeFrequenciesBuilder;
   absl::flat_hash_map<uint64_t, double> probabilities_;
   uint64_t max_count_ = 0;
-  double unknown_probability = 1.0;
+  double unknown_probability_ = 1.0;
+};
+
+class UnicodeFrequenciesBuilder {
+ public:
+  UnicodeFrequenciesBuilder() = default;
+
+  // Add frequency data for the codepoint pair (cp1, cp2).
+  // When cp1 == cp2 this supplies frequency for a single codepoint.
+  void Add(uint32_t cp1, uint32_t cp2, uint64_t count);
+
+  UnicodeFrequencies Build();
+
+ private:
+  absl::flat_hash_map<uint64_t, uint64_t> frequencies_;
+  uint64_t max_count_ = 0;
 };
 
 }  // namespace ift::freq

--- a/ift/freq/unicode_frequencies_test.cc
+++ b/ift/freq/unicode_frequencies_test.cc
@@ -45,17 +45,17 @@ TEST(UnicodeFrequenciesTest, ProbabilityFor_MissingFrequency) {
 }
 
 TEST(UnicodeFrequenciesTest, AddAccumulates) {
-  UnicodeFrequencies freq;
+  UnicodeFrequenciesBuilder builder;
 
-  freq.Add(2, 3, 20);
-  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(2, 3), 20.0 / 20.0);
+  builder.Add(2, 3, 20);
+  EXPECT_DOUBLE_EQ(builder.Build().ProbabilityFor(2, 3), 20.0 / 20.0);
 
-  freq.Add(1, 2, 10);
-  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(1, 2), 10.0 / 20.0);
+  builder.Add(1, 2, 10);
+  EXPECT_DOUBLE_EQ(builder.Build().ProbabilityFor(1, 2), 10.0 / 20.0);
 
-  freq.Add(2, 1, 15);
-  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(1, 2), 1.0);
-  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(2, 3), 20.0 / 25.0);
+  builder.Add(2, 1, 15);
+  EXPECT_DOUBLE_EQ(builder.Build().ProbabilityFor(1, 2), 1.0);
+  EXPECT_DOUBLE_EQ(builder.Build().ProbabilityFor(2, 3), 20.0 / 25.0);
 }
 
 TEST(UnicodeFrequenciesTest, CoveredCodepoints) {

--- a/ift/freq/unigram_probability_calculator_test.cc
+++ b/ift/freq/unigram_probability_calculator_test.cc
@@ -12,12 +12,12 @@ using ift::encoder::SubsetDefinition;
 namespace ift::freq {
 
 TEST(UnigramProbabilityCalculatorTest, ComputeProbability) {
-  UnicodeFrequencies frequencies;
-  frequencies.Add(1, 1, 10);
-  frequencies.Add(2, 2, 20);
-  frequencies.Add(3, 3, 5);
+  UnicodeFrequenciesBuilder builder;
+  builder.Add(1, 1, 10);
+  builder.Add(2, 2, 20);
+  builder.Add(3, 3, 5);
 
-  UnigramProbabilityCalculator calculator(std::move(frequencies));
+  UnigramProbabilityCalculator calculator(builder.Build());
 
   SubsetDefinition def1;
   def1.codepoints = {1, 2};
@@ -42,12 +42,12 @@ TEST(UnigramProbabilityCalculatorTest, ComputeProbability) {
 }
 
 TEST(UnigramProbabilityCalculatorTest, ComputeMergedProbability) {
-  UnicodeFrequencies frequencies;
-  frequencies.Add(1, 1, 10);
-  frequencies.Add(2, 2, 20);
-  frequencies.Add(3, 3, 5);
+  UnicodeFrequenciesBuilder builder;
+  builder.Add(1, 1, 10);
+  builder.Add(2, 2, 20);
+  builder.Add(3, 3, 5);
 
-  UnigramProbabilityCalculator calculator(std::move(frequencies));
+  UnigramProbabilityCalculator calculator(builder.Build());
 
   Segment s1{{1}, calculator.ComputeProbability({1})};
   Segment s3{{3}, calculator.ComputeProbability({3})};
@@ -67,10 +67,10 @@ TEST(UnigramProbabilityCalculatorTest, ComputeConjunctiveProbability) {
   Segment s2{{'b'}, ProbabilityBound{0.2, 0.2}};
   Segment s3{{'c'}, ProbabilityBound{0.7, 0.7}};
 
-  UnicodeFrequencies frequencies;
-  frequencies.Add(1, 1, 10);
+  UnicodeFrequenciesBuilder builder;
+  builder.Add(1, 1, 10);
 
-  UnigramProbabilityCalculator calculator(std::move(frequencies));
+  UnigramProbabilityCalculator calculator(builder.Build());
 
   std::vector<ProbabilityBound> bounds{s2.ProbabilityBound()};
   ProbabilityBound bound = calculator.ComputeConjunctiveProbability(bounds);

--- a/util/gen_ift_segmentation_plan.cc
+++ b/util/gen_ift_segmentation_plan.cc
@@ -123,8 +123,16 @@ StatusOr<hb_face_unique_ptr> LoadFont(const char* filename) {
 static Status Analysis(hb_face_t* font,
                        const btree_map<SegmentSet, MergeStrategy>& merge_groups,
                        const GlyphSegmentation& segmentation) {
+
   unsigned group_index = 0;
-  double overall_cost = 0.0;
+
+  double ift_init_cost = 0.0;
+  double non_ift_total_cost = 0.0;
+  double ideal_init_cost = 0.0;
+
+  double ift_patch_cost = 0.0;
+  double ideal_patch_cost = 0.0;
+
   for (const auto& [_, strategy] : merge_groups) {
     if (!strategy.UseCosts()) {
       // Can only evaluate costs for strategies that utilize costs.
@@ -136,21 +144,28 @@ static Status Analysis(hb_face_t* font,
     SegmentationCost cost =
         TRY(segmenter.TotalCost(font, segmentation, *calculator));
 
-    overall_cost += cost.total_cost;
+    if (ift_init_cost == 0.0) {
+      ideal_init_cost = cost.ideal_init_cost;
+      ift_init_cost = cost.ift_init_cost;
+      non_ift_total_cost = cost.non_ift_total_cost;
+    }
 
-    std::cerr << "non_ift_cost_bytes[" << group_index
-              << "] = " << (uint64_t)cost.cost_for_non_segmented << std::endl;
-    std::cerr << "total_cost_bytes[" << group_index
-              << "] = " << (uint64_t)cost.total_cost << std::endl;
+    ift_patch_cost += cost.ift_patch_cost;
+    ideal_patch_cost += cost.ideal_patch_cost;
+
+
+    std::cerr << "ift_cost_bytes[" << group_index
+              << "] = " << (uint64_t)cost.ift_patch_cost << std::endl;
     std::cerr << "ideal_cost_bytes[" << group_index
-              << "] = " << (uint64_t)cost.ideal_cost << std::endl;
+              << "] = " << (uint64_t)cost.ideal_patch_cost << std::endl;
     std::cerr << std::endl;
 
     group_index++;
   }
 
-  std::cerr << "total_cost_across_groups = " << (uint64_t)overall_cost
-            << std::endl;
+  std::cerr << "non_ift_total_cost = " << (uint64_t) non_ift_total_cost << std::endl;
+  std::cerr << "ift_total_cost = " << (uint64_t) (ift_init_cost + ift_patch_cost) << std::endl;
+  std::cerr << "ideal_total_cost = " << (uint64_t) (ideal_init_cost + ideal_patch_cost) << std::endl;
 
   return absl::OkStatus();
 }


### PR DESCRIPTION
- Each group's cost was including the init font cost, so the final total cost would have init font cost added multiple times.
- Reduce memory usage during encoding by eliminating an unneeded map of frequency counts (only probabilities are used by the encoder)