### PR TITLE
Improve the accuracy of the init font moving cost delta computation.

### DIFF
--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -201,6 +201,23 @@ cc_test(
 )
 
 cc_test(
+    name = "requested_segmentation_information_test",
+    size = "small",
+    srcs = [
+        "requested_segmentation_information_test.cc",
+    ],
+    data = [
+        "//ift/common:testdata",
+    ],
+    deps = [
+        ":encoder",
+        ":segmentation_info",
+        "//ift/common",
+        "@googletest//:gtest_main",
+    ],
+)
+
+cc_test(
     name = "subset_definition_test",
     size = "small",
     srcs = [

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -1,6 +1,7 @@
 #include "ift/encoder/activation_condition.h"
 
 #include <algorithm>
+#include <vector>
 
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_map.h"
@@ -181,7 +182,7 @@ bool ActivationCondition::Intersects(const common::SegmentSet& segments) const {
 }
 
 ActivationCondition ActivationCondition::ReplaceSegments(
-    segment_index_t base_segment, const common::SegmentSet& segments) const {
+    segment_index_t base_segment, const SegmentSet& segments) const {
   ActivationCondition new_condition = *this;
   for (auto& condition_group : new_condition.conditions_) {
     if (condition_group.intersects(segments)) {
@@ -190,6 +191,25 @@ ActivationCondition ActivationCondition::ReplaceSegments(
     }
   }
   Simplify(new_condition.conditions_);
+  return new_condition;
+}
+
+ActivationCondition ActivationCondition::RemoveIntersectingSubgroups(const SegmentSet& segments) const {
+  ActivationCondition new_condition = ActivationCondition::True(0);
+  new_condition.activated_ = activated_;
+  new_condition.encoding_ = encoding_;
+  new_condition.is_fallback_ = is_fallback_;
+  new_condition.is_exclusive_ = is_exclusive_;
+
+
+  for (const auto& condition_group : conditions_) {
+    if (!condition_group.intersects(segments)) {
+      new_condition.conditions_.push_back(condition_group);
+    }
+  }
+
+  // Simplify is not needed as the existing condition will already be simplified and removing
+  // sub-groups does not affect simplification.
   return new_condition;
 }
 

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -124,6 +124,10 @@ class ActivationCondition {
   ActivationCondition ReplaceSegments(segment_index_t base_segment,
                                       const common::SegmentSet& segments) const;
 
+  // Generate a new condition which is a copy of this one but with all
+  // sub grups that contain segments removed.
+  ActivationCondition RemoveIntersectingSubgroups(const common::SegmentSet& segments) const;
+
   /*
    * Returns a human readable string representation of this condition.
    */

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -244,9 +244,9 @@ StatusOr<uint32_t> CandidateMerge::Woff2SizeOf(hb_face_t* original_face,
   return (double)woff2.size();
 }
 
-// Finds the set of patches which intersect gids.
-static flat_hash_map<ActivationCondition, GlyphSet> PatchesWithGlyphs(
-    const SegmentationContext& context, const GlyphSet& gids) {
+// Finds the set of patches which intersect either gids or segments.
+static flat_hash_map<ActivationCondition, GlyphSet> PatchesWithGlyphsOrSegments(
+    const SegmentationContext& context, const GlyphSet& gids, const SegmentSet& segments) {
   // To more efficiently target our search we can use the glyph_condition_set to
   // locate conditions that intersect with gids.
   GlyphSet fallback_glyphs = context.glyph_groupings.UnmappedGlyphs();
@@ -265,6 +265,11 @@ static flat_hash_map<ActivationCondition, GlyphSet> PatchesWithGlyphs(
     }
 
     conditions_of_interest.insert(*result);
+  }
+
+  for (segment_index_t s : segments) {
+    const auto& conditions = context.glyph_groupings.TriggeringSegmentToConditions(s);
+    conditions_of_interest.insert(conditions.begin(), conditions.end());
   }
 
   flat_hash_map<ActivationCondition, GlyphSet> result;
@@ -286,7 +291,7 @@ static flat_hash_map<ActivationCondition, GlyphSet> PatchesWithGlyphs(
 
 Status CandidateMerge::ComputeInitFontGlyphDelta(
     Merger& merger, const GlyphSet& moved_glyphs, GlyphSet& new_glyph_closure,
-    GlyphSet& glyph_closure_delta) {
+    GlyphSet& glyph_closure_delta, CodepointSet& codepoint_closure_delta) {
   SubsetDefinition inital_subset =
       merger.Context().SegmentationInfo().InitFontSegment();
   inital_subset.gids.union_set(moved_glyphs);
@@ -299,7 +304,53 @@ Status CandidateMerge::ComputeInitFontGlyphDelta(
   glyph_closure_delta.subtract(
       merger.Context().SegmentationInfo().InitFontGlyphs());
 
+  codepoint_closure_delta = std::move(expanded.codepoints);
+  codepoint_closure_delta.subtract(inital_subset.codepoints);
+
   return absl::OkStatus();
+}
+
+static std::optional<std::pair<ActivationCondition, GlyphSet>> FindExistingCondition(
+  const flat_hash_map<ActivationCondition, GlyphSet>& condition_and_glyphs,
+  const ActivationCondition& condition) {
+
+  auto it = condition_and_glyphs.find(condition);
+  if (it != condition_and_glyphs.end()) {
+    return *it;
+  }
+
+  if (condition.IsUnitary()) {
+    // For unitary conditions, the existing one might exist under a different is_exclusive value
+    segment_index_t s = *condition.TriggeringSegments().min();
+    ActivationCondition secondary = ActivationCondition::exclusive_segment(s, 0);
+    if (condition.IsExclusive()) {
+      secondary = ActivationCondition::or_segments({s}, 0);
+    }
+    it = condition_and_glyphs.find(secondary);
+    if (it != condition_and_glyphs.end()) {
+      return *it;
+    }
+  }
+
+  return std::nullopt;
+}
+
+static StatusOr<double> CostFor(Merger& merger, const ActivationCondition& condition, const GlyphSet& glyphs) {
+  double probability = 1.0;
+  if (!condition.IsFallback()) {
+    probability = TRY(
+          condition.Probability(merger.Context().SegmentationInfo().Segments(),
+                                *merger.Strategy().ProbabilityCalculator()));
+  }
+
+  double patch_size =
+      TRY(merger.Context().patch_size_cache_for_init_font->GetPatchSize(
+          glyphs)) + merger.Strategy().NetworkOverheadCost();
+
+  double cost = probability * patch_size;
+  VLOG(1) << "    - (" << probability << " * " << patch_size
+          << ") -> " << cost << " [modified patch]";
+  return cost;
 }
 
 StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
@@ -315,25 +366,25 @@ StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
   // size of the init font closure as a proxy to measure the cost of glyph data
   // in the initial font.
 
-  // TODO(garretrieger): XXXXX figure out which segments are removed as a result
-  // of the init font change. Then compute modified patch deltas similar to
-  // ComputeCostDelta but doing segment removal instead of replacement.
-
   // Moving glyphs to the initial font has the following affects:
-  // 1. The initial font subset definition is updated to included moved_glyphs.
-  //    This in turn expands the initial closure pulling in moved_glyphs and
-  //    possibly some additional glyphs. As a result there is some increase in
-  //    the initial font size.
+  // 1. Based on the input moved_glyphs an expanded set of glyphs and codepoints are found
+  //    and moved to the initial font.
+  // 2. This affects condition -> patch costs by changing the contained glyphs and in
+  //    some cases modifying the activation conditions. Conditions are changed by either
+  //    segments being fully moved to init font (becoming always true), or more rarely
+  //    by segment definitions changing which in turn affects the probability.
 
   GlyphSet new_glyph_closure, glyph_closure_delta;
+  CodepointSet codepoint_closure_delta;
   TRYV(ComputeInitFontGlyphDelta(merger, moved_glyphs, new_glyph_closure,
-                                 glyph_closure_delta));
+                                 glyph_closure_delta, codepoint_closure_delta));
 
   double total_delta = 0.0;
   double before = existing_init_font_size;
   double after =
       TRY(merger.Context().patch_size_cache_for_init_font->GetPatchSize(
           new_glyph_closure));
+
   if (after > before) {
     // case where after is < before happen occasionally as the result of
     // running with lower brotli compression quality. Ignores these in order
@@ -342,49 +393,68 @@ StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
   }
   VLOG(1) << "    + " << total_delta << " [init font increase]";
 
-  // 2. All of the glyphs which are newly added to the initial closure are
-  // removed
-  //    from any patches which they occur in.
-  // 3. Any patches which now have no glyphs left are removed.
+  SegmentSet modified_segments = merger.Context().SegmentationInfo().SegmentsForCodepoints(codepoint_closure_delta);
+  SegmentSet removed_segments;
+  for (segment_index_t s : modified_segments) {
+    const auto& segment = merger.Context().SegmentationInfo().Segments().at(s).Definition();
+    if (segment.feature_tags.empty() && segment.codepoints.is_subset_of(codepoint_closure_delta)) {
+      // all codepoints are being moved to init font, so this segment is going to be removed.
+      removed_segments.insert(s);
+    }
+  }
+
+  flat_hash_map<ActivationCondition, GlyphSet> new_conditions;
+
   const uint32_t per_request_overhead = merger.Strategy().NetworkOverheadCost();
-  for (const auto& [condition, glyphs] :
-       PatchesWithGlyphs(merger.Context(), glyph_closure_delta)) {
-    // TODO(garretrieger): Glyph removal from a patch could possibly influence
-    // the probability of that patch occuring (via removal of segments). Ideally
-    // we'd include that in this calculation. This should have only a minor
-    // impact on the computed delta's since the majority of cases we process
-    // here will just be full patch removals.
-    double patch_probability = 1.0;
+  auto affected_conditions = PatchesWithGlyphsOrSegments(merger.Context(), glyph_closure_delta, modified_segments);
+  for (const auto& [condition, glyphs] : affected_conditions) {
+
+    GlyphSet glyphs_after = glyphs;
+    glyphs_after.subtract(glyph_closure_delta);
+
+    total_delta -= TRY(CostFor(merger, condition, glyphs));
+
+    if (glyphs_after.empty()) {
+      continue;
+    }
+
+    // Remove segments effectively become always true, so update the condition by removing
+    // sub-groups that contain those segments as the whole subgroup will also become "true".
+    ActivationCondition updated = condition.RemoveIntersectingSubgroups(removed_segments);
+    auto [it, did_insert] = new_conditions.emplace(updated, GlyphSet {});
+    it->second.union_set(glyphs_after);
+    if (!did_insert) {
+      continue;
+    }
+
+    auto existing = FindExistingCondition(merger.Context().glyph_groupings.ConditionsAndGlyphs(), updated);
+    if (existing.has_value() && !affected_conditions.contains(existing->first)) {
+      // Existing isn't in the affected list so we need to account for it's removal, and transfer
+      // it's glyphs to new_conditions.
+      it->second.union_set(existing->second);
+      total_delta -= TRY(CostFor(merger, existing->first, existing->second));
+    }
+  }
+
+  for (const auto& [condition, glyphs] : new_conditions) {
+    double patch_probability_after = 1.0;
     if (!condition.IsFallback()) {
-      patch_probability = TRY(
+      // TODO(garretrieger): XXXX also include the effect of modified segments in this calc.
+      // Start with finding a test case.
+      patch_probability_after = TRY(
           condition.Probability(merger.Context().SegmentationInfo().Segments(),
                                 *merger.Strategy().ProbabilityCalculator()));
     }
 
-    double patch_size_before =
-        TRY(merger.Context().patch_size_cache_for_init_font->GetPatchSize(
-            glyphs)) +
-        per_request_overhead;
-
-    GlyphSet new_glyphs = glyphs;
-    new_glyphs.subtract(glyph_closure_delta);
-
-    double cost_before = patch_probability * patch_size_before;
-    VLOG(1) << "    - (" << patch_probability << " * " << patch_size_before
-            << ") -> " << cost_before << " [modified patch]";
-    total_delta -= cost_before;
-
-    if (!new_glyphs.empty()) {
-      double patch_size_after =
+    double patch_size_after =
           TRY(merger.Context().patch_size_cache_for_init_font->GetPatchSize(
-              new_glyphs)) +
+              glyphs)) +
           per_request_overhead;
-      double cost_after = patch_probability * patch_size_after;
+    double cost_after = patch_probability_after * patch_size_after;
 
-      VLOG(1) << "    + (" << patch_probability << " * " << patch_size_after
-              << ") -> " << cost_after << " [modified patch]";
-      total_delta += cost_after;
-    }
+    VLOG(1) << "    + (" << patch_probability_after << " * " << patch_size_after
+            << ") -> " << cost_after << " [modified patch]";
+    total_delta += cost_after;
   }
 
   VLOG(1) << "    = " << total_delta;
@@ -395,16 +465,22 @@ StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
 StatusOr<double> CandidateMerge::ComputeBestCaseInitFontCostDelta(
     Merger& merger, uint32_t existing_init_font_size,
     const GlyphSet& moved_glyphs) {
+
+  // TODO(garretrieger): consider reworking this to avoid running a glyph closure, by
+  // working only with the explicitly moved glyphs.
   GlyphSet new_glyph_closure, glyph_closure_delta;
+  CodepointSet codepoint_closure_delta;
   TRYV(ComputeInitFontGlyphDelta(merger, moved_glyphs, new_glyph_closure,
-                                 glyph_closure_delta));
+                                 glyph_closure_delta, codepoint_closure_delta));
 
   double cost_delta = 0.0;
   double best_case_reduction =
       merger.Strategy().BestCaseSizeReductionFraction();
   double per_request_overhead = merger.Strategy().NetworkOverheadCost();
+  // This best case computation is a simplified version that ignores the impact of changing
+  // segments on the cost computation and focuses only on the glyphs that are being moved.
   for (const auto& [condition, glyphs] :
-       PatchesWithGlyphs(merger.Context(), glyph_closure_delta)) {
+       PatchesWithGlyphsOrSegments(merger.Context(), glyph_closure_delta, SegmentSet {})) {
     double patch_probability = 1.0;
     if (!condition.IsFallback()) {
       patch_probability = TRY(

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -150,11 +150,6 @@ struct CandidateMerge {
       Merger& merger, const ift::common::SegmentSet& merged_segments,
       const Segment& merged_segment, std::optional<common::GlyphSet> exclusive_gids);
 
-  static absl::Status ComputeInitFontGlyphDelta(
-      Merger& merger, const ift::common::GlyphSet& moved_glyphs,
-      ift::common::GlyphSet& new_glyph_closure,
-      ift::common::GlyphSet& glyph_closure_delta);
-
   // Computes the predicted change to the toal cost if moved_glyphs are
   // moved from patches into the initial font.
   //
@@ -178,6 +173,14 @@ struct CandidateMerge {
   static absl::StatusOr<uint32_t> Woff2SizeOf(hb_face_t* original_face,
                                               const SubsetDefinition& def,
                                               int quality);
+
+ private:
+  static absl::Status ComputeInitFontGlyphDelta(
+      Merger& merger, const ift::common::GlyphSet& moved_glyphs,
+      ift::common::GlyphSet& glyph_closure_delta,
+      ift::common::GlyphSet& new_glyph_closure,
+      ift::common::CodepointSet& codepoint_closure_delta
+    );
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/candidate_merge_test.cc
+++ b/ift/encoder/candidate_merge_test.cc
@@ -3,6 +3,7 @@
 #include <memory>
 #include <optional>
 
+#include "absl/log/globals.h"
 #include "gtest/gtest.h"
 #include "ift/common/font_data.h"
 #include "ift/common/int_set.h"
@@ -11,14 +12,17 @@
 #include "ift/encoder/merger.h"
 #include "ift/encoder/mock_patch_size_cache.h"
 #include "ift/encoder/subset_definition.h"
+#include "ift/encoder/types.h"
 #include "ift/freq/mock_probability_calculator.h"
 #include "ift/freq/probability_bound.h"
 #include "ift/freq/unicode_frequencies.h"
 
 using ift::config::CLOSURE_ONLY;
+using ift::config::DEP_GRAPH_ONLY;
 using ift::config::PATCH;
 
 using ift::common::CodepointSet;
+using ift::common::GlyphSet;
 using ift::common::FontData;
 using ift::common::hb_face_unique_ptr;
 using ift::common::IntSet;
@@ -479,6 +483,119 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_RequiresPatches) {
   ASSERT_TRUE(r.ok()) << r.status();
   // {0 or 1} has no patch associated with it, so no merge is possible.
   ASSERT_FALSE(r->has_value());
+}
+
+TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
+  std::vector<Segment> segments = {
+      {{'b'}, ProbabilityBound{0.95, 0.95}},
+      {{'f'}, ProbabilityBound{0.85, 0.85}},
+      {{'i'}, ProbabilityBound{0.75, 0.75}},
+  };
+
+  auto probability_calculator =
+      std::make_unique<freq::MockProbabilityCalculator>(segments);
+
+  ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY);
+  auto context = SegmentationContext::InitializeSegmentationContext(
+      roboto.get(), {'a'}, segments, segmenter.unmapped_glyph_handling(),
+      segmenter.condition_analysis_mode(), segmenter.brotli_quality(),
+      segmenter.init_font_merging_brotli_quality());
+  ASSERT_TRUE(context.ok()) << context.status();
+
+  Merger merger = *Merger::New(
+      *context,
+      MergeStrategy::CostBased(std::move(probability_calculator), 75, 4), all,
+      all);
+
+  glyph_id_t g_a = 69;
+  glyph_id_t g_b = 70;
+  glyph_id_t g_f = 74;
+  glyph_id_t g_i = 77;
+  glyph_id_t g_fi = 444;
+  glyph_id_t g_ffi = 446;
+
+  uint32_t init_size = *context->patch_size_cache_for_init_font->GetPatchSize({0, g_a});
+  uint32_t plus_b_size = *context->patch_size_cache_for_init_font->GetPatchSize({0, g_a, g_b});
+  uint32_t plus_f_size = *context->patch_size_cache_for_init_font->GetPatchSize({0, g_a, g_f});
+  uint32_t plus_f_i_fi_ffi_size = *context->patch_size_cache_for_init_font->GetPatchSize({0, g_a, g_f, g_i, g_fi, g_ffi});
+  uint32_t plus_fi_ffi_size = *context->patch_size_cache_for_init_font->GetPatchSize({0, g_a, g_fi, g_ffi});
+  uint32_t plus_fi_size = *context->patch_size_cache_for_init_font->GetPatchSize({0, g_a, g_fi});
+
+  uint32_t b_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_b});
+  uint32_t f_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_f});
+  uint32_t i_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_i});
+  uint32_t fi_ffi_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_fi, g_ffi});
+  uint32_t ffi_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_ffi});
+  uint32_t i_fi_ffi_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_i, g_fi, g_ffi});
+
+  /* Case 1: simple move */
+  auto r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_b});
+  ASSERT_TRUE(r.ok()) << r.status();
+  double delta = r->first;
+  GlyphSet moved_glyphs = r->second;
+
+  EXPECT_EQ(delta,
+    // patch with b removed and moved to the init font.
+    (plus_b_size - init_size) - 0.95 * (b_size + 75));
+  EXPECT_EQ(moved_glyphs, (GlyphSet {g_b}));
+
+  /* Case 2: move + modified conditions (one half of (f AND i) moved) */
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_f});
+  ASSERT_TRUE(r.ok()) << r.status();
+  delta = r->first;
+  moved_glyphs = r->second;
+
+  EXPECT_NEAR(delta,
+    (plus_f_size - init_size) /* init font increase */
+    - 0.85 * (f_size + 75) /* if (f) removed */
+    - 0.75 * (i_size + 75) /* if (i) removed */
+    - (0.75 * 0.85) * (fi_ffi_size + 75) /* if (f and i) removed */
+    + 0.75 * (i_fi_ffi_size + 75) /* if (i) with ligatures */,
+    1e-9
+  );
+  EXPECT_EQ(moved_glyphs, (GlyphSet {g_f}));
+
+  /* Case 3: move non exclusive */
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_fi, g_ffi});
+  ASSERT_TRUE(r.ok()) << r.status();
+  delta = r->first;
+  moved_glyphs = r->second;
+
+  EXPECT_NEAR(delta,
+    (plus_fi_ffi_size - init_size) /* init font increase */
+    - (0.85 * 0.75) * (fi_ffi_size + 75), /* if (f and i) removed */
+    1e-9
+  );
+  EXPECT_EQ(moved_glyphs, (GlyphSet {g_fi, g_ffi}));
+
+  /* Case 4: move part of a patch */
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_fi});
+  ASSERT_TRUE(r.ok()) << r.status();
+  delta = r->first;
+  moved_glyphs = r->second;
+
+  EXPECT_NEAR(delta,
+    (plus_fi_size - init_size) /* init font increase */
+    - (0.85 * 0.75) * (fi_ffi_size + 75) /* if (f and i) removed */
+    + (0.85 * 0.75) * (ffi_size + 75), /* if (f and i) added */
+    1e-9
+  );
+  EXPECT_EQ(moved_glyphs, (GlyphSet {g_fi}));
+
+  /* Case 5: move multiple */
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_f, g_i});
+  ASSERT_TRUE(r.ok()) << r.status();
+  delta = r->first;
+  moved_glyphs = r->second;
+
+  EXPECT_NEAR(delta,
+    (plus_f_i_fi_ffi_size - init_size) /* init font increase */
+    - 0.85 * (f_size + 75) /* if (f) removed */
+    - 0.75 * (i_size + 75) /* if (i) removed */
+    - (0.75 * 0.85) * (fi_ffi_size + 75), /* if (f and i) removed */
+    1e-9
+  );
+  EXPECT_EQ(moved_glyphs, (GlyphSet {g_f, g_i, g_fi, g_ffi}));
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/requested_segmentation_information.cc
+++ b/ift/encoder/requested_segmentation_information.cc
@@ -3,11 +3,14 @@
 #include <memory>
 #include <vector>
 
+#include "ift/common/int_set.h"
 #include "ift/encoder/segment.h"
 #include "ift/encoder/subset_definition.h"
 
 using ift::config::UnmappedGlyphHandling;
 
+using ift::common::CodepointSet;
+using ift::common::SegmentSet;
 using absl::StatusOr;
 
 namespace ift::encoder {
@@ -55,8 +58,42 @@ RequestedSegmentationInformation::RequestedSegmentationInformation(
       unmapped_glyph_handling_(unmapped_glyph_handling) {
   // ReassignInitSubset expects full_definition_ is already populated.
   full_definition_ = init_font_segment;
-  for (const auto& s : segments_) {
-    full_definition_.Union(s.Definition());
+  for (size_t i = 0; i < segments_.size(); ++i) {
+    full_definition_.Union(segments_[i].Definition());
+    AddToIndex(i, segments_[i].Definition().codepoints);
+  }
+}
+
+SegmentSet RequestedSegmentationInformation::SegmentsForCodepoints(
+    const CodepointSet& codepoints) const {
+  SegmentSet result;
+  for (hb_codepoint_t cp : codepoints) {
+    auto it = codepoint_to_segments_.find(cp);
+    if (it != codepoint_to_segments_.end()) {
+      result.union_set(it->second);
+    }
+  }
+  return result;
+}
+
+void RequestedSegmentationInformation::AddToIndex(
+    segment_index_t s, const CodepointSet& codepoints) {
+  for (hb_codepoint_t cp : codepoints) {
+    codepoint_to_segments_[cp].insert(s);
+  }
+}
+
+void RequestedSegmentationInformation::RemoveFromIndex(
+    segment_index_t s, const CodepointSet& codepoints) {
+  for (hb_codepoint_t cp : codepoints) {
+    auto it = codepoint_to_segments_.find(cp);
+    if (it == codepoint_to_segments_.end()) {
+      continue;
+    }
+    it->second.erase(s);
+    if (it->second.empty()) {
+      codepoint_to_segments_.erase(it);
+    }
   }
 }
 

--- a/ift/encoder/requested_segmentation_information.h
+++ b/ift/encoder/requested_segmentation_information.h
@@ -3,6 +3,7 @@
 
 #include <memory>
 
+#include "absl/container/flat_hash_map.h"
 #include "ift/common/int_set.h"
 #include "ift/common/try.h"
 #include "ift/config/common.pb.h"
@@ -36,10 +37,14 @@ class RequestedSegmentationInformation {
                                const ift::common::SegmentSet& to_merge,
                                const Segment& merged_segment) {
     auto& base_segment = segments_[base];
+    RemoveFromIndex(base, base_segment.Definition().codepoints);
     base_segment = merged_segment;
+    AddToIndex(base, base_segment.Definition().codepoints);
+
     for (segment_index_t s : to_merge) {
       // To avoid changing the indices of other segments set the ones we're
       // removing to empty sets. That effectively disables them.
+      RemoveFromIndex(s, segments_[s].Definition().codepoints);
       segments_[s].Clear();
     }
     return base_segment.Definition().codepoints.size();
@@ -60,9 +65,12 @@ class RequestedSegmentationInformation {
     // Changing the init font subset may have caused additional codepoints to be
     // moved to the init font. We need to update the segment definitions to
     // remove these.
-    for (auto& s : segments_) {
-      // TODO XXXXX this also needs to handle features?
+    for (size_t i = 0; i < segments_.size(); ++i) {
+      auto& s = segments_[i];
       if (s.Definition().codepoints.intersects(init_font_segment_.codepoints)) {
+        ift::common::CodepointSet intersection = s.Definition().codepoints;
+        intersection.intersect(init_font_segment_.codepoints);
+        RemoveFromIndex(i, intersection);
         s.Definition().codepoints.subtract(init_font_segment_.codepoints);
       }
     }
@@ -140,13 +148,23 @@ class RequestedSegmentationInformation {
     return def;
   }
 
+  ift::common::SegmentSet SegmentsForCodepoints(
+      const ift::common::CodepointSet& codepoints) const;
+
  private:
+  void AddToIndex(segment_index_t seg_idx,
+                  const ift::common::CodepointSet& codepoints);
+  void RemoveFromIndex(segment_index_t seg_idx,
+                       const ift::common::CodepointSet& codepoints);
+
   std::vector<Segment> segments_;
   SubsetDefinition init_font_segment_;
   SubsetDefinition full_definition_;
   ift::common::GlyphSet full_closure_;
   bool segments_disjoint_;
   enum ift::config::UnmappedGlyphHandling unmapped_glyph_handling_;
+  absl::flat_hash_map<hb_codepoint_t, ift::common::SegmentSet>
+      codepoint_to_segments_;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/requested_segmentation_information_test.cc
+++ b/ift/encoder/requested_segmentation_information_test.cc
@@ -1,0 +1,113 @@
+#include "ift/encoder/requested_segmentation_information.h"
+
+#include <vector>
+
+#include "gtest/gtest.h"
+#include "ift/common/font_data.h"
+#include "ift/encoder/subset_definition.h"
+#include "ift/freq/probability_bound.h"
+
+using ift::config::PATCH;
+using ift::common::CodepointSet;
+using ift::common::SegmentSet;
+using ift::common::FontData;
+using ift::common::hb_face_unique_ptr;
+using ift::common::make_hb_face;
+using ift::freq::ProbabilityBound;
+
+namespace ift::encoder {
+
+class RequestedSegmentationInformationTest : public ::testing::Test {
+ protected:
+  RequestedSegmentationInformationTest() : roboto(make_hb_face(nullptr)) {
+    roboto = from_file("ift/common/testdata/Roboto-Regular.ttf");
+  }
+
+  hb_face_unique_ptr from_file(const char* filename) {
+    hb_blob_t* blob = hb_blob_create_from_file_or_fail(filename);
+    if (!blob) {
+      assert(false);
+    }
+    FontData result(blob);
+    hb_blob_destroy(blob);
+    return result.face();
+  }
+
+  hb_face_unique_ptr roboto;
+};
+
+TEST_F(RequestedSegmentationInformationTest, SegmentsForCodepoints) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'a', 'b'}, ProbabilityBound::Zero()},
+      {{'b', 'c'}, ProbabilityBound::Zero()},
+      {{'d'}, ProbabilityBound::Zero()},
+  };
+
+  auto info_or =
+      RequestedSegmentationInformation::Create(segments, {}, cache, PATCH);
+  ASSERT_TRUE(info_or.ok());
+  auto& info = *info_or;
+
+  EXPECT_EQ(info->SegmentsForCodepoints({'a'}), (SegmentSet{0}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'b'}), (SegmentSet{0, 1}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'c'}), (SegmentSet{1}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'d'}), (SegmentSet{2}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'e'}), (SegmentSet{}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'a', 'c'}), (SegmentSet{0, 1}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'a', 'd'}), (SegmentSet{0, 2}));
+}
+
+TEST_F(RequestedSegmentationInformationTest, IndexUpdatesOnMerge) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'a'}, ProbabilityBound::Zero()},
+      {{'b'}, ProbabilityBound::Zero()},
+      {{'c'}, ProbabilityBound::Zero()},
+  };
+
+  auto info_or =
+      RequestedSegmentationInformation::Create(segments, {}, cache, PATCH);
+  ASSERT_TRUE(info_or.ok());
+  auto& info = *info_or;
+
+  EXPECT_EQ(info->SegmentsForCodepoints({'a'}), (SegmentSet{0}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'b'}), (SegmentSet{1}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'c'}), (SegmentSet{2}));
+
+  // Merge segment 1 into segment 0, new definition is {'a', 'b'}
+  Segment merged{{'a', 'b'}, ProbabilityBound::Zero()};
+  info->AssignMergedSegment(0, {1}, merged);
+
+  EXPECT_EQ(info->SegmentsForCodepoints({'a'}), (SegmentSet{0}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'b'}), (SegmentSet{0}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'c'}), (SegmentSet{2}));
+}
+
+TEST_F(RequestedSegmentationInformationTest, IndexUpdatesOnReassignInit) {
+  GlyphClosureCache cache(roboto.get());
+  std::vector<Segment> segments{
+      {{'a', 'b'}, ProbabilityBound::Zero()},
+      {{'b', 'c'}, ProbabilityBound::Zero()},
+  };
+
+  auto info_or =
+      RequestedSegmentationInformation::Create(segments, {}, cache, PATCH);
+  ASSERT_TRUE(info_or.ok());
+  auto& info = *info_or;
+
+  EXPECT_EQ(info->SegmentsForCodepoints({'a'}), (SegmentSet{0}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'b'}), (SegmentSet{0, 1}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'c'}), (SegmentSet{1}));
+
+  // Reassign init subset to include 'b'. This should remove 'b' from all segments.
+  SubsetDefinition new_init;
+  new_init.codepoints = {'b'};
+  ASSERT_TRUE(info->ReassignInitSubset(cache, new_init).ok());
+
+  EXPECT_EQ(info->SegmentsForCodepoints({'a'}), (SegmentSet{0}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'b'}), (SegmentSet{}));
+  EXPECT_EQ(info->SegmentsForCodepoints({'c'}), (SegmentSet{1}));
+}
+
+}  // namespace ift::encoder


### PR DESCRIPTION
Previous version ignored the impact of condition probability changes due to segment removal, this adds those to the calculation.