### PR TITLE
Performance Optimizations for processing CJK fonts

### DIFF
--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -600,7 +600,7 @@ static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
 }
 
 static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
-  config.set_preprocess_merging_group_size_for_ungrouped(kMinimumGroupSize*3);
+  config.set_preprocess_merging_group_size_for_ungrouped(kMinimumGroupSize * 3);
 
   config.set_unmapped_glyph_handling(MOVE_TO_INIT_FONT);
 

--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -600,7 +600,7 @@ static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
 }
 
 static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
-  config.set_preprocess_merging_group_size_for_ungrouped(kMinimumGroupSize);
+  config.set_preprocess_merging_group_size_for_ungrouped(kMinimumGroupSize*3);
 
   config.set_unmapped_glyph_handling(MOVE_TO_INIT_FONT);
 
@@ -641,6 +641,7 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
   }
 
   ApplyQualityLevelTo(quality, *config.mutable_base_heuristic_config());
+  ApplyQualityLevelTo(quality, *config.mutable_ungrouped_config());
   ApplyQualityLevelTo(quality, *config.mutable_base_cost_config());
 
   for (auto& merge_group : *config.mutable_merge_groups()) {

--- a/ift/config/auto_segmenter_config_test.cc
+++ b/ift/config/auto_segmenter_config_test.cc
@@ -103,7 +103,10 @@ base_cost_config {
   min_group_size: 4
   optimization_cutoff_fraction: 0.005
 }
-preprocess_merging_group_size_for_ungrouped: 4
+ungrouped_config {
+  min_patch_size: 2500
+}
+preprocess_merging_group_size_for_ungrouped: 12
 merge_groups {
   name: "Cyrillic"
   preprocess_merging_group_size: 1

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -357,15 +357,17 @@ StatusOr<ProbabilityBound> ActivationCondition::ProbabilityBound(
 }
 
 StatusOr<double> ActivationCondition::MergedProbability(
-    Span<const Segment> segments, const SegmentSet& merged_segments,
+    Span<const Segment> segments,
+    segment_index_t merged_segment_index,
     const Segment& merged_segment,
     const ProbabilityCalculator& calculator) const {
-  return TRY(MergedProbabilityBound(segments, merged_segments, merged_segment, calculator)).Average();
+  return TRY(MergedProbabilityBound(segments, merged_segment_index, merged_segment, calculator)).Average();
 }
 
 
 StatusOr<ProbabilityBound> ActivationCondition::MergedProbabilityBound(
-    Span<const Segment> segments, const SegmentSet& merged_segments,
+    Span<const Segment> segments,
+    segment_index_t merged_segment_index,
     const Segment& merged_segment,
     const ProbabilityCalculator& calculator) const {
 
@@ -373,17 +375,9 @@ StatusOr<ProbabilityBound> ActivationCondition::MergedProbabilityBound(
     return freq::ProbabilityBound(1.0, 1.0);
   }
 
-  if (merged_segments.empty()) {
-    // No merged segments, means we can just use the normal calculation.
-    return ProbabilityBound(segments, calculator);
-  }
-
-  segment_index_t base = *merged_segments.min();
-  ActivationCondition merged = ReplaceSegments(base, merged_segments);
-
   std::vector<freq::ProbabilityBound> bounds;
-  bool is_conjunctive = merged.conditions_.size() > 1;
-  for (const auto& segment_set : merged.conditions_) {
+  bool is_conjunctive = conditions_.size() > 1;
+  for (const auto& segment_set : conditions_) {
     freq::ProbabilityBound set_bound = freq::ProbabilityBound::Zero();
     if (segment_set.empty()) {
       return absl::InternalError("Unexpected empty disjunctive group.");
@@ -391,14 +385,14 @@ StatusOr<ProbabilityBound> ActivationCondition::MergedProbabilityBound(
       // For a group (s1 OR s2 OR ...), compute the union of their definitions.
       std::vector<const Segment*> union_segments;
       for (unsigned s_index : segment_set) {
-        if (s_index == base) {
+        if (s_index == merged_segment_index) {
           union_segments.push_back(&merged_segment);
         } else {
           union_segments.push_back(&segments[s_index]);
         }
       }
       set_bound = calculator.ComputeMergedProbability(union_segments);
-    } else if (*segment_set.min() ==  base) {
+    } else if (*segment_set.min() ==  merged_segment_index) {
       set_bound = merged_segment.ProbabilityBound();
     } else {
       set_bound = segments[*segment_set.min()].ProbabilityBound();

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -92,6 +92,12 @@ ActivationCondition ActivationCondition::composite_condition(
   return conditions;
 }
 
+ActivationCondition ActivationCondition::clear_exclusive(ActivationCondition&& condition) {
+  ActivationCondition updated(std::move(condition));
+  updated.is_exclusive_ = false;
+  return updated;
+}
+
 static void Simplify(std::vector<SegmentSet>& conditions) {
   if (conditions.size() <= 1) return;
 

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -12,6 +12,7 @@
 #include "ift/encoder/entry_graph.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
+#include "ift/freq/probability_bound.h"
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
 
@@ -30,6 +31,7 @@ using ift::freq::ProbabilityCalculator;
 using ift::proto::GLYPH_KEYED;
 using ift::proto::PatchEncoding;
 using ift::proto::PatchMap;
+using ift::freq::ProbabilityBound;
 
 namespace ift::encoder {
 
@@ -312,8 +314,14 @@ ActivationCondition::ActivationConditionsToPatchMapEntries(
 StatusOr<double> ActivationCondition::Probability(
     Span<const Segment> segments,
     const ProbabilityCalculator& calculator) const {
+  return TRY(this->ProbabilityBound(segments, calculator)).Average();
+}
+
+StatusOr<ProbabilityBound> ActivationCondition::ProbabilityBound(
+    Span<const Segment> segments,
+    const ProbabilityCalculator& calculator) const {
   if (conditions_.empty()) {
-    return 1.0;
+    return freq::ProbabilityBound(1.0, 1.0);
   }
 
   std::vector<freq::ProbabilityBound> bounds;
@@ -334,59 +342,69 @@ StatusOr<double> ActivationCondition::Probability(
     }
 
     if (!is_conjunctive) {
-      return set_bound.Average();
+      return set_bound;
     }
     bounds.push_back(set_bound);
   }
 
-  return calculator.ComputeConjunctiveProbability(bounds).Average();
+  return calculator.ComputeConjunctiveProbability(bounds);
 }
 
 StatusOr<double> ActivationCondition::MergedProbability(
     Span<const Segment> segments, const SegmentSet& merged_segments,
     const Segment& merged_segment,
     const ProbabilityCalculator& calculator) const {
+  return TRY(MergedProbabilityBound(segments, merged_segments, merged_segment, calculator)).Average();
+}
+
+
+StatusOr<ProbabilityBound> ActivationCondition::MergedProbabilityBound(
+    Span<const Segment> segments, const SegmentSet& merged_segments,
+    const Segment& merged_segment,
+    const ProbabilityCalculator& calculator) const {
+
   if (conditions_.empty()) {
-    return 1.0;
+    return freq::ProbabilityBound(1.0, 1.0);
   }
 
-  std::vector<freq::ProbabilityBound> bounds;
-  bool is_conjunctive = conditions_.size() > 1;
-  for (const auto& segment_set : conditions_) {
-    freq::ProbabilityBound set_bound = freq::ProbabilityBound::Zero();
+  if (merged_segments.empty()) {
+    // No merged segments, means we can just use the normal calculation.
+    return ProbabilityBound(segments, calculator);
+  }
 
+  segment_index_t base = *merged_segments.min();
+  ActivationCondition merged = ReplaceSegments(base, merged_segments);
+
+  std::vector<freq::ProbabilityBound> bounds;
+  bool is_conjunctive = merged.conditions_.size() > 1;
+  for (const auto& segment_set : merged.conditions_) {
+    freq::ProbabilityBound set_bound = freq::ProbabilityBound::Zero();
     if (segment_set.empty()) {
       return absl::InternalError("Unexpected empty disjunctive group.");
-    }
-
-    std::vector<const Segment*> union_segments;
-    if (segment_set.intersects(merged_segments)) {
-      // replace all segments in 'merged_segments' with 'merged_segment'.
-      union_segments.push_back(&merged_segment);
-      for (unsigned s : segment_set) {
-        if (!merged_segments.contains(s)) {
-          union_segments.push_back(&segments[s]);
+    } else if (segment_set.size() > 1) {
+      // For a group (s1 OR s2 OR ...), compute the union of their definitions.
+      std::vector<const Segment*> union_segments;
+      for (unsigned s_index : segment_set) {
+        if (s_index == base) {
+          union_segments.push_back(&merged_segment);
+        } else {
+          union_segments.push_back(&segments[s_index]);
         }
       }
-    } else {
-      for (unsigned s : segment_set) {
-        union_segments.push_back(&segments[s]);
-      }
-    }
-
-    if (union_segments.size() > 1) {
       set_bound = calculator.ComputeMergedProbability(union_segments);
+    } else if (*segment_set.min() ==  base) {
+      set_bound = merged_segment.ProbabilityBound();
     } else {
-      set_bound = union_segments[0]->ProbabilityBound();
+      set_bound = segments[*segment_set.min()].ProbabilityBound();
     }
 
     if (!is_conjunctive) {
-      return set_bound.Average();
+      return set_bound;
     }
     bounds.push_back(set_bound);
   }
 
-  return calculator.ComputeConjunctiveProbability(bounds).Average();
+  return calculator.ComputeConjunctiveProbability(bounds);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -101,10 +101,8 @@ class ActivationCondition {
    */
   ift::common::SegmentSet TriggeringSegments() const {
     ift::common::SegmentSet out;
-    for (auto g : conditions_) {
-      for (auto segment_id : g) {
-        out.insert(segment_id);
-      }
+    for (const auto& segments : conditions_) {
+      out.union_set(segments);
     }
     return out;
   }

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -58,6 +58,12 @@ class ActivationCondition {
       absl::Span<const ift::common::SegmentSet> groups, patch_id_t activated,
       bool is_fallback = false);
 
+  /*
+   * Constructs a new condition equal to 'condition' except with the is exclusive flag
+   * cleared.
+   */
+  static ActivationCondition clear_exclusive(ActivationCondition&& condition);
+
   // Returns a new activation condition that activates on (a && b)
   //
   // The new condition uses the values for the other fields

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -6,6 +6,7 @@
 #include "ift/encoder/segment.h"
 #include "ift/encoder/subset_definition.h"
 #include "ift/encoder/types.h"
+#include "ift/freq/probability_bound.h"
 #include "ift/freq/probability_calculator.h"
 #include "ift/proto/patch_encoding.h"
 #include "ift/proto/patch_map.h"
@@ -165,6 +166,10 @@ class ActivationCondition {
   // Important: this makes the assumption that segment probabilies are
   //            independent which means this is only an estimate as this is
   //            likely not true.
+  absl::StatusOr<freq::ProbabilityBound> ProbabilityBound(
+      absl::Span<const Segment> segments,
+      const ift::freq::ProbabilityCalculator& calculator) const;
+
   absl::StatusOr<double> Probability(
       absl::Span<const Segment> segments,
       const ift::freq::ProbabilityCalculator& calculator) const;
@@ -172,6 +177,12 @@ class ActivationCondition {
   // Compute and return the probability that this condition will be activated if
   // it is modified to merge all segments in "merged_segments" into a single
   // segment with "merged_probability".
+  absl::StatusOr<freq::ProbabilityBound> MergedProbabilityBound(
+      absl::Span<const Segment> segments,
+      const ift::common::SegmentSet& merged_segments,
+      const Segment& merged_segment,
+      const ift::freq::ProbabilityCalculator& calculator) const;
+
   absl::StatusOr<double> MergedProbability(
       absl::Span<const Segment> segments,
       const ift::common::SegmentSet& merged_segments,

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -183,13 +183,13 @@ class ActivationCondition {
   // segment with "merged_probability".
   absl::StatusOr<freq::ProbabilityBound> MergedProbabilityBound(
       absl::Span<const Segment> segments,
-      const ift::common::SegmentSet& merged_segments,
+      segment_index_t merged_segment_index,
       const Segment& merged_segment,
       const ift::freq::ProbabilityCalculator& calculator) const;
 
   absl::StatusOr<double> MergedProbability(
       absl::Span<const Segment> segments,
-      const ift::common::SegmentSet& merged_segments,
+      segment_index_t merged_segment_index,
       const Segment& merged_segment,
       const ift::freq::ProbabilityCalculator& calculator) const;
 

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -347,13 +347,14 @@ TEST(ActivationConditionTest, MergedProbability) {
   EXPECT_NEAR(*ActivationCondition::and_segments({0, 1, 2}, 1)
                    .MergedProbability(segments, {1, 2}, merged_segment,
                                       probability_calculator),
-              0.75 * 0.85 * 0.85, 1e-9);
+              0.75 * 0.85, 1e-9); // .. AND 1 AND 2 becomes .. AND 1
 
   // Composite condition
+  // (0 or 1) AND 2 =merge {1, 2}=> (0 or 1)
   EXPECT_NEAR(*ActivationCondition::composite_condition({{0, 1}, {2}}, 1)
                    .MergedProbability(segments, {1, 2}, merged_segment,
                                       probability_calculator),
-              0.90 * 0.85, 1e-9);
+              0.85, 1e-9);
 }
 
 TEST(ActivationConditionTest, True) {

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -310,49 +310,61 @@ TEST(ActivationConditionTest, MergedProbability) {
 
   // Ignores segments that are not present in the condition.
   EXPECT_NEAR(*ActivationCondition::exclusive_segment(0, 1).MergedProbability(
-                  segments, {5}, merged_segment, probability_calculator),
+                  segments, 5, merged_segment, probability_calculator),
               0.75, 1e-9);
   EXPECT_NEAR(*ActivationCondition::or_segments({0, 2}, 1).MergedProbability(
-                  segments, {5}, merged_segment, probability_calculator),
+                  segments, 5, merged_segment, probability_calculator),
               0.80, 1e-9);
   EXPECT_NEAR(*ActivationCondition::and_segments({0, 2}, 1).MergedProbability(
-                  segments, {5}, merged_segment, probability_calculator),
+                  segments, 5, merged_segment, probability_calculator),
               0.75 * 0.25, 1e-9);
 
   // Conjunctive with merge intersection
   // {0} get's replaced with {0 U 1}
 
-  EXPECT_NEAR(*ActivationCondition::and_segments({0, 2}, 1).MergedProbability(
-                  segments, {0, 1}, merged_segment, probability_calculator),
+  EXPECT_NEAR(*ActivationCondition::and_segments({0, 2}, 1)
+            .ReplaceSegments(0, {0, 1})
+            .MergedProbability(
+                  segments, 0, merged_segment, probability_calculator),
               0.85 * 0.25, 1e-9);
 
   // Disjunctive with merge intersection
   // {0} get's replaced with {0 U 1}
-  EXPECT_NEAR(*ActivationCondition::or_segments({0}, 1).MergedProbability(
-                  segments, {0, 1}, merged_segment, probability_calculator),
+  EXPECT_NEAR(*ActivationCondition::or_segments({0}, 1)
+              .ReplaceSegments(0, {0, 1})
+              .MergedProbability(
+                  segments, 0, merged_segment, probability_calculator),
               0.85, 1e-9);
-  EXPECT_NEAR(*ActivationCondition::or_segments({1}, 1).MergedProbability(
-                  segments, {0, 1}, merged_segment, probability_calculator),
+  EXPECT_NEAR(*ActivationCondition::or_segments({1}, 1)
+    .ReplaceSegments(0, {0, 1})
+    .MergedProbability(
+                  segments, 0, merged_segment, probability_calculator),
               0.85, 1e-9);
-  EXPECT_NEAR(*ActivationCondition::or_segments({0, 1}, 1).MergedProbability(
-                  segments, {0, 1}, merged_segment, probability_calculator),
+  EXPECT_NEAR(*ActivationCondition::or_segments({0, 1}, 1)
+    .ReplaceSegments(0, {0, 1})
+    .MergedProbability(
+                  segments, 0, merged_segment, probability_calculator),
               0.85, 1e-9);
 
   // Disjunctive with partial merge intersection
-  EXPECT_NEAR(*ActivationCondition::or_segments({0, 2}, 1).MergedProbability(
-                  segments, {0, 1}, merged_segment, probability_calculator),
+  EXPECT_NEAR(*ActivationCondition::or_segments({0, 2}, 1)
+    .ReplaceSegments(0, {0, 1})
+    .MergedProbability(
+                  segments, 0, merged_segment, probability_calculator),
               0.95, 1e-9);
 
   // Conjunctive with partial merge intersection
   EXPECT_NEAR(*ActivationCondition::and_segments({0, 1, 2}, 1)
-                   .MergedProbability(segments, {1, 2}, merged_segment,
+                    .ReplaceSegments(2, {1, 2})
+                   .MergedProbability(segments, 2, merged_segment,
                                       probability_calculator),
               0.75 * 0.85, 1e-9); // .. AND 1 AND 2 becomes .. AND 1
 
   // Composite condition
   // (0 or 1) AND 2 =merge {1, 2}=> (0 or 1)
   EXPECT_NEAR(*ActivationCondition::composite_condition({{0, 1}, {2}}, 1)
-                   .MergedProbability(segments, {1, 2}, merged_segment,
+  .ReplaceSegments(1, {1, 2})
+                   .MergedProbability(segments, 1, merged_segment,
                                       probability_calculator),
               0.85, 1e-9);
 }

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -5,7 +5,6 @@
 #include <utility>
 #include <vector>
 
-#include "absl/container/btree_map.h"
 #include "absl/log/log.h"
 #include "absl/status/status.h"
 #include "absl/status/statusor.h"
@@ -28,8 +27,8 @@
 
 namespace ift::encoder {
 
-using absl::btree_map;
-using absl::btree_set;
+using absl::flat_hash_set;
+using absl::flat_hash_map;
 using absl::Status;
 using absl::StatusOr;
 using ift::GlyphKeyedDiff;
@@ -197,8 +196,6 @@ static void MergeSegments(const Merger& merger, const SegmentSet& segments,
 static StatusOr<const GlyphSet*> ConditionToGlyphs(
     const Merger& merger, const ActivationCondition& condition) {
 
-  // TODO XXXXX this is hot in a profile (because of btree), can we use flat_hash? or improve speed?
-  //             ie. keep a second condition_and_glyphs mapping in hash set?
   const auto& conditions_and_glyphs =
       merger.Context().glyph_groupings.ConditionsAndGlyphs();
   auto it = conditions_and_glyphs.find(condition);
@@ -206,28 +203,27 @@ static StatusOr<const GlyphSet*> ConditionToGlyphs(
     return absl::InternalError(
         "Condition which should be present wasn't found.");
   }
-
   return &it->second;
 }
 
-// TODO XXXXX this is hot in a profile (because of btree), can we use flat_hash? or improve speed?
 static Status AddConditionAndGlyphs(
     const Merger& merger, const ActivationCondition& condition,
-    btree_map<ActivationCondition, const GlyphSet*>& conditions) {
-  auto existing = conditions.lower_bound(condition);
-  if (existing != conditions.end() && existing->first == condition) {
+    flat_hash_map<ActivationCondition, const GlyphSet*>& conditions) {
+
+  auto existing = conditions.find(condition);
+  if (existing != conditions.end()) {
     // already exists.
     return absl::OkStatus();
   }
 
-  conditions.emplace_hint(existing, condition,
-                          TRY(ConditionToGlyphs(merger, condition)));
+  conditions.emplace(condition,
+                     TRY(ConditionToGlyphs(merger, condition)));
   return absl::OkStatus();
 }
 
 static Status FindModifiedConditions(
     const Merger& merger, const SegmentSet& merged_segments,
-    btree_map<ActivationCondition, const GlyphSet*>& modified_conditions) {
+    flat_hash_map<ActivationCondition, const GlyphSet*>& modified_conditions) {
   for (auto s : merged_segments) {
     for (const auto& c :
          merger.Context().glyph_groupings.TriggeringSegmentToConditions(s)) {
@@ -268,12 +264,12 @@ StatusOr<uint32_t> CandidateMerge::Woff2SizeOf(hb_face_t* original_face,
 }
 
 // Finds the set of patches which intersect gids.
-static btree_map<ActivationCondition, GlyphSet> PatchesWithGlyphs(
+static flat_hash_map<ActivationCondition, GlyphSet> PatchesWithGlyphs(
     const SegmentationContext& context, const GlyphSet& gids) {
   // To more efficiently target our search we can use the glyph_condition_set to
   // locate conditions that intersect with gids.
   GlyphSet fallback_glyphs = context.glyph_groupings.UnmappedGlyphs();
-  btree_set<ActivationCondition> conditions_of_interest;
+  flat_hash_set<ActivationCondition> conditions_of_interest;
   for (glyph_id_t gid : gids) {
     if (fallback_glyphs.contains(gid)) {
       // Fallback glyphs are handled separately at the end since the
@@ -290,7 +286,7 @@ static btree_map<ActivationCondition, GlyphSet> PatchesWithGlyphs(
     conditions_of_interest.insert(*result);
   }
 
-  btree_map<ActivationCondition, GlyphSet> result;
+  flat_hash_map<ActivationCondition, GlyphSet> result;
   for (const auto& condition : conditions_of_interest) {
     result.insert(std::make_pair(
         condition,
@@ -506,7 +502,7 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   // conditions that intersect merged_segments.
   //
   // Map value is the glyphs associated with condition.
-  btree_map<ActivationCondition, const GlyphSet*> modified_conditions;
+  flat_hash_map<ActivationCondition, const GlyphSet*> modified_conditions;
 
   TRYV(FindModifiedConditions(merger, merged_segments, modified_conditions));
 
@@ -521,7 +517,7 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
     uint32_t largest_patch_size = 0;
     uint32_t combined_patch_size = 0;
   };
-  btree_map<ActivationCondition, Info> new_conditions;
+  flat_hash_map<ActivationCondition, Info> new_conditions;
 
   segment_index_t base = *merged_segments.min();
   const auto& segments = merger.Context().SegmentationInfo().Segments();

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -232,9 +232,7 @@ static Status FindModifiedConditions(
         continue;
       }
 
-      if (c.TriggeringSegments().intersects(merged_segments)) {
-        TRYV(AddConditionAndGlyphs(merger, c, modified_conditions));
-      }
+      TRYV(AddConditionAndGlyphs(merger, c, modified_conditions));
     }
   }
 

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -486,12 +486,12 @@ StatusOr<double> CandidateMerge::ComputeBestCaseInitFontCostDelta(
   return cost_delta;
 }
 
+template<bool best_case>
 StatusOr<double> CandidateMerge::ComputeCostDelta(
       Merger& merger,
       const SegmentSet& merged_segments,
       const Segment& merged_segment,
-      std::optional<GlyphSet> exclusive_gids,
-      bool best_case
+      std::optional<GlyphSet> exclusive_gids
     ) {
 
   if (merged_segments.size() <= 1) {
@@ -518,6 +518,7 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
     uint32_t combined_patch_size = 0;
   };
   flat_hash_map<ActivationCondition, Info> new_conditions;
+  new_conditions.reserve(modified_conditions.size());
 
   segment_index_t base = *merged_segments.min();
   const auto& segments = merger.Context().SegmentationInfo().Segments();
@@ -526,9 +527,9 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
     ActivationCondition updated = condition.ReplaceSegments(base, merged_segments);
     if (updated.IsExclusive()) {
       // Clear is exclusive flag so that de-dup happens properly
-      updated = ActivationCondition::composite_condition(updated.conditions(), 0);
+      updated = ActivationCondition::clear_exclusive(std::move(updated));
     }
-    auto [it, did_insert] = new_conditions.try_emplace(updated);
+    auto [it, did_insert] = new_conditions.try_emplace(std::move(updated));
 
     auto& info = it->second;
     if (did_insert) {
@@ -728,8 +729,8 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
     // Before doing a full assessment check a "best case" cost delta.
     // If that doesn't beat the current smallest there's no need to
     // do more indepth analysis.
-    double best_case_delta = TRY(ComputeCostDelta(
-        merger, segments_to_merge_with_base, merged_segment, std::nullopt, true));
+    double best_case_delta = TRY(ComputeCostDelta<true>(
+        merger, segments_to_merge_with_base, merged_segment, std::nullopt));
     if (best_case_delta >= best_merge_candidate->CostDelta()) {
       // We can't possibly beat the current lowest delta.
       return std::nullopt;
@@ -782,8 +783,8 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
   double cost_delta = 0.0;
   if (merger.Strategy().UseCosts()) {
     // Cost delta values are only needed when using cost based merge strategy.
-    cost_delta = TRY(ComputeCostDelta(merger, segments_to_merge_with_base,
-                                      merged_segment, exclusive_gids, false));
+    cost_delta = TRY(ComputeCostDelta<false>(merger, segments_to_merge_with_base,
+                                      merged_segment, exclusive_gids));
   }
 
   if (best_merge_candidate.has_value() &&

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -194,8 +194,11 @@ static void MergeSegments(const Merger& merger, const SegmentSet& segments,
   base.SetProbability(bound);
 }
 
-static StatusOr<uint32_t> ConditionToPatchSize(
+static StatusOr<const GlyphSet*> ConditionToGlyphs(
     const Merger& merger, const ActivationCondition& condition) {
+
+  // TODO XXXXX this is hot in a profile (because of btree), can we use flat_hash? or improve speed?
+  //             ie. keep a second condition_and_glyphs mapping in hash set?
   const auto& conditions_and_glyphs =
       merger.Context().glyph_groupings.ConditionsAndGlyphs();
   auto it = conditions_and_glyphs.find(condition);
@@ -204,13 +207,13 @@ static StatusOr<uint32_t> ConditionToPatchSize(
         "Condition which should be present wasn't found.");
   }
 
-  const GlyphSet& glyphs = it->second;
-  return TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs));
+  return &it->second;
 }
 
-static Status AddConditionAndPatchSize(
+// TODO XXXXX this is hot in a profile (because of btree), can we use flat_hash? or improve speed?
+static Status AddConditionAndGlyphs(
     const Merger& merger, const ActivationCondition& condition,
-    btree_map<ActivationCondition, uint32_t>& conditions) {
+    btree_map<ActivationCondition, const GlyphSet*>& conditions) {
   auto existing = conditions.lower_bound(condition);
   if (existing != conditions.end() && existing->first == condition) {
     // already exists.
@@ -218,14 +221,13 @@ static Status AddConditionAndPatchSize(
   }
 
   conditions.emplace_hint(existing, condition,
-                          TRY(ConditionToPatchSize(merger, condition)));
+                          TRY(ConditionToGlyphs(merger, condition)));
   return absl::OkStatus();
 }
 
 static Status FindModifiedConditions(
     const Merger& merger, const SegmentSet& merged_segments,
-    btree_map<ActivationCondition, uint32_t>& removed_conditions,
-    btree_map<ActivationCondition, uint32_t>& modified_conditions) {
+    btree_map<ActivationCondition, const GlyphSet*>& modified_conditions) {
   for (auto s : merged_segments) {
     for (const auto& c :
          merger.Context().glyph_groupings.TriggeringSegmentToConditions(s)) {
@@ -234,15 +236,8 @@ static Status FindModifiedConditions(
         continue;
       }
 
-      auto condition_segments = c.TriggeringSegments();
-      if (condition_segments.is_subset_of(merged_segments)) {
-        TRYV(AddConditionAndPatchSize(merger, c, removed_conditions));
-        continue;
-      }
-
-      condition_segments.intersect(merged_segments);
-      if (!condition_segments.empty()) {
-        TRYV(AddConditionAndPatchSize(merger, c, modified_conditions));
+      if (c.TriggeringSegments().intersects(merged_segments)) {
+        TRYV(AddConditionAndGlyphs(merger, c, modified_conditions));
       }
     }
   }
@@ -495,93 +490,73 @@ StatusOr<double> CandidateMerge::ComputeBestCaseInitFontCostDelta(
   return cost_delta;
 }
 
-static std::optional<double> ComputeMergedSizeReduction(
-    uint32_t new_patch_size,
-    const btree_map<ActivationCondition, uint32_t>& removed_conditions) {
-  int32_t total_removed_size = 0;
-  int32_t largest_size = 0;
-  for (const auto& [_, removed_size] : removed_conditions) {
-    total_removed_size += removed_size;
-    largest_size = std::max((int32_t)removed_size, largest_size);
-  }
-
-  int32_t extra_raw = total_removed_size - largest_size;
-  int32_t extra_actual = ((int32_t)new_patch_size) - largest_size;
-  if (extra_raw == 0) {
-    return std::nullopt;
-  }
-  return (double)extra_actual / (double)extra_raw;
-}
-
 StatusOr<double> CandidateMerge::ComputeCostDelta(
-    Merger& merger, const SegmentSet& merged_segments,
-    const Segment& merged_segment,
-    std::optional<uint32_t> maybe_new_patch_size) {
-  // TODO(garretrieger): the accuracy of this can be improved by factoring
-  // in the new exclusive glyph set for the merged segment. These glyphs
-  // can be subtracted from any existing patches that contain them.
-  // We'll also need to check against fallback glyphs (there's a possibility
-  // some of them will be moved into the new merged patch)
-  const uint32_t per_request_overhead = merger.Strategy().NetworkOverheadCost();
+      Merger& merger,
+      const SegmentSet& merged_segments,
+      const Segment& merged_segment,
+      std::optional<GlyphSet> exclusive_gids,
+      bool best_case
+    ) {
 
-  // These are conditions which will be removed by appying the merge.
-  // A condition is removed if it is a subset of the merged_segments.
+  if (merged_segments.size() <= 1) {
+    return 0;
+  }
+
+  // These are conditions which will be modified by applying the merge. These are
+  // conditions that intersect merged_segments.
   //
-  // Map value is the size of the patch associated with the condition.
-  btree_map<ActivationCondition, uint32_t> removed_conditions;
+  // Map value is the glyphs associated with condition.
+  btree_map<ActivationCondition, const GlyphSet*> modified_conditions;
 
-  // These are conditions which will be modified, but not removed
-  // by applying the merge. These are conditions that intersect
-  // but are not a subset of merged_segments.
+  TRYV(FindModifiedConditions(merger, merged_segments, modified_conditions));
+
+  // new_conditions is modified conditions updated to apply the segment merging.
+  // May have less conditions than modified as multiple conditions may merge together
+  // as a result of updating their segments.
   //
-  // Map value is the size of the patch associated with the condition.
-  btree_map<ActivationCondition, uint32_t> modified_conditions;
+  // Map value is the set of glyphs and probability associated with the new condition.
+  struct Info {
+    GlyphSet glyphs;
+    double probability = 0.0;
+    uint32_t largest_patch_size = 0;
+    uint32_t combined_patch_size = 0;
+  };
+  btree_map<ActivationCondition, Info> new_conditions;
 
-  TRYV(FindModifiedConditions(merger, merged_segments, removed_conditions,
-                              modified_conditions));
+  segment_index_t base = *merged_segments.min();
+  const auto& segments = merger.Context().SegmentationInfo().Segments();
+  const auto* calculator = merger.Strategy().ProbabilityCalculator();
+  for (const auto& [condition, glyphs] : modified_conditions) {
+    ActivationCondition updated = condition.ReplaceSegments(base, merged_segments);
+    if (updated.IsExclusive()) {
+      // Clear is exclusive flag so that de-dup happens properly
+      updated = ActivationCondition::composite_condition(updated.conditions(), 0);
+    }
+    auto [it, did_insert] = new_conditions.try_emplace(updated);
 
-  uint32_t new_patch_size = 0;
-  if (maybe_new_patch_size.has_value()) {
-    new_patch_size = *maybe_new_patch_size;
-    if (merger.ShouldRecordMergedSizeReductions()) {
-      std::optional<double> reduction =
-          ComputeMergedSizeReduction(new_patch_size, removed_conditions);
-      if (reduction.has_value()) {
-        merger.RecordMergedSizeReduction(*reduction);
-      }
+    auto& info = it->second;
+    if (did_insert) {
+      // Because we haven't actuated the merge yet (segments does not reflect it),
+      // MergedProbability() is needed to correctly compute the new probability.
+      info.probability = TRY(condition.MergedProbability(segments, merged_segments,
+                                       merged_segment, *calculator));
     }
-  } else {
-    // In the best case the merged patch size is equal to that of the largest
-    // removed patch, plus the data of all other removed patches reduced by a
-    // configured fraction.
-    uint32_t total_removed_size = 0;
-    uint32_t largest_size = 0;
-    for (const auto& [_, removed_size] : removed_conditions) {
-      total_removed_size += removed_size;
-      largest_size = std::max(removed_size, largest_size);
+
+    if (!best_case) {
+      info.glyphs.union_set(*glyphs);
     }
-    uint32_t extra = total_removed_size - largest_size;
-    extra = std::max(
-        (uint32_t)(extra * merger.Strategy().BestCaseSizeReductionFraction()),
-        Merger::BEST_CASE_MERGE_SIZE_DELTA);
-    new_patch_size = largest_size + extra;
+
+    uint32_t patch_size = TRY(merger.Context().patch_size_cache->GetPatchSize(*glyphs));
+    info.largest_patch_size = std::max(info.largest_patch_size, patch_size);
+    info.combined_patch_size += patch_size;
   }
 
   double cost_delta = 0.0;
-  VLOG(1) << "cost_delta for merge of " << merged_segments.ToString() << " =";
-  // Merge will introduce a new patch (merged_segment) with size
-  // "new_patch_size", add the associated cost.
-  double p = merged_segment.Probability();
-  double s = new_patch_size + per_request_overhead;
-  cost_delta += p * s;
-  VLOG(1) << "    + (" << p << " * " << s << ") -> " << cost_delta
-          << " [merged patch]";
 
-  // Now we remove all of the cost associated with segments that are either
-  // removed or modified.
-  const auto& segments = merger.Context().SegmentationInfo().Segments();
-  const auto* calculator = merger.Strategy().ProbabilityCalculator();
-  for (const auto& [c, size] : removed_conditions) {
+  // Remove cost associate within any modified conditions patch pairs.
+  const uint32_t per_request_overhead = merger.Strategy().NetworkOverheadCost();
+  for (const auto& [c, glyphs] : modified_conditions) {
+    uint32_t size = TRY(merger.Context().patch_size_cache->GetPatchSize(*glyphs));
     double p = TRY(c.Probability(segments, *calculator));
     double s = (size + per_request_overhead);
     double d = p * s;
@@ -589,43 +564,66 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
     VLOG(1) << "    - (" << p << " * " << s << ") -> " << d
             << " [removed patch " << c.ToString() << "]";
   }
-  for (const auto& [c, size] : modified_conditions) {
-    double p = TRY(c.Probability(segments, *calculator));
-    double s = size + per_request_overhead;
-    double d = p * s;
-    VLOG(1) << "    - (" << p << " * " << s << " ) -> " << d
-            << " [modified patch " << c.ToString() << "]";
-    cost_delta -= d;
-  }
 
-  // TODO(garretrieger): rework this to account for glyphs added via closure to
-  // the new exclusive patch.
-  //  - A new exclusive patch is introduced with a known set of glyphs.
-  //  - Patches that are effected are either those with merge segments in their
-  //  conditions.
-  //  - Or those containing glyphs that are in the new patch (includes
-  //  fallback), this part would be new.
-  //  - For those that intersect the new exclusive glyphs, we need to either
-  //  remove them or
-  //    compute new size as a result of glyph removal.
-  //  - An index from gid -> activation condition would be useful here.
-  //    Can be done currently by going gid -> (via glyph condition set) segments
-  //    -> (via triggering segments) conditions, but that will currently over
-  //    select conditions.
-
-  // Lastly add back the costs associated with the modified version of each
-  // segment.
-  for (const auto& [c, size] : modified_conditions) {
+  // Add in cost associated within the new conditions patch pairs.
+  bool fallback_changed = false;
+  for (auto& [c, info] : new_conditions) {
     // For modified conditions we assume the associated patch size does not
     // change, only the probability associated with the condition changes.
-    double d = TRY(c.MergedProbability(segments, merged_segments,
-                                       merged_segment, *calculator)) *
-               (size + per_request_overhead);
-    VLOG(1) << "    + " << d << " [modified patch " << c.ToString() << "]";
+    double p = info.probability;
+
+    uint32_t size = 0;
+    if (best_case) {
+      uint32_t extra = info.combined_patch_size - info.largest_patch_size;
+      extra = std::max(
+        (uint32_t)(extra * merger.Strategy().BestCaseSizeReductionFraction()),
+        Merger::BEST_CASE_MERGE_SIZE_DELTA);
+      size = info.largest_patch_size + extra;
+    } else {
+      if (exclusive_gids.has_value()) {
+        // When we do not have complete glyph conditions then exclusive_gids
+        // provides a hint at which glyphs will end up in the exclusive patch
+        // after the merge, incorporate them into the size calculation here.
+        // Remove them from all other patches and place them into the exclusive
+        // patch.
+        info.glyphs.subtract(*exclusive_gids);
+        if (c.IsUnitary()) {
+          info.glyphs.union_set(*exclusive_gids);
+          if (merger.Context().glyph_groupings.UnmappedGlyphs().intersects(*exclusive_gids)) {
+            fallback_changed = true;
+          }
+        }
+      }
+      size = TRY(merger.Context().patch_size_cache->GetPatchSize(info.glyphs));
+      if (merger.ShouldRecordMergedSizeReductions()) {
+        int32_t extra_raw = info.combined_patch_size - info.largest_patch_size;
+        int32_t extra_actual = ((int32_t)size) - info.largest_patch_size;
+        if (extra_raw != 0.0)  {
+          merger.RecordMergedSizeReduction((double)extra_actual / (double)extra_raw);
+        }
+      }
+    }
+
+    double s = (size + per_request_overhead);
+    double d = p * s;
+    VLOG(1) << "    + (" << p << " * " << s << ") -> " << d
+            << " [new patch " << c.ToString() << "]";
     cost_delta += d;
   }
-  VLOG(1) << "    = " << cost_delta;
 
+  if (fallback_changed) {
+    GlyphSet new_fallback = merger.Context().glyph_groupings.UnmappedGlyphs();
+    new_fallback.subtract(*exclusive_gids);
+
+    // Fallback is always needed with 100% probability so delta is just the size difference (new - old)
+    double diff = ((double) TRY(merger.Context().patch_size_cache->GetPatchSize(new_fallback)))
+      - ((double) TRY(merger.Context().patch_size_cache->GetPatchSize(merger.Context().glyph_groupings.UnmappedGlyphs())));
+    VLOG(1) << "    + " << diff
+            << " [fallback delta]";
+    cost_delta += diff;
+  }
+
+  VLOG(1) << "    = " << cost_delta;
   return cost_delta;
 }
 
@@ -639,6 +637,8 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
   // 3. Add a new combined patch that contains all of the glyphs of 1 + 2.
   //    New condition is {base} union {merged}, with corresponding new
   //    probability.
+
+  // TODO XXXXX review this implementation wrt to dep graph glyph conditions.
 
   double network_overhead = merger.Strategy().NetworkOverheadCost();
   double base_patch_size =
@@ -694,6 +694,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
     Merger& merger, segment_index_t base_segment_index,
     const SegmentSet& segments_to_merge_,
     const std::optional<CandidateMerge>& best_merge_candidate) {
+
   if (!merger.Strategy().UseCosts() &&
       WouldMixFeaturesAndCodepoints(merger.Context().SegmentationInfo(),
                                     base_segment_index, segments_to_merge_)) {
@@ -732,7 +733,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
     // If that doesn't beat the current smallest there's no need to
     // do more indepth analysis.
     double best_case_delta = TRY(ComputeCostDelta(
-        merger, segments_to_merge_with_base, merged_segment, std::nullopt));
+        merger, segments_to_merge_with_base, merged_segment, std::nullopt, true));
     if (best_case_delta >= best_merge_candidate->CostDelta()) {
       // We can't possibly beat the current lowest delta.
       return std::nullopt;
@@ -753,25 +754,28 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
   }
 
   uint32_t new_patch_size = 0;
-  if (!segments_to_merge_are_inert) {
-    // TODO(garretrieger): XXXX utilize and/or_gids to improve the cost
-    // computation.
-    GlyphSet and_gids, or_gids, exclusive_gids;
-    TRYV(merger.Context().AnalyzeSegment(segments_to_merge_with_base, and_gids,
-                                         or_gids, exclusive_gids));
+  std::optional<GlyphSet> exclusive_gids;
+  if (!merger.Strategy().UseCosts() || merger.Context().GetConditionAnalysisMode() != config::DEP_GRAPH_ONLY) {
+    if (!segments_to_merge_are_inert) {
+      // When we're not in pure depgraph mode then glyph conditions are incomplete.
+      // To help improve accuracy run a closure to find the new set of exclusive
+      // glyphs associated with the merge and incorporate that into the cost calculations.
+      GlyphSet and_gids, or_gids;
+      exclusive_gids = GlyphSet {};
+      TRYV(merger.Context().AnalyzeSegment(segments_to_merge_with_base, and_gids,
+                                           or_gids, *exclusive_gids));
+    } else {
+      // When the segments being added to base are all inert then we can assume
+      // the merged patch is just a combination of the glyphs from the base and
+      // the input segments. Since the segments being added are intert we know
+      // that they won't interact with base and will just bring along their own
+      // glyphs.
+      exclusive_gids = gid_conditions_to_update;
+      exclusive_gids->union_set(
+          merger.Context().glyph_groupings.ExclusiveGlyphs(base_segment_index));
+    }
     new_patch_size =
-        TRY(merger.Context().patch_size_cache->GetPatchSize(exclusive_gids));
-  } else {
-    // When the segments being added to base are all inert then we can assume
-    // the merged patch is just a combination of the glyphs from the base and
-    // the input segments. Since the segments being added are intert we know
-    // that they won't interact with base and will just bring along their own
-    // glyphs.
-    GlyphSet merged_glyphs = gid_conditions_to_update;
-    merged_glyphs.union_set(
-        merger.Context().glyph_groupings.ExclusiveGlyphs(base_segment_index));
-    new_patch_size =
-        TRY(merger.Context().patch_size_cache->GetPatchSize(merged_glyphs));
+          TRY(merger.Context().patch_size_cache->GetPatchSize(*exclusive_gids));
   }
 
   if (!merger.Strategy().UseCosts() &&
@@ -783,7 +787,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
   if (merger.Strategy().UseCosts()) {
     // Cost delta values are only needed when using cost based merge strategy.
     cost_delta = TRY(ComputeCostDelta(merger, segments_to_merge_with_base,
-                                      merged_segment, new_patch_size));
+                                      merged_segment, exclusive_gids, false));
   }
 
   if (best_merge_candidate.has_value() &&

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -529,13 +529,13 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
       // Clear is exclusive flag so that de-dup happens properly
       updated = ActivationCondition::clear_exclusive(std::move(updated));
     }
-    auto [it, did_insert] = new_conditions.try_emplace(std::move(updated));
+    auto [it, did_insert] = new_conditions.try_emplace(updated);
 
     auto& info = it->second;
     if (did_insert) {
       // Because we haven't actuated the merge yet (segments does not reflect it),
       // MergedProbability() is needed to correctly compute the new probability.
-      info.probability = TRY(condition.MergedProbability(segments, merged_segments,
+      info.probability = TRY(updated.MergedProbability(segments, base,
                                        merged_segment, *calculator));
     }
 

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -193,46 +193,28 @@ static void MergeSegments(const Merger& merger, const SegmentSet& segments,
   base.SetProbability(bound);
 }
 
-static StatusOr<const GlyphSet*> ConditionToGlyphs(
-    const Merger& merger, const ActivationCondition& condition) {
-
-  const auto& conditions_and_glyphs =
-      merger.Context().glyph_groupings.ConditionsAndGlyphs();
-  auto it = conditions_and_glyphs.find(condition);
-  if (it == conditions_and_glyphs.end()) {
-    return absl::InternalError(
-        "Condition which should be present wasn't found.");
-  }
-  return &it->second;
-}
-
-static Status AddConditionAndGlyphs(
-    const Merger& merger, const ActivationCondition& condition,
-    flat_hash_map<ActivationCondition, const GlyphSet*>& conditions) {
-
-  auto existing = conditions.find(condition);
-  if (existing != conditions.end()) {
-    // already exists.
-    return absl::OkStatus();
-  }
-
-  conditions.emplace(condition,
-                     TRY(ConditionToGlyphs(merger, condition)));
-  return absl::OkStatus();
-}
-
 static Status FindModifiedConditions(
     const Merger& merger, const SegmentSet& merged_segments,
     flat_hash_map<ActivationCondition, const GlyphSet*>& modified_conditions) {
+  const auto& groupings = merger.Context().glyph_groupings;
+  const auto& conditions_and_glyphs = groupings.ConditionsAndGlyphs();
+
   for (auto s : merged_segments) {
-    for (const auto& c :
-         merger.Context().glyph_groupings.TriggeringSegmentToConditions(s)) {
+    for (const auto& c : groupings.TriggeringSegmentToConditions(s)) {
       if (c.IsFallback()) {
         // Ignore fallback for this analysis.
         continue;
       }
 
-      TRYV(AddConditionAndGlyphs(merger, c, modified_conditions));
+      auto [it, inserted] = modified_conditions.try_emplace(c, nullptr);
+      if (inserted) {
+        auto glyph_it = conditions_and_glyphs.find(c);
+        if (glyph_it == conditions_and_glyphs.end()) {
+          return absl::InternalError(
+              "Condition which should be present wasn't found.");
+        }
+        it->second = &glyph_it->second;
+      }
     }
   }
 
@@ -325,18 +307,16 @@ StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
   VLOG(1) << "cost_delta for move of glyphs " << moved_glyphs.ToString()
           << " to the initial font =";
 
-  // TODO(garretrieger): if the segmenter is configured to place fallback glyphs
-  // in
-  //  the init font we might consider doing this computation with that
-  //  assumption built in. Compute font sizes with the fallback moved and then
-  //  don't do a delta for the fallback patch.
-
   // For this analysis we only care about the glyph data size in the initial
   // font since all 'no glyph' data cost will be incurred via table keyed
   // patches or in the initial font and thus isn't relevant to whether the gids
   // are in the initial font or a patch. So we utilize the glyph keyed patch
   // size of the init font closure as a proxy to measure the cost of glyph data
   // in the initial font.
+
+  // TODO(garretrieger): XXXXX figure out which segments are removed as a result
+  // of the init font change. Then compute modified patch deltas similar to
+  // ComputeCostDelta but doing segment removal instead of replacement.
 
   // Moving glyphs to the initial font has the following affects:
   // 1. The initial font subset definition is updated to included moved_glyphs.
@@ -519,49 +499,50 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   new_conditions.reserve(modified_conditions.size());
 
   segment_index_t base = *merged_segments.min();
-  const auto& segments = merger.Context().SegmentationInfo().Segments();
+  const auto& context = merger.Context();
+  const auto& patch_size_cache = context.patch_size_cache;
+  const auto& segments = context.SegmentationInfo().Segments();
   const auto* calculator = merger.Strategy().ProbabilityCalculator();
+  double cost_delta = 0.0;
+  const uint32_t per_request_overhead = merger.Strategy().NetworkOverheadCost();
   for (const auto& [condition, glyphs] : modified_conditions) {
-    ActivationCondition updated = condition.ReplaceSegments(base, merged_segments);
+    uint32_t patch_size =
+        TRY(patch_size_cache->GetPatchSize(*glyphs));
+    double p = TRY(condition.Probability(segments, *calculator));
+    double d = p * (patch_size + per_request_overhead);
+    cost_delta -= d;
+    VLOG(1) << "    - (" << p << " * " << (patch_size + per_request_overhead)
+            << ") -> " << d << " [removed patch " << condition.ToString()
+            << "]";
+
+    ActivationCondition updated =
+        condition.ReplaceSegments(base, merged_segments);
     if (updated.IsExclusive()) {
       // Clear is exclusive flag so that de-dup happens properly
       updated = ActivationCondition::clear_exclusive(std::move(updated));
     }
-    auto [it, did_insert] = new_conditions.try_emplace(updated);
+    auto [it, did_insert] = new_conditions.try_emplace(std::move(updated));
 
     auto& info = it->second;
     if (did_insert) {
-      // Because we haven't actuated the merge yet (segments does not reflect it),
-      // MergedProbability() is needed to correctly compute the new probability.
-      info.probability = TRY(updated.MergedProbability(segments, base,
-                                       merged_segment, *calculator));
+      // Because we haven't actuated the merge yet (segments does not reflect
+      // it), MergedProbability() is needed to correctly compute the new
+      // probability.
+      info.probability = TRY(it->first.MergedProbability(
+          segments, base, merged_segment, *calculator));
     }
 
     if (!best_case) {
       info.glyphs.union_set(*glyphs);
     }
 
-    uint32_t patch_size = TRY(merger.Context().patch_size_cache->GetPatchSize(*glyphs));
     info.largest_patch_size = std::max(info.largest_patch_size, patch_size);
     info.combined_patch_size += patch_size;
   }
 
-  double cost_delta = 0.0;
-
-  // Remove cost associate within any modified conditions patch pairs.
-  const uint32_t per_request_overhead = merger.Strategy().NetworkOverheadCost();
-  for (const auto& [c, glyphs] : modified_conditions) {
-    uint32_t size = TRY(merger.Context().patch_size_cache->GetPatchSize(*glyphs));
-    double p = TRY(c.Probability(segments, *calculator));
-    double s = (size + per_request_overhead);
-    double d = p * s;
-    cost_delta -= d;
-    VLOG(1) << "    - (" << p << " * " << s << ") -> " << d
-            << " [removed patch " << c.ToString() << "]";
-  }
-
   // Add in cost associated within the new conditions patch pairs.
   bool fallback_changed = false;
+  double best_case_reduction_fraction = merger.Strategy().BestCaseSizeReductionFraction();
   for (auto& [c, info] : new_conditions) {
     // For modified conditions we assume the associated patch size does not
     // change, only the probability associated with the condition changes.
@@ -571,7 +552,7 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
     if (best_case) {
       uint32_t extra = info.combined_patch_size - info.largest_patch_size;
       extra = std::max(
-        (uint32_t)(extra * merger.Strategy().BestCaseSizeReductionFraction()),
+        (uint32_t)(extra * best_case_reduction_fraction),
         Merger::BEST_CASE_MERGE_SIZE_DELTA);
       size = info.largest_patch_size + extra;
     } else {
@@ -584,12 +565,12 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
         info.glyphs.subtract(*exclusive_gids);
         if (c.IsUnitary()) {
           info.glyphs.union_set(*exclusive_gids);
-          if (merger.Context().glyph_groupings.UnmappedGlyphs().intersects(*exclusive_gids)) {
+          if (context.glyph_groupings.UnmappedGlyphs().intersects(*exclusive_gids)) {
             fallback_changed = true;
           }
         }
       }
-      size = TRY(merger.Context().patch_size_cache->GetPatchSize(info.glyphs));
+      size = TRY(patch_size_cache->GetPatchSize(info.glyphs));
       if (merger.ShouldRecordMergedSizeReductions()) {
         int32_t extra_raw = info.combined_patch_size - info.largest_patch_size;
         int32_t extra_actual = ((int32_t)size) - info.largest_patch_size;
@@ -607,12 +588,12 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   }
 
   if (fallback_changed) {
-    GlyphSet new_fallback = merger.Context().glyph_groupings.UnmappedGlyphs();
+    GlyphSet new_fallback = context.glyph_groupings.UnmappedGlyphs();
     new_fallback.subtract(*exclusive_gids);
 
     // Fallback is always needed with 100% probability so delta is just the size difference (new - old)
-    double diff = ((double) TRY(merger.Context().patch_size_cache->GetPatchSize(new_fallback)))
-      - ((double) TRY(merger.Context().patch_size_cache->GetPatchSize(merger.Context().glyph_groupings.UnmappedGlyphs())));
+    double diff = ((double) TRY(patch_size_cache->GetPatchSize(new_fallback)))
+      - ((double) TRY(patch_size_cache->GetPatchSize(context.glyph_groupings.UnmappedGlyphs())));
     VLOG(1) << "    + " << diff
             << " [fallback delta]";
     cost_delta += diff;
@@ -632,8 +613,6 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
   // 3. Add a new combined patch that contains all of the glyphs of 1 + 2.
   //    New condition is {base} union {merged}, with corresponding new
   //    probability.
-
-  // TODO XXXXX review this implementation wrt to dep graph glyph conditions.
 
   double network_overhead = merger.Strategy().NetworkOverheadCost();
   double base_patch_size =

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -145,9 +145,10 @@ struct CandidateMerge {
   //
   // If best_case is true then this will compute an estimated best possible cost
   // delta from the merge (computationally cheap) instead of the real delta.
+  template<bool best_case>
   static absl::StatusOr<double> ComputeCostDelta(
       Merger& merger, const ift::common::SegmentSet& merged_segments,
-      const Segment& merged_segment, std::optional<common::GlyphSet> exclusive_gids, bool best_case);
+      const Segment& merged_segment, std::optional<common::GlyphSet> exclusive_gids);
 
   static absl::Status ComputeInitFontGlyphDelta(
       Merger& merger, const ift::common::GlyphSet& moved_glyphs,

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -140,11 +140,14 @@ struct CandidateMerge {
   // Computes the predicted change to the total cost if merged_segments
   // are joined together into a new segment, merged_segment.
   //
-  // If new_patch_size is not provided then this computes a "best case" delta
-  // where the new patch size is choosen to produce the best achievable delta.
+  // exclusive_gids is an optional hint that specifies which glyphs
+  // will end up in the exclusive patch after merged_segments are merged together.
+  //
+  // If best_case is true then this will compute an estimated best possible cost
+  // delta from the merge (computationally cheap) instead of the real delta.
   static absl::StatusOr<double> ComputeCostDelta(
       Merger& merger, const ift::common::SegmentSet& merged_segments,
-      const Segment& merged_segment, std::optional<uint32_t> new_patch_size);
+      const Segment& merged_segment, std::optional<common::GlyphSet> exclusive_gids, bool best_case);
 
   static absl::Status ComputeInitFontGlyphDelta(
       Merger& merger, const ift::common::GlyphSet& moved_glyphs,

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -194,11 +194,8 @@ static StatusOr<bool> GlyphGroupingsAreEquivalent(
  */
 Status ValidateIncrementalGroupings(hb_face_t* face,
                                     const SegmentationContext& context) {
-  SegmentationContext non_incremental_context = TRY(SegmentationContext::Create(
-      face, context.SegmentationInfo().InitFontSegment(),
-      context.SegmentationInfo().Segments(),
-      context.SegmentationInfo().GetUnmappedGlyphHandling(),
-      context.GetConditionAnalysisMode(), 1, 1));
+
+  SegmentationContext non_incremental_context = TRY(context.WithSameSettings());
 
   // Compute the glyph groupings/conditions from scratch to compare against the
   // incrementall produced ones.

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -88,35 +88,36 @@ Status CheckForDisjointCodepoints(
 }
 
 static void PrintCondition(
-    const std::pair<ActivationCondition, GlyphSet>& condition, bool added) {
-  VLOG(0) << (added ? "++ " : "-- ") << condition.first.ToString() << " => "
-          << condition.second.ToString();
+    const GlyphGroupings& groupings, const ActivationCondition& condition, bool added) {
+  const auto& glyphs = groupings.ConditionsAndGlyphs().at(condition);
+  VLOG(0) << (added ? "++ " : "-- ") << condition.ToString() << " => "
+          << glyphs.ToString();
 }
 
-static void PrintDiff(const btree_map<ActivationCondition, GlyphSet>& a,
-                      const btree_map<ActivationCondition, GlyphSet>& b) {
-  auto it_a = a.begin();
-  auto it_b = b.begin();
+static void PrintDiff(const GlyphGroupings& a,
+                      const GlyphGroupings& b) {
+  auto it_a = a.OrderedConditions().begin();
+  auto it_b = b.OrderedConditions().begin();
 
-  while (it_a != a.end() || it_b != b.end()) {
-    if (it_a == a.end()) {
-      PrintCondition(*it_b, true);
+  while (it_a != a.OrderedConditions().end() || it_b != b.OrderedConditions().end()) {
+    if (it_a == a.OrderedConditions().end()) {
+      PrintCondition(b, *it_b, true);
       it_b++;
-    } else if (it_b == b.end()) {
-      PrintCondition(*it_a, false);
+    } else if (it_b == b.OrderedConditions().end()) {
+      PrintCondition(a, *it_a, false);
       it_a++;
-    } else if (it_a->first == it_b->first) {
-      if (it_a->second != it_b->second) {
-        PrintCondition(*it_a, false);
-        PrintCondition(*it_b, true);
+    } else if (*it_a == *it_b) {
+      if (a.ConditionsAndGlyphs().at(*it_a) != b.ConditionsAndGlyphs().at(*it_b)) {
+        PrintCondition(a, *it_a, false);
+        PrintCondition(b, *it_b, true);
       }
       it_a++;
       it_b++;
-    } else if (it_a->first < it_b->first) {
-      PrintCondition(*it_a, false);
+    } else if (*it_a < *it_b) {
+      PrintCondition(a, *it_a, false);
       it_a++;
     } else {
-      PrintCondition(*it_b, true);
+      PrintCondition(b, *it_b, true);
       it_b++;
     }
   }
@@ -217,8 +218,8 @@ Status ValidateIncrementalGroupings(hb_face_t* face,
             non_incremental_context.glyph_groupings))) {
       VLOG(0) << "-- incremental grouping";
       VLOG(0) << "++ non-incremental grouping";
-      PrintDiff(context.glyph_groupings.ConditionsAndGlyphs(),
-                non_incremental_context.glyph_groupings.ConditionsAndGlyphs());
+      PrintDiff(context.glyph_groupings,
+                non_incremental_context.glyph_groupings);
       return absl::FailedPreconditionError(
           "conditions_and_glyphs aren't correct.");
     }

--- a/ift/encoder/condition_to_glyphs_index.h
+++ b/ift/encoder/condition_to_glyphs_index.h
@@ -3,7 +3,8 @@
 
 #include <optional>
 
-#include "absl/container/btree_map.h"
+#include "absl/container/btree_set.h"
+#include "ift/common/int_set.h"
 #include "ift/encoder/activation_condition.h"
 #include "ift/encoder/types.h"
 
@@ -12,6 +13,7 @@ namespace ift::encoder {
 // Stores a mapping from ActivationCondition to a set of glyphs.
 //
 // Also maintains the reverse mapping indices.
+template<bool keep_ordered>
 class ConditionToGlyphsIndex {
  public:
   std::optional<ActivationCondition> Invalidate(glyph_id_t gid) {
@@ -22,17 +24,18 @@ class ConditionToGlyphsIndex {
 
     ActivationCondition condition = it->second;
 
-    auto& glyphs = conditions_and_glyphs_.at(condition);
-    glyphs.erase(gid);
+    auto glyphs_it = conditions_and_glyphs_.find(condition);
+
+    glyphs_it->second.erase(gid);
     glyph_to_condition_.erase(gid);
 
-    if (glyphs.empty()) {
-      Remove(condition);
+    if (glyphs_it->second.empty()) {
+      Remove(condition, glyphs_it);
     }
     return condition;
   }
 
-  void Remove(ActivationCondition condition) {
+  void Remove(const ActivationCondition& condition) {
     auto it = conditions_and_glyphs_.find(condition);
     if (it == conditions_and_glyphs_.end()) {
       return;
@@ -42,7 +45,16 @@ class ConditionToGlyphsIndex {
       glyph_to_condition_.erase(gid);
     }
 
-    conditions_and_glyphs_.erase(it);
+    Remove(condition, it);
+  }
+
+ private:
+  template<typename It>
+  void Remove(const ActivationCondition& condition, It conditions_and_glyphs_it) {
+    conditions_and_glyphs_.erase(conditions_and_glyphs_it);
+    if (keep_ordered) {
+      ordered_conditions_.erase(condition);
+    }
 
     for (segment_index_t s : condition.TriggeringSegments()) {
       auto it = triggering_segment_to_conditions_.find(s);
@@ -54,9 +66,13 @@ class ConditionToGlyphsIndex {
       }
     }
   }
+ public:
 
   absl::Status Union(ActivationCondition condition, common::GlyphSet glyphs) {
     conditions_and_glyphs_[condition].union_set(glyphs);
+    if (keep_ordered) {
+      ordered_conditions_.emplace(condition);
+    }
 
     for (segment_index_t s : condition.TriggeringSegments()) {
       triggering_segment_to_conditions_[s].insert(condition);
@@ -77,6 +93,9 @@ class ConditionToGlyphsIndex {
   absl::Status Add(ActivationCondition condition, common::GlyphSet glyphs) {
     const auto& [new_value_it, did_insert] =
         conditions_and_glyphs_.insert(std::pair(condition, glyphs));
+    if (keep_ordered) {
+      ordered_conditions_.emplace(condition);
+    }
 
     if (!did_insert) {
       // If there's an existing value it must match what we're trying to add
@@ -112,9 +131,13 @@ class ConditionToGlyphsIndex {
     return absl::OkStatus();
   }
 
-  const absl::btree_map<ActivationCondition, common::GlyphSet>&
+  const absl::flat_hash_map<ActivationCondition, common::GlyphSet>&
   ConditionsAndGlyphs() const {
     return conditions_and_glyphs_;
+  }
+
+  const absl::btree_set<ActivationCondition>& OrderedConditions() const {
+    return ordered_conditions_;
   }
 
   const absl::flat_hash_map<glyph_id_t, ActivationCondition>& GlyphToCondition()
@@ -130,13 +153,16 @@ class ConditionToGlyphsIndex {
 
   bool operator==(const ConditionToGlyphsIndex& other) const {
     return conditions_and_glyphs_ == other.conditions_and_glyphs_ &&
+           /* don't need to check ordered_conditions_ it's equivalent to conditions_and_glyphs_ */
            glyph_to_condition_ == other.glyph_to_condition_ &&
            triggering_segment_to_conditions_ ==
                other.triggering_segment_to_conditions_;
   }
 
  private:
-  absl::btree_map<ActivationCondition, common::GlyphSet> conditions_and_glyphs_;
+  absl::flat_hash_map<ActivationCondition, common::GlyphSet> conditions_and_glyphs_;
+  absl::btree_set<ActivationCondition> ordered_conditions_;
+
   absl::flat_hash_map<glyph_id_t, ActivationCondition> glyph_to_condition_;
   absl::flat_hash_map<segment_index_t, absl::btree_set<ActivationCondition>>
       triggering_segment_to_conditions_;

--- a/ift/encoder/condition_to_glyphs_index.h
+++ b/ift/encoder/condition_to_glyphs_index.h
@@ -146,7 +146,7 @@ class ConditionToGlyphsIndex {
   }
 
   const absl::flat_hash_map<segment_index_t,
-                            absl::btree_set<ActivationCondition>>&
+                            absl::flat_hash_set<ActivationCondition>>&
   TriggeringSegmentToConditions() const {
     return triggering_segment_to_conditions_;
   }
@@ -164,7 +164,7 @@ class ConditionToGlyphsIndex {
   absl::btree_set<ActivationCondition> ordered_conditions_;
 
   absl::flat_hash_map<glyph_id_t, ActivationCondition> glyph_to_condition_;
-  absl::flat_hash_map<segment_index_t, absl::btree_set<ActivationCondition>>
+  absl::flat_hash_map<segment_index_t, absl::flat_hash_set<ActivationCondition>>
       triggering_segment_to_conditions_;
 };
 

--- a/ift/encoder/estimated_patch_size_cache.h
+++ b/ift/encoder/estimated_patch_size_cache.h
@@ -23,6 +23,11 @@ class EstimatedPatchSizeCache : public PatchSizeCache {
         new EstimatedPatchSizeCache(face, compression_ratio));
   }
 
+  static std::unique_ptr<PatchSizeCache> New(hb_face_t* face, double compression_ratio) {
+    return std::unique_ptr<PatchSizeCache>(
+        new EstimatedPatchSizeCache(face, compression_ratio));
+  }
+
   absl::StatusOr<uint32_t> GetPatchSize(
       const ift::common::GlyphSet& gids) override;
 
@@ -30,15 +35,15 @@ class EstimatedPatchSizeCache : public PatchSizeCache {
 
   double CompressionRatio() const { return compression_ratio_; }
 
+  static absl::StatusOr<double> EstimateCompressionRatio(
+      hb_face_t* original_face);
+
  private:
   explicit EstimatedPatchSizeCache(hb_face_t* original_face,
                                    double compression_ratio)
       : face_(ift::common::make_hb_face(hb_face_reference(original_face))),
         compression_ratio_(compression_ratio),
         cache_() {}
-
-  static absl::StatusOr<double> EstimateCompressionRatio(
-      hb_face_t* original_face);
 
   ift::common::hb_face_unique_ptr face_;
   double compression_ratio_;

--- a/ift/encoder/glyph_closure_cache.cc
+++ b/ift/encoder/glyph_closure_cache.cc
@@ -29,16 +29,48 @@ StatusOr<GlyphSet> GlyphClosureCache::SegmentClosure(
   return GlyphClosure(closure_def);
 }
 
+// This generates the subset definition that contains all segments except for
+// those listed in segment_ids.
+SubsetDefinition ComputeExceptSegment(
+    const RequestedSegmentationInformation& segmentation_info,
+    const SegmentSet& segment_ids, const SubsetDefinition& combined) {
+  if (segmentation_info.SegmentsAreDisjoint() &&
+      (segment_ids.size() == 1 ||
+       segment_ids.size() < (segmentation_info.Segments().size() / 2))) {
+    // Approach that is optimized for the case where input segments are disjoint
+    // and the number of segment ids is smallish.
+    SubsetDefinition except_segment = segmentation_info.FullDefinition();
+    except_segment.Subtract(combined);
+    return except_segment;
+  }
+
+  // Otherwise this approach will always work even with non-disjoint segments
+  SegmentSet except_segment_ids = segment_ids;
+  except_segment_ids.invert();
+
+  uint32_t num_segments = segmentation_info.Segments().size();
+  SubsetDefinition except_segment = segmentation_info.InitFontSegment();
+  for (segment_index_t s : except_segment_ids) {
+    if (s >= num_segments) {
+      break;
+    }
+    except_segment.Union(segmentation_info.Segments()[s].Definition());
+  }
+
+  return except_segment;
+}
+
 StatusOr<bool> GlyphClosureCache::HasAdditionalConditions(
     const RequestedSegmentationInformation* segmentation_info,
     const SegmentSet& segments, const GlyphSet& glyphs) {
-  SegmentSet except;
-  if (!segmentation_info->Segments().empty()) {
-    except.insert_range(0, segmentation_info->Segments().size() - 1);
-  }
-  except.subtract(segments);
 
-  GlyphSet closure_glyphs = TRY(SegmentClosure(segmentation_info, except));
+  SubsetDefinition combined;
+  for (segment_index_t s : segments) {
+    combined.Union(segmentation_info->Segments().at(s).Definition());
+  }
+
+  SubsetDefinition except = ComputeExceptSegment(*segmentation_info, segments, combined);
+  GlyphSet closure_glyphs = TRY(GlyphClosure(except));
   return closure_glyphs.intersects(glyphs);
 }
 
@@ -86,37 +118,6 @@ StatusOr<GlyphSet> GlyphClosureCache::CodepointsToOrGids(
                       exclusive_gids));
 
   return or_gids;
-}
-
-// This generates the subset definition that contains all segments except for
-// those listed in segment_ids.
-SubsetDefinition ComputeExceptSegment(
-    const RequestedSegmentationInformation& segmentation_info,
-    const SegmentSet& segment_ids, const SubsetDefinition& combined) {
-  if (segmentation_info.SegmentsAreDisjoint() &&
-      (segment_ids.size() == 1 ||
-       segment_ids.size() < (segmentation_info.Segments().size() / 2))) {
-    // Approach that is optimized for the case where input segments are disjoint
-    // and the number of segment ids is smallish.
-    SubsetDefinition except_segment = segmentation_info.FullDefinition();
-    except_segment.Subtract(combined);
-    return except_segment;
-  }
-
-  // Otherwise this approach will always work even with non-disjoint segments
-  SegmentSet except_segment_ids = segment_ids;
-  except_segment_ids.invert();
-
-  uint32_t num_segments = segmentation_info.Segments().size();
-  SubsetDefinition except_segment = segmentation_info.InitFontSegment();
-  for (segment_index_t s : except_segment_ids) {
-    if (s >= num_segments) {
-      break;
-    }
-    except_segment.Union(segmentation_info.Segments()[s].Definition());
-  }
-
-  return except_segment;
 }
 
 Status GlyphClosureCache::AnalyzeSegment(

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -144,7 +144,8 @@ StatusOr<GlyphSegmentation> GlyphGroupings::ToGlyphSegmentation(
   // The fallback patch isn't stored in ConditionAndGlyphs() so add it in
   // manually.
   SegmentSet fallback_segments;
-  auto conditions_with_fallback = ConditionsAndGlyphs();
+  btree_map<ActivationCondition, GlyphSet> conditions_with_fallback;
+  conditions_with_fallback.insert(ConditionsAndGlyphs().begin(), ConditionsAndGlyphs().end());
   if (!unmapped_glyphs_.empty()) {
     fallback_segments = segmentation_info.NonEmptySegments();
 

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -37,9 +37,13 @@ class GlyphGroupings {
 
   bool operator!=(const GlyphGroupings& other) { return !(*this == other); }
 
-  const absl::btree_map<ActivationCondition, ift::common::GlyphSet>&
+  const absl::flat_hash_map<ActivationCondition, ift::common::GlyphSet>&
   ConditionsAndGlyphs() const {
     return conditions_and_glyphs_.ConditionsAndGlyphs();
+  }
+
+  const absl::btree_set<ActivationCondition>& OrderedConditions() const {
+    return conditions_and_glyphs_.OrderedConditions();
   }
 
   // Returns the set all of segments that are part of a disjunctive condition.
@@ -251,15 +255,15 @@ class GlyphGroupings {
   GlyphPartition combined_patches_;
   bool combined_patches_dirty_ = false;
 
-  absl::btree_map<ift::common::SegmentSet, ift::common::GlyphSet>
+  absl::flat_hash_map<ift::common::SegmentSet, ift::common::GlyphSet>
       or_glyph_groups_;
-  absl::btree_map<segment_index_t, ift::common::GlyphSet>
+  absl::flat_hash_map<segment_index_t, ift::common::GlyphSet>
       exclusive_glyph_groups_;
 
   // This is a set of disjunctive conditions which have been combined by the
   // CombinePatches() mechanism. Does not store groupings which have not been
   // modified the the mechanism.
-  absl::btree_map<ift::common::SegmentSet, ift::common::GlyphSet>
+  absl::flat_hash_map<ift::common::SegmentSet, ift::common::GlyphSet>
       combined_or_glyph_groups_;
 
   // This is a set of segments which are normally exclusive but have been
@@ -267,8 +271,8 @@ class GlyphGroupings {
   ift::common::SegmentSet combined_exclusive_segments_;
 
   // An alternate representation of and/or_glyph_groups_, derived from them.
-  ConditionToGlyphsIndex conditions_and_glyphs_;
-  ConditionToGlyphsIndex conditions_and_glyphs_pre_combination_;
+  ConditionToGlyphsIndex<true> conditions_and_glyphs_;
+  ConditionToGlyphsIndex<false> conditions_and_glyphs_pre_combination_;
 
   // These glyphs aren't mapped by any conditions and as a result should be
   // included in the fallback patch.

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -92,9 +92,9 @@ class GlyphGroupings {
   }
 
   // Returns a list of conditions which include segment.
-  const absl::btree_set<ActivationCondition>& TriggeringSegmentToConditions(
+  const absl::flat_hash_set<ActivationCondition>& TriggeringSegmentToConditions(
       segment_index_t segment) const {
-    static absl::btree_set<ActivationCondition> empty;
+    static absl::flat_hash_set<ActivationCondition> empty;
     auto it =
         conditions_and_glyphs_.TriggeringSegmentToConditions().find(segment);
     if (it != conditions_and_glyphs_.TriggeringSegmentToConditions().end()) {

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -33,7 +33,7 @@ using ift::common::hb_face_unique_ptr;
 using ift::common::make_hb_face;
 using ift::common::SegmentSet;
 
-void PrintTo(const btree_map<ActivationCondition, GlyphSet>& conditions,
+void PrintTo(const flat_hash_map<ActivationCondition, GlyphSet>& conditions,
              std::ostream* os) {
   *os << "conditions:\n";
   for (const auto& [c, gids] : conditions) {
@@ -197,7 +197,7 @@ TEST_F(GlyphGroupingsTest, SimpleGrouping) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s3 OR s4 -> {g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({'a', 'b'})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k'})},
@@ -256,7 +256,7 @@ TEST_F(GlyphGroupingsTest, SegmentChange) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s3 OR s4 -> {g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0),
        ToGlyphs({'a', 'b', 'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
@@ -283,7 +283,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s0 OR s3 OR s4 -> {a, b, g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
       {ActivationCondition::and_segments({2, 3}, 0), ToGlyphs({'e', 'f'})},
@@ -328,7 +328,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_WithInertSpecialCase) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s3 OR s4 -> {g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::or_segments({0, 3}, 0),
        ToGlyphs({'a', 'b', 'c', 'd', 'k'})},
       {ActivationCondition::and_segments({2, 3}, 0), ToGlyphs({'e', 'f'})},
@@ -361,7 +361,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_Invalidates) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s0 OR s3 OR s4 -> {a, b, g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
       {ActivationCondition::and_segments({2, 3}, 0), ToGlyphs({'e', 'f'})},
@@ -397,7 +397,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_PartialUpdate) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s0 OR s3 OR s4 -> {a, b, g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
       {ActivationCondition::and_segments({2, 3}, 0), ToGlyphs({'e', 'f'})},
@@ -434,7 +434,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_Noop) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s3 OR s4 -> {g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({'a', 'b'})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
@@ -462,7 +462,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_DoesntAffectConjunction) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s3 OR s4 -> {g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({'a', 'b'})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
@@ -524,7 +524,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_SegmentChanges) {
   // s2 AND s3 -> {e, f}
   // s2 OR s3 -> {j}
   // s0 OR s3 OR s4 -> {a, b, c, , d, g, h}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
       {ActivationCondition::and_segments({2, 3}, 0), ToGlyphs({'e', 'f'})},
       {ActivationCondition::or_segments({2, 3}, 0), ToGlyphs({'j'})},
@@ -602,7 +602,7 @@ TEST_F(GlyphGroupingsTest, ComplexConditionFinding_LeaveUnmapped) {
   // Condition map:
   // if (s0) then p0 => {56} [excl]
   // if (s1) then p0 => {80} [excl]
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({0x54})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({0x6C})},
   };
@@ -624,7 +624,7 @@ TEST_F(GlyphGroupingsTest, ComplexConditionFinding_Basic) {
   // if ((s0 OR s3 OR s4)) then p0 => {782}
   // if ((s1 OR s2 OR s4)) then p0 => {748}
   // if ((s2 OR s3 OR s4)) then p0 => {442}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({0x54})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({0x6C})},
 
@@ -653,7 +653,7 @@ TEST_F(GlyphGroupingsTest, ComplexConditionFinding_Basic_WithDependencyGraph) {
   // if ((s0 OR s3 OR s4)) then p0 => {782}
   // if ((s1 OR s2 OR s4)) then p0 => {748}
   // if ((s2 OR s3 OR s4)) then p0 => {442}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({0x54})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({0x6C})},
 
@@ -680,7 +680,7 @@ TEST_F(GlyphGroupingsTest, ComplexConditionFinding_IncrementalUnchanged) {
       *requested_segmentation_info_complex_, *glyph_conditions_complex_,
       *closure_cache_, std::nullopt, glyphs_to_group_complex_, {});
   ASSERT_TRUE(sc.ok()) << sc;
-  btree_map<ActivationCondition, GlyphSet> expected =
+  flat_hash_map<ActivationCondition, GlyphSet> expected =
       glyph_groupings_complex_.ConditionsAndGlyphs();
 
   // Incremental regrouping, should arrive back at the same mapping.
@@ -716,7 +716,7 @@ TEST_F(GlyphGroupingsTest, ComplexConditionFinding_IncrementalChanged) {
       *closure_cache_, std::nullopt, ToGlyphs({0x54}), {0, 3});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({0x54})},
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({0x6C})},
       {ActivationCondition::or_segments({1, 2, 4}, 0), {748}},
@@ -753,7 +753,7 @@ TEST_F(GlyphGroupingsTest, ComplexConditionFinding_CombinedPatches) {
   // if ((s0 OR s1 OR s3 OR s4)) then p0 => {80, 782}
   // if ((s1 OR s2 OR s4)) then p0 => {748}
   // if ((s2 OR s3 OR s4)) then p0 => {442}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({0x54})},
 
       {ActivationCondition::or_segments({0, 1, 3, 4}, 0), {ToGlyph(0x6C), 782}},
@@ -789,7 +789,7 @@ TEST_F(GlyphGroupingsTest,
   // if ((s0 OR s1)) then p0 => {56, 80, 782}
   // if ((s1 OR s2 OR s4)) then p0 => {748}
   // if ((s0 OR s2 OR s4)) then p0 => {442}
-  btree_map<ActivationCondition, GlyphSet> expected = {
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::or_segments({0, 1}, 0),
        {ToGlyph(0x54), ToGlyph(0x6C), 782}},
       {ActivationCondition::or_segments({1, 2, 4}, 0), {748}},
@@ -816,7 +816,7 @@ TEST_F(GlyphGroupingsTest, IncrementalExclusiveConflict) {
   ActivationCondition expected = ActivationCondition::exclusive_segment(0, 0);
 
   ASSERT_EQ(glyph_groupings_.ConditionsAndGlyphs(),
-            (btree_map<ActivationCondition, GlyphSet>{
+            (flat_hash_map<ActivationCondition, GlyphSet>{
                 {expected, {ToGlyph('a'), ToGlyph('b')}}}));
 }
 

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -644,7 +644,12 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryMergingACompositeCondition(
   ActivationCondition base_condition =
       ActivationCondition::exclusive_segment(base_segment_index, UINT32_MAX);
 
-  for (ActivationCondition next_condition : candidate_conditions) {
+  std::vector<ActivationCondition> sorted_conditions;
+  sorted_conditions.reserve(candidate_conditions.size());
+  sorted_conditions.insert(sorted_conditions.end(), candidate_conditions.begin(), candidate_conditions.end());
+  std::sort(sorted_conditions.begin(), sorted_conditions.end());
+
+  for (ActivationCondition next_condition : sorted_conditions) {
     if (next_condition.IsFallback()) {
       // Merging the fallback will cause all segments to be merged into one,
       // which is undesirable so don't consider the fallback.

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -521,10 +521,10 @@ Status Merger::CollectCompositeCandidateMerges(
   ActivationCondition last_exclusive =
       ActivationCondition::exclusive_segment(UINT32_MAX, 0);
 
-  for (auto it = context_->glyph_groupings.ConditionsAndGlyphs().lower_bound(
+  for (auto it = context_->glyph_groupings.OrderedConditions().lower_bound(
            last_exclusive);
-       it != context_->glyph_groupings.ConditionsAndGlyphs().end(); it++) {
-    const auto& next_condition = it->first;
+       it != context_->glyph_groupings.OrderedConditions().end(); it++) {
+    const auto& next_condition = *it;
     if (next_condition.IsFallback() || next_condition.IsExclusive()) {
       // Merging the fallback will cause all segments to be merged into one,
       // which is undesirable so don't consider the fallback. Also skip

--- a/ift/encoder/merger.h
+++ b/ift/encoder/merger.h
@@ -2,7 +2,6 @@
 #define IFT_ENCODER_MERGER_H_
 
 #include <cstdint>
-#include <sstream>
 
 #include "ift/common/int_set.h"
 #include "ift/encoder/candidate_merge.h"

--- a/ift/encoder/requested_segmentation_information.h
+++ b/ift/encoder/requested_segmentation_information.h
@@ -128,9 +128,6 @@ class RequestedSegmentationInformation {
 
   SubsetDefinition CombinedDefinition(
       const ift::common::SegmentSet& segments) const {
-    // TODO(garretrieger): this approach is inefficient vs the subtraction
-    // method, add the special case path or remove use of this function in
-    // favour of incrementally produced defs.
     SubsetDefinition def;
     for (segment_index_t s : segments) {
       def.Union(Segments().at(s).Definition());

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -67,13 +67,26 @@ class SegmentationContext {
         init_font_brotli_quality, std::move(closure_cache),
         std::move(segmentation_info));
 
-    if ((condition_analysis_mode == ift::config::CLOSURE_AND_DEP_GRAPH) ||
-        (condition_analysis_mode ==
-         ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH) ||
-        (condition_analysis_mode == ift::config::DEP_GRAPH_ONLY)) {
-      context.dependency_closure_ = TRY(DependencyClosure::Create(
-          context.segmentation_info_.get(), context.original_face.get()));
-    }
+    TRYV(context.InitDependencyClosure());
+    return context;
+  }
+
+  absl::StatusOr<SegmentationContext> WithSameSettings() const {
+    std::unique_ptr<GlyphClosureCache> closure_cache =
+        std::make_unique<GlyphClosureCache>(original_face.get());
+
+    std::unique_ptr<RequestedSegmentationInformation> segmentation_info =
+        TRY(RequestedSegmentationInformation::Create(SegmentationInfo().Segments(), SegmentationInfo().InitFontSegment(),
+                                                     *closure_cache,
+                                                     SegmentationInfo().GetUnmappedGlyphHandling()));
+
+    SegmentationContext context(
+        original_face.get(), SegmentationInfo().GetUnmappedGlyphHandling(), condition_analysis_mode_, brotli_quality_,
+        init_font_brotli_quality_, std::move(closure_cache),
+        std::move(segmentation_info), estimated_compression_ratio_);
+
+    // TODO XXXX we can save some more time by copying the existing dependency closure object.
+    TRYV(context.InitDependencyClosure());
     return context;
   }
 
@@ -97,8 +110,11 @@ class SegmentationContext {
       ift::config::ConditionAnalysisMode condition_analysis_mode,
       uint32_t brotli_quality, uint32_t init_font_brotli_quality,
       std::unique_ptr<GlyphClosureCache> closure_cache,
-      std::unique_ptr<RequestedSegmentationInformation> segmentation_info)
-      : patch_size_cache(NewPatchSizeCache(face, brotli_quality)),
+      std::unique_ptr<RequestedSegmentationInformation> segmentation_info,
+      std::optional<double> estimated_compression_ratio = std::nullopt
+    )
+      : estimated_compression_ratio_(estimated_compression_ratio),
+        patch_size_cache(NewPatchSizeCache(face, brotli_quality)),
         patch_size_cache_for_init_font(
             NewPatchSizeCache(face, init_font_brotli_quality)),
         glyph_closure_cache(std::move(closure_cache)),
@@ -108,7 +124,19 @@ class SegmentationContext {
         glyph_condition_set(hb_face_get_glyph_count(face)),
         glyph_groupings(hb_face_get_glyph_count(face)),
         brotli_quality_(brotli_quality),
+        init_font_brotli_quality_(init_font_brotli_quality),
         condition_analysis_mode_(condition_analysis_mode) {}
+
+  absl::Status InitDependencyClosure() {
+    if ((condition_analysis_mode_ == ift::config::CLOSURE_AND_DEP_GRAPH) ||
+        (condition_analysis_mode_ ==
+         ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH) ||
+        (condition_analysis_mode_ == ift::config::DEP_GRAPH_ONLY)) {
+      dependency_closure_ = TRY(DependencyClosure::Create(
+          segmentation_info_.get(), original_face.get()));
+    }
+    return absl::OkStatus();
+  }
 
  public:
   unsigned BrotliQuality() const { return brotli_quality_; }
@@ -268,17 +296,27 @@ class SegmentationContext {
   // too small to be worthwhile.
   absl::StatusOr<segment_index_t> ComputeSegmentCutoff() const;
 
-  static std::unique_ptr<PatchSizeCache> NewPatchSizeCache(
+  // TODO XXXX make this return StatusOr<...>
+  std::unique_ptr<PatchSizeCache> NewPatchSizeCache(
       hb_face_t* face, uint32_t brotli_quality) {
     if (brotli_quality == 0) {
-      auto cache = EstimatedPatchSizeCache::New(face);
-      if (cache.ok()) {
-        return std::move(*cache);
+      if (!estimated_compression_ratio_.has_value()) {
+        auto r = EstimatedPatchSizeCache::EstimateCompressionRatio(face);
+        if (r.ok()) {
+          estimated_compression_ratio_ = *r;
+        }
+      }
+
+      if (estimated_compression_ratio_.has_value()) {
+        return EstimatedPatchSizeCache::New(face, *estimated_compression_ratio_);
       }
     }
     return std::unique_ptr<PatchSizeCache>(
         new PatchSizeCacheImpl(face, brotli_quality));
   }
+
+ private:
+  std::optional<double> estimated_compression_ratio_;
 
  public:
   // Caches and logging
@@ -306,6 +344,7 @@ class SegmentationContext {
   ift::common::SegmentSet inert_segments_;
 
   unsigned brotli_quality_;
+  unsigned init_font_brotli_quality_;
 
   ift::config::ConditionAnalysisMode condition_analysis_mode_;
 };

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -85,7 +85,6 @@ class SegmentationContext {
         init_font_brotli_quality_, std::move(closure_cache),
         std::move(segmentation_info), estimated_compression_ratio_);
 
-    // TODO XXXX we can save some more time by copying the existing dependency closure object.
     TRYV(context.InitDependencyClosure());
     return context;
   }


### PR DESCRIPTION
Various performance optimizations to speed up segmenting CJK and fonts that have large character and/or condition counts:
- Cost delta computation was doing one subset closure per delta computation, that's been removed when in dep graph only mode.
- In several areas switch from btree to flat_hash where ordering isn't important. Particularly for cases dealing with ActivationCondition's as the operator< used by btree can be expensive for these.
- Corrected merged probability calculations by having it apply simplification before computing probabilities to eliminate redundant terms.
- Speed up of ActivationCondition::TriggeringSegments()
- Speed up of CandidateMerge::FindModifiedConditions()
- Speed up of segmentation context initialization.

On test font Chiron Sung HK this takes total segmenting time (quality = 1) from ~4 hours to 45 minutes.