### PR TITLE
Speed up total cost analysis at the end.

### DIFF
--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -38,6 +38,8 @@ cc_library(
     name = "glyph_partition",
     srcs = [
         "glyph_partition.cc",
+    ],
+    hdrs = [
         "glyph_partition.h",
     ],
     deps = [

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -41,6 +41,7 @@ using ift::config::SegmentationPlan;
 using ift::config::SegmentsProto;
 using ift::config::UnmappedGlyphHandling;
 
+using absl::Span;
 using absl::btree_map;
 using absl::btree_set;
 using absl::flat_hash_map;
@@ -583,7 +584,6 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
     merger_name = *mergers[merger_index].Strategy().Name();
   }
 
-  segment_index_t last_merged_segment_index = 0;
   VLOG(0) << "Starting merge selection for merge group " << merger_name
           << std::endl
           << "  " << mergers[merger_index].NumInscopeSegments()
@@ -632,19 +632,14 @@ StatusOr<GlyphSegmentation> ClosureGlyphSegmenter::CodepointToGlyphSegments(
   return absl::InternalError("unreachable");
 }
 
-StatusOr<SegmentationCost> ClosureGlyphSegmenter::TotalCost(
+StatusOr<std::vector<SegmentationCost>> ClosureGlyphSegmenter::TotalCosts(
     hb_face_t* original_face, const GlyphSegmentation& segmentation,
-    const ProbabilityCalculator& probability_calculator) const {
+    Span<const ProbabilityCalculator* const> probability_calculators) const {
   SubsetDefinition non_ift;
   non_ift.Union(segmentation.InitialFontSegment());
 
-  std::vector<Segment> segments;
   for (const auto& def : segmentation.Segments()) {
     non_ift.Union(def);
-
-    auto P = probability_calculator.ComputeProbability(def);
-    Segment s(def, P);
-    segments.push_back(std::move(s));
   }
 
   double init_font_size = TRY(CandidateMerge::Woff2SizeOf(
@@ -652,41 +647,54 @@ StatusOr<SegmentationCost> ClosureGlyphSegmenter::TotalCost(
   double non_ift_font_size =
       TRY(CandidateMerge::Woff2SizeOf(original_face, non_ift, 11));
 
-  // TODO(garretrieger): for the total cost we need to also add in the table
-  // keyed patch costs
-  //                     may want to use the IFT compiler to produce the
-  //                     complete encoding then compute table keyed costs from
-  //                     that (in conjunction) with probability calculations.
-  double total_cost = 0;
-
   // Use highest quality so we get the true cost.
   PatchSizeCacheImpl patch_sizer(original_face, 11);
-  for (const auto& c : segmentation.Conditions()) {
-    double Pc = TRY(c.Probability(segments, probability_calculator));
-    const GlyphSet& gids = segmentation.GidSegments().at(c.activated());
-    double patch_size = (double)TRY(patch_sizer.GetPatchSize(gids));
-    total_cost += Pc * (patch_size + 75);
-  }
 
-  double ideal_cost = 0.0;
-  double incremental_size =
-      non_ift_font_size / (double)non_ift.codepoints.size();
-  double init_font_ideal_size = incremental_size * segmentation.InitialFontSegment().codepoints.size();
-  for (unsigned cp : non_ift.codepoints) {
-    if (segmentation.InitialFontSegment().codepoints.contains(cp)) {
-      continue;
+  std::vector<SegmentationCost> out;
+  for (const ProbabilityCalculator* probability_calculator : probability_calculators) {
+
+    std::vector<Segment> segments;
+    for (const auto& def : segmentation.Segments()) {
+      auto P = probability_calculator->ComputeProbability(def);
+      Segment s(def, P);
+      segments.push_back(std::move(s));
     }
-    double Pcp = probability_calculator.ComputeProbability({cp}).Average();
-    ideal_cost += Pcp * incremental_size;
-  }
 
-  return SegmentationCost{
+    // TODO(garretrieger): for the total cost we need to also add in the table
+    // keyed patch costs
+    //                     may want to use the IFT compiler to produce the
+    //                     complete encoding then compute table keyed costs from
+    //                     that (in conjunction) with probability calculations.
+    double total_cost = 0;
+
+    for (const auto& c : segmentation.Conditions()) {
+      double Pc = TRY(c.Probability(segments, *probability_calculator));
+      const GlyphSet& gids = segmentation.GidSegments().at(c.activated());
+      double patch_size = (double)TRY(patch_sizer.GetPatchSize(gids));
+      total_cost += Pc * (patch_size + 75);
+    }
+
+    double ideal_cost = 0.0;
+    double incremental_size =
+        non_ift_font_size / (double)non_ift.codepoints.size();
+    double init_font_ideal_size = incremental_size * segmentation.InitialFontSegment().codepoints.size();
+    for (unsigned cp : non_ift.codepoints) {
+      if (segmentation.InitialFontSegment().codepoints.contains(cp)) {
+        continue;
+      }
+      double Pcp = probability_calculator->ComputeProbability({cp}).Average();
+      ideal_cost += Pcp * incremental_size;
+    }
+
+    out.push_back(SegmentationCost{
       .ift_init_cost = init_font_size,
       .ift_patch_cost = total_cost,
       .non_ift_total_cost = non_ift_font_size,
       .ideal_init_cost = init_font_ideal_size,
       .ideal_patch_cost = ideal_cost,
-  };
+    });
+  }
+  return out;
 }
 
 Status ClosureGlyphSegmenter::FallbackCost(

--- a/ift/encoder/closure_glyph_segmenter.h
+++ b/ift/encoder/closure_glyph_segmenter.h
@@ -13,6 +13,7 @@
 #include "ift/encoder/merge_strategy.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/freq/probability_calculator.h"
+#include "ift/encoder/patch_size_cache.h"
 
 namespace ift::encoder {
 
@@ -73,9 +74,9 @@ class ClosureGlyphSegmenter {
    * Computes the total cost (expected number of bytes transferred) for a given
    * segmentation with respect to the provided frequency data.
    */
-  absl::StatusOr<SegmentationCost> TotalCost(
+  absl::StatusOr<std::vector<SegmentationCost>> TotalCosts(
       hb_face_t* original_face, const GlyphSegmentation& segmentation,
-      const freq::ProbabilityCalculator& probability_calculator) const;
+      absl::Span<const freq::ProbabilityCalculator* const> probability_calculators) const;
 
   /*
    * Computes the total cost of the fallback patch (expected number of bytes

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -1103,11 +1103,11 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
   ASSERT_TRUE(sc.ok()) << sc;
 
   ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY);
-  SegmentationCost base_cost =
-      *segmenter.TotalCost(roboto.get(), segmentation1, calculator);
-  ASSERT_GT(base_cost.ift_init_cost, 1000);
-  ASSERT_EQ(base_cost.ift_init_cost, base_cost.non_ift_total_cost);
-  ASSERT_EQ(base_cost.ift_init_cost, base_cost.ideal_init_cost);
+  std::vector<SegmentationCost> base_cost =
+      *segmenter.TotalCosts(roboto.get(), segmentation1, {&calculator});
+  ASSERT_GT(base_cost[0].ift_init_cost, 1000);
+  ASSERT_EQ(base_cost[0].ift_init_cost, base_cost[0].non_ift_total_cost);
+  ASSERT_EQ(base_cost[0].ift_init_cost, base_cost[0].ideal_init_cost);
 
   // Add some patches
   GlyphSegmentation segmentation2({'a', 'b', 'c'}, {}, {});
@@ -1125,10 +1125,10 @@ TEST_F(ClosureGlyphSegmenterTest, TotalCost) {
   };
   segmentation2.CopySegments(segments);
 
-  SegmentationCost with_patches_cost =
-      *segmenter.TotalCost(roboto.get(), segmentation2, calculator);
-  ASSERT_GT(with_patches_cost.ift_patch_cost, base_cost.ift_patch_cost);
-  ASSERT_LT(with_patches_cost.ideal_patch_cost, with_patches_cost.ift_patch_cost);
+  std::vector<SegmentationCost> with_patches_cost =
+      *segmenter.TotalCosts(roboto.get(), segmentation2, {&calculator});
+  ASSERT_GT(with_patches_cost[0].ift_patch_cost, base_cost[0].ift_patch_cost);
+  ASSERT_LT(with_patches_cost[0].ideal_patch_cost, with_patches_cost[0].ift_patch_cost);
 }
 
 TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {

--- a/ift/encoder/patch_size_cache.h
+++ b/ift/encoder/patch_size_cache.h
@@ -2,7 +2,6 @@
 #define IFT_ENCODER_PATCH_SIZE_CACHE_H_
 
 #include <cstdint>
-#include <memory>
 
 #include "absl/container/flat_hash_map.h"
 #include "absl/log/log.h"

--- a/util/gen_ift_segmentation_plan.cc
+++ b/util/gen_ift_segmentation_plan.cc
@@ -28,6 +28,7 @@
 #include "ift/encoder/glyph_segmentation.h"
 #include "ift/encoder/merge_strategy.h"
 #include "ift/encoder/subset_definition.h"
+#include "ift/freq/probability_calculator.h"
 #include "ift/freq/unicode_frequencies.h"
 #include "util/auto_config_flags.h"
 
@@ -35,6 +36,7 @@ using ift::config::CLOSURE_ONLY;
 using ift::config::PATCH;
 using ift::config::SegmentationPlan;
 using ift::config::SegmenterConfig;
+using ift::freq::ProbabilityCalculator;
 
 /*
  * Given a code point based segmentation creates an appropriate glyph based
@@ -124,31 +126,41 @@ static Status Analysis(hb_face_t* font,
                        const btree_map<SegmentSet, MergeStrategy>& merge_groups,
                        const GlyphSegmentation& segmentation) {
 
-  unsigned group_index = 0;
 
-  double ift_init_cost = 0.0;
-  double non_ift_total_cost = 0.0;
-  double ideal_init_cost = 0.0;
+  std::vector<const ProbabilityCalculator*> strategy_probability_calculators;
+  std::vector<unsigned> strategy_group_index;
 
-  double ift_patch_cost = 0.0;
-  double ideal_patch_cost = 0.0;
-
+  unsigned i = 0;
   for (const auto& [_, strategy] : merge_groups) {
+    i++;
     if (!strategy.UseCosts()) {
       // Can only evaluate costs for strategies that utilize costs.
       continue;
     }
 
-    auto calculator = strategy.ProbabilityCalculator();
-    ClosureGlyphSegmenter segmenter(11, 11, PATCH, CLOSURE_ONLY);
-    SegmentationCost cost =
-        TRY(segmenter.TotalCost(font, segmentation, *calculator));
+    strategy_group_index.push_back(i - 1);
+    strategy_probability_calculators.push_back(strategy.ProbabilityCalculator());
+  }
 
+  ClosureGlyphSegmenter segmenter(11, 11, PATCH, CLOSURE_ONLY);
+  auto costs = TRY(segmenter.TotalCosts(font, segmentation, strategy_probability_calculators));
+
+  double ift_init_cost = 0.0;
+  double non_ift_total_cost = 0.0;
+  double ideal_init_cost = 0.0;
+  double ift_patch_cost = 0.0;
+  double ideal_patch_cost = 0.0;
+
+
+  i = 0;
+  for (const auto& cost : costs) {
     if (ift_init_cost == 0.0) {
       ideal_init_cost = cost.ideal_init_cost;
       ift_init_cost = cost.ift_init_cost;
       non_ift_total_cost = cost.non_ift_total_cost;
     }
+
+    unsigned group_index = strategy_group_index[i++];
 
     ift_patch_cost += cost.ift_patch_cost;
     ideal_patch_cost += cost.ideal_patch_cost;


### PR DESCRIPTION
- Share a patch size cache between each strategy cost calculation.
- Don't repeat init font and non ift font size calculatations.