### PR TITLE
Add some additional special casing for layout features during segmenting

### DIFF
--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -187,6 +187,7 @@ static void MergeSegments(const Merger& merger, const SegmentSet& segments,
     merged_segments.push_back(&s);
   }
 
+  // Compute probability before modifying base since it's in the merged segments array.
   const auto* calculator = merger.Strategy().ProbabilityCalculator();
   const auto& bound = calculator->ComputeMergedProbability(merged_segments);
   base.Definition() = std::move(union_def);
@@ -669,8 +670,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
     const SegmentSet& segments_to_merge_,
     const std::optional<CandidateMerge>& best_merge_candidate) {
 
-  if (!merger.Strategy().UseCosts() &&
-      WouldMixFeaturesAndCodepoints(merger.Context().SegmentationInfo(),
+  if (WouldMixFeaturesAndCodepoints(merger.Context().SegmentationInfo(),
                                     base_segment_index, segments_to_merge_)) {
     // With the heuristic merger if it doesn't find a previous merge candidate
     // will try to merge together segments that are composed of codepoints with
@@ -678,8 +678,13 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
     // likely rarely used this will inflate the size of the patches for those
     // codepoint segments unnecessarily.
     //
-    // So don't merge cases where we would be combining codepoint
-    // only segments with feature only segments.
+    // In the cost case we don't have proper frequency data for features and
+    // likewise don't have co-occurence data with features + codepoints. This
+    // makes it difficult to make proper merging decisions that involve
+    // mixing codepoints and features.
+    //
+    // As a result, don't do merges that mix features and codepoints in any
+    // cases.
     VLOG(0) << "  Merge would mix features into a codepoint only segment, "
                "skipping.";
     return std::nullopt;

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -328,8 +328,8 @@ static std::vector<Segment> PreGroupSegments(
         Segment{subset_definitions[o.original_index], o.probability};
     ordering_it++;
 
-    // Don't pregroup feature segments, these genearlly have broad interactions
-    // and pre-grouping can them blindly can cause poor outcomes.
+    // Don't pregroup feature segments, these generally have broad interactions
+    // and pre-grouping them blindly can cause poor outcomes.
     bool is_feature_segment = !segment.Definition().feature_tags.empty();
 
     segment_index_map[o.original_index] = i;
@@ -346,8 +346,8 @@ static std::vector<Segment> PreGroupSegments(
           break;
         }
 
-        // Don't pregroup feature segments, these genearlly have broad interactions
-        // and pre-grouping can them blindly can cause poor outcomes.
+        // Don't pregroup feature segments, these generally have broad interactions
+        // and pre-grouping them blindly can cause poor outcomes.
         if (!subset_definitions[ordering_it->original_index].feature_tags.empty()) {
           break;
         }

--- a/ift/encoder/closure_glyph_segmenter.cc
+++ b/ift/encoder/closure_glyph_segmenter.cc
@@ -328,14 +328,27 @@ static std::vector<Segment> PreGroupSegments(
         Segment{subset_definitions[o.original_index], o.probability};
     ordering_it++;
 
-    if (strategy == nullptr || strategy->PreClosureGroupSize() <= 1 ||
-        o.probability.Max() > strategy->PreClosureProbabilityThreshold()) {
-      segment_index_map[o.original_index] = i;
-    } else {
+    // Don't pregroup feature segments, these genearlly have broad interactions
+    // and pre-grouping can them blindly can cause poor outcomes.
+    bool is_feature_segment = !segment.Definition().feature_tags.empty();
+
+    segment_index_map[o.original_index] = i;
+
+    if (strategy != nullptr &&
+        !is_feature_segment &&
+        strategy->PreClosureGroupSize() > 1 &&
+        o.probability.Max() <= strategy->PreClosureProbabilityThreshold()) {
+
       uint32_t remaining = strategy->PreClosureGroupSize() - 1;
       while (remaining > 0) {
         if (ordering_it == ordering.end() ||
             ordering_it->group_index != o.group_index) {
+          break;
+        }
+
+        // Don't pregroup feature segments, these genearlly have broad interactions
+        // and pre-grouping can them blindly can cause poor outcomes.
+        if (!subset_definitions[ordering_it->original_index].feature_tags.empty()) {
           break;
         }
 
@@ -348,6 +361,7 @@ static std::vector<Segment> PreGroupSegments(
       }
 
       if (strategy->UseCosts()) {
+        // Segment definition has changed so probability needs to be recomputed.
         segment.SetProbability(
             strategy->ProbabilityCalculator()->ComputeProbability(
                 segment.Definition()));

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -1881,6 +1881,126 @@ if (s3) then p0
 )");
 }
 
+TEST_F(ClosureGlyphSegmenterTest, FeatureSegments_NoPreGrouping_MidGroup) {
+  UnicodeFrequencies freq{
+      {{' ', ' '}, 100}, {{'a', 'a'}, 30}, {{'b', 'b'}, 29},
+  };
+
+  MergeStrategy costs = *MergeStrategy::CostBased(std::move(freq), 0, 1);
+  costs.SetPreClosureProbabilityThreshold(0.55);
+  costs.SetPreClosureGroupSize(3);
+
+  SubsetDefinition feat_seg;
+  feat_seg.feature_tags.insert(HB_TAG('s', 'm', 'c', 'p'));
+  feat_seg.codepoints.insert('c');
+
+  auto segmentation = CodepointToGlyphSegments(roboto.get(), {},
+                                               {
+                                                   {'a'},
+                                                   {'b'},
+                                                   feat_seg,
+                                               },
+                                               costs);
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  std::vector<SubsetDefinition> expected_segments = {
+      {'a', 'b'},
+      feat_seg,
+  };
+  ASSERT_EQ(segmentation->Segments(), expected_segments);
+
+
+  // Use heuristic so that segments don't get re-ordered by probability.
+  MergeStrategy heuristic = MergeStrategy::Heuristic(0);
+  heuristic.SetPreClosureProbabilityThreshold(0.55);
+  heuristic.SetPreClosureGroupSize(3);
+  segmentation = CodepointToGlyphSegments(roboto.get(), {},
+                                               {
+                                                   {'a'},
+                                                   feat_seg,
+                                                   {'b'},
+                                               },
+                                               heuristic);
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  // The feature segment comes up mid group so it breaks up the group and segments
+  // all stay separate.
+  expected_segments = {
+      {'a'},
+      feat_seg,
+      {'b'},
+  };
+  ASSERT_EQ(segmentation->Segments(), expected_segments);
+}
+
+TEST_F(ClosureGlyphSegmenterTest, FeatureSegments_NoPreGrouping_AsFirst) {
+  UnicodeFrequencies freq{
+      {{' ', ' '}, 100}, {{'a', 'a'}, 30}, {{'b', 'b'}, 29}, {{'c', 'c'}, 28},
+  };
+
+  MergeStrategy costs = *MergeStrategy::CostBased(std::move(freq), 0, 1);
+  costs.SetPreClosureProbabilityThreshold(0.55);
+  costs.SetPreClosureGroupSize(3);
+
+  SubsetDefinition feat_seg;
+  feat_seg.feature_tags.insert(HB_TAG('s', 'm', 'c', 'p'));
+  feat_seg.codepoints.insert('a');
+
+  auto segmentation = CodepointToGlyphSegments(roboto.get(), {},
+                                               {
+                                                   feat_seg,
+                                                   {'b'},
+                                                   {'c'},
+                                               },
+                                               costs);
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  std::vector<SubsetDefinition> expected_segments = {
+      feat_seg,
+      {'b', 'c'},
+  };
+  ASSERT_EQ(segmentation->Segments(), expected_segments);
+}
+
+TEST_F(ClosureGlyphSegmenterTest, PreGrouping_RemappedIndexBug) {
+  // Regression test for a bug in assigned updated segment indices after pre-grouping
+  // The first segment in a group was always being remapped to segment 0. This uses
+  // two separate merge groups to ensure the second one does not end up with segment 0.
+  UnicodeFrequencies freq_high{
+      {{' ', ' '}, 100}, {{'a', 'a'}, 100},
+  };
+
+  MergeStrategy strategy_0 = *MergeStrategy::CostBased(std::move(freq_high), 0, 1);
+
+  // Use Heuristic for Group 1 to force merging of whatever ends up in it.
+  MergeStrategy strategy_1 = MergeStrategy::Heuristic(1000);
+  strategy_1.SetPreClosureProbabilityThreshold(0.5);
+  strategy_1.SetPreClosureGroupSize(2);
+
+  btree_map<SegmentSet, MergeStrategy> merge_groups{
+      {{0}, strategy_0},
+      {{1, 2}, strategy_1},
+  };
+
+  auto segmentation = CodepointToGlyphSegments(roboto.get(), {},
+                                               {
+                                                   {'a'},
+                                                   {'b'},
+                                                   {'c'},
+                                               },
+                                               merge_groups);
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+
+
+  // We should not see 'a' show up in the second group
+  std::vector<SubsetDefinition> expected_segments = {
+      {'a'},
+      {'b', 'c'},
+  };
+  ASSERT_EQ(segmentation->Segments(), expected_segments);
+}
+
 // TODO(garretrieger): test that segments are excluded by init font segment. ie.
 // if a segment is present in the init font then it should be cleared out in the
 // segmentation.

--- a/ift/freq/bigram_probability_calculator.cc
+++ b/ift/freq/bigram_probability_calculator.cc
@@ -1,5 +1,7 @@
 #include "ift/freq/bigram_probability_calculator.h"
 
+#include <algorithm>
+
 #include "ift/common/int_set.h"
 #include "ift/encoder/segment.h"
 #include "ift/encoder/subset_definition.h"
@@ -87,11 +89,32 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
 
 ProbabilityBound BigramProbabilityCalculator::ComputeProbability(
     const SubsetDefinition& definition) const {
+  return ComputeProbabilityInternal(definition, 0.0);
+}
+
+ProbabilityBound BigramProbabilityCalculator::ComputeProbabilityInternal(
+    const SubsetDefinition& definition, double best_lower) const {
   if (definition.Empty()) {
     return {1, 1};
   }
-  // TODO(garretrieger): XXXX incorporate layout tags
-  return BigramProbabilityBound(definition.codepoints, 0.0);
+
+  ProbabilityBound codepoints_bound = BigramProbabilityBound(definition.codepoints, best_lower);
+
+  if (definition.feature_tags.empty()) {
+    return codepoints_bound;
+  }
+
+  double feature_min = 0.0;
+  double feature_sum = 0.0;
+  for (hb_tag_t tag : definition.feature_tags) {
+    double p = frequencies_.ProbabilityForLayoutTag(tag);
+    feature_min = std::max(feature_min, p);
+    feature_sum += p;
+  }
+  double t_max = std::min(1.0, feature_sum);
+
+  return ProbabilityBound(std::max(codepoints_bound.Min(), feature_min),
+                          std::min(1.0, codepoints_bound.Max() + t_max));
 }
 
 ProbabilityBound BigramProbabilityCalculator::ComputeMergedProbability(
@@ -140,7 +163,7 @@ ProbabilityBound BigramProbabilityCalculator::ComputeMergedProbability(
     }
   }
   */
-  return BigramProbabilityBound(union_def.codepoints, best_lower);
+  return ComputeProbabilityInternal(union_def, best_lower);
 }
 
 ProbabilityBound BigramProbabilityCalculator::ComputeConjunctiveProbability(

--- a/ift/freq/bigram_probability_calculator.cc
+++ b/ift/freq/bigram_probability_calculator.cc
@@ -19,6 +19,13 @@ BigramProbabilityCalculator::BigramProbabilityCalculator(
 
 ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
     const CodepointSet& codepoints, double best_lower) const {
+  auto it = cache_.find(codepoints);
+  if (it != cache_.end()) {
+    double lower = std::max(it->second.Min(), best_lower);
+    double upper = std::max(it->second.Max(), lower);
+    return ProbabilityBound(lower, upper);
+  }
+
   unsigned n = codepoints.size();
   std::vector<unsigned> cps;
   std::vector<double> P;
@@ -39,7 +46,9 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
 
   if (max_single_bound >= 1.0) {
     // Bounds can't be lower than [1, 1] stop checking.
-    return ProbabilityBound(1.0, 1.0);
+    ProbabilityBound bound(1.0, 1.0);
+    cache_.emplace(codepoints, bound);
+    return bound;
   }
 
   double bigram_total = 0.0;
@@ -54,7 +63,9 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
       max_pair_bound = std::max(P[i] + P[j] - Pij, max_pair_bound);
       if (max_pair_bound >= 1.0) {
         // Bounds can't be lower than [1, 1] stop checking.
-        return ProbabilityBound(1.0, 1.0);
+        ProbabilityBound bound(1.0, 1.0);
+        cache_.emplace(codepoints, bound);
+        return bound;
       }
     }
   }
@@ -73,18 +84,23 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
   // - Either the largest individual codepoint frequency.
   // - max(Pi + Pj - Pij)
   // - Or: sum(Pi) - sum(Pj<k)
-  double lower =
-      std::max(std::max(std::max(unigram_total - bigram_total, max_pair_bound),
-                        max_single_bound),
-               best_lower);
+  double raw_lower =
+      std::max(std::max(unigram_total - bigram_total, max_pair_bound),
+               max_single_bound);
 
   // == Upper Bound ==
   // An upper bound is given by
   // sum(Pi) - max_j=1..n [ sum_j!=k(Pjk) ]
-  double upper =
-      std::max(std::min(unigram_total - max_partial_bigram_total, 1.0), lower);
+  double raw_upper =
+      std::max(std::min(unigram_total - max_partial_bigram_total, 1.0), raw_lower);
 
-  return ProbabilityBound(lower, upper);
+  ProbabilityBound raw_bound(raw_lower, raw_upper);
+  cache_.emplace(codepoints, raw_bound);
+
+  double final_lower = std::max(raw_lower, best_lower);
+  double final_upper = std::max(raw_upper, final_lower);
+
+  return ProbabilityBound(final_lower, final_upper);
 }
 
 ProbabilityBound BigramProbabilityCalculator::ComputeProbability(

--- a/ift/freq/bigram_probability_calculator.h
+++ b/ift/freq/bigram_probability_calculator.h
@@ -1,6 +1,7 @@
 #ifndef IFT_FREQ_BIGRAM_PROBABILITY_CALCULATOR_H_
 #define IFT_FREQ_BIGRAM_PROBABILITY_CALCULATOR_H_
 
+#include "absl/container/flat_hash_map.h"
 #include "ift/common/int_set.h"
 #include "ift/freq/probability_bound.h"
 #include "ift/freq/probability_calculator.h"
@@ -37,6 +38,7 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
       double best_lower) const;
 
   UnicodeFrequencies frequencies_;
+  mutable absl::flat_hash_map<ift::common::CodepointSet, ProbabilityBound> cache_;
 };
 
 }  // namespace ift::freq

--- a/ift/freq/bigram_probability_calculator.h
+++ b/ift/freq/bigram_probability_calculator.h
@@ -32,6 +32,10 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
       const ift::common::CodepointSet& codepoints,
       double current_best_lower) const;
 
+  ProbabilityBound ComputeProbabilityInternal(
+      const ift::encoder::SubsetDefinition& definition,
+      double best_lower) const;
+
   UnicodeFrequencies frequencies_;
 };
 

--- a/ift/freq/bigram_probability_calculator_test.cc
+++ b/ift/freq/bigram_probability_calculator_test.cc
@@ -128,7 +128,39 @@ TEST(BigramProbabilityCalculatorTest, ComputeProbability_ClampedUpper) {
 }
 
 TEST(BigramProbabilityCalculatorTest, ComputeProbability_WithLayoutTags) {
-  // TODO(garretrieger): XXXX test with layout tags once implemented.
+  UnicodeFrequencies frequencies{
+      {{'a', 'a'}, 70},
+      {{'c', 'c'}, 100},
+  };
+
+  BigramProbabilityCalculator calc(std::move(frequencies));
+
+  SubsetDefinition def;
+  def.feature_tags.insert(HB_TAG('l', 'i', 'g', 'a'));
+
+  // P(liga) = 0.001
+  // Codepoints are empty, so codepoints_bound = {0, 0}
+  // Combined: Lower = max(0, 0.001) = 0.001
+  //           Upper = min(1.0, 0 + 0.001) = 0.001
+  ASSERT_EQ(calc.ComputeProbability(def), (ProbabilityBound{0.001, 0.001}));
+
+  // Add another tag
+  def.feature_tags.insert(HB_TAG('c', 'c', 'm', 'p'));
+  // P(ccmp) = 0.001
+  // Combined tags probability:
+  // features_min = 0.001
+  // features_sum = 0.002
+  // Lower = max(0, 0.001) = 0.001
+  // Upper = min(1.0, 0 + 0.002) = 0.002
+  ASSERT_EQ(calc.ComputeProbability(def), (ProbabilityBound{0.001, 0.002}));
+
+  // Add a codepoint
+  def.codepoints.insert('a');
+  // P(a) = 0.7
+  // codepoints_bound = {0.7, 0.7}
+  // Lower = max(0.7, 0.001) = 0.7
+  // Upper = min(1.0, 0.7 + 0.002) = 0.702
+  ASSERT_EQ(calc.ComputeProbability(def), (ProbabilityBound{0.7, 0.702}));
 }
 
 TEST(BigramProbabilityCalculatorTest, ComputeConjunctiveProbability) {

--- a/ift/freq/bigram_probability_calculator_test.cc
+++ b/ift/freq/bigram_probability_calculator_test.cc
@@ -38,6 +38,22 @@ TEST(BigramProbabilityCalculatorTest, ComputeProbability) {
   ASSERT_DOUBLE_EQ(b.Max(), Pabd_upper);
 }
 
+TEST(BigramProbabilityCalculatorTest, ComputeProbability_Cached) {
+  UnicodeFrequencies frequencies{
+      {{'a', 'a'}, 70}, {{'b', 'b'}, 60}, {{'c', 'c'}, 100},
+      {{'a', 'b'}, 40}, {{'a', 'c'}, 50}, {{'b', 'c'}, 60},
+  };
+
+  BigramProbabilityCalculator calc(std::move(frequencies));
+
+  // Call once to populate cache
+  calc.ComputeProbability({'a', 'b'});
+
+  // Call again to use cache
+  double Pab = 0.70 + 0.60 - 0.40;
+  ASSERT_EQ(calc.ComputeProbability({'a', 'b'}), (ProbabilityBound{Pab, Pab}));
+}
+
 TEST(BigramProbabilityCalculatorTest, ComputeMergedProbability) {
   UnicodeFrequencies frequencies{
       {{'a', 'a'}, 70}, {{'b', 'b'}, 60}, {{'c', 'c'}, 100},


### PR DESCRIPTION
- Don't merge layout feature containing segments during pre-grouping.
- Don't mix codepoint and layout feature segments during cost based merging.
- Add bigram probability calculation support for segments which contain layout features.

Lastly, this adds a cache to bigram probability calculator to help speed up repeated probability calculations. Improves runtimes at quality 2 and above.