### PR TITLE
Reduce segmenter memory usage further.

### DIFF
--- a/ift/config/load_codepoints.cc
+++ b/ift/config/load_codepoints.cc
@@ -203,18 +203,22 @@ static Status LoadFrequenciesFromRiegeliIndividual(
   return absl::OkStatus();
 }
 
-StatusOr<UnicodeFrequencies> LoadFrequenciesFromRiegeli(const char* path) {
+StatusOr<UnicodeFrequencies> LoadFrequenciesFromRiegeli(
+    const char* path,
+    std::optional<CodepointSet> filter) {
   auto paths = TRY(ExpandShardedPath(path));
-  UnicodeFrequenciesBuilder builder;
+  UnicodeFrequenciesBuilder builder(filter);
   for (const auto& path : paths) {
     TRYV(LoadFrequenciesFromRiegeliIndividual(path.c_str(), builder));
   }
   return builder.Build();
 }
 
-StatusOr<UnicodeFrequencies> LoadBuiltInFrequencies(const char* name) {
+StatusOr<UnicodeFrequencies> LoadBuiltInFrequencies(
+    const char* name,
+    std::optional<CodepointSet> filter) {
   std::string path = StrCat("../ift_encoder_data+/data/", name);
-  return LoadFrequenciesFromRiegeli(path.c_str());
+  return LoadFrequenciesFromRiegeli(path.c_str(), filter);
 }
 
 StatusOr<flat_hash_map<std::string, CodepointSet>> BuiltInFrequenciesList() {

--- a/ift/config/load_codepoints.h
+++ b/ift/config/load_codepoints.h
@@ -42,14 +42,16 @@ absl::StatusOr<ift::common::FontData> LoadFile(const char* path);
 // For example "FrequencyData.riegeli@*" will load all files of the
 // form FrequencyData.riegeli-*-of-* into the frequency data set.
 absl::StatusOr<ift::freq::UnicodeFrequencies> LoadFrequenciesFromRiegeli(
-    const char* path);
+    const char* path,
+    std::optional<ift::common::CodepointSet> filter = std::nullopt);
 
 // loads frequency data from https://github.com/w3c/ift-encoder-data
 //
 // name is the file name to load.
 // Append "@*" to the name to load all sharded files for a name.
 absl::StatusOr<ift::freq::UnicodeFrequencies> LoadBuiltInFrequencies(
-    const char* name);
+    const char* name,
+    std::optional<ift::common::CodepointSet> filter = std::nullopt);
 
 // Returns a list of all built-in frequency data sets and the codepoints
 // they cover.

--- a/ift/config/segmenter_config_util.cc
+++ b/ift/config/segmenter_config_util.cc
@@ -32,9 +32,10 @@ namespace ift::config {
 // Loads unicode frequency data from either a dedicated frequency data file or
 // from the codepoint and frequency entries if no data file is given.
 StatusOr<UnicodeFrequencies> SegmenterConfigUtil::GetFrequencyData(
-    const std::string& frequency_data_file_path, bool built_in) {
+    const std::string& frequency_data_file_path, bool built_in,
+    std::optional<CodepointSet> filter) {
   if (built_in) {
-    return LoadBuiltInFrequencies(frequency_data_file_path.c_str());
+    return LoadBuiltInFrequencies(frequency_data_file_path.c_str(), filter);
   }
 
   std::filesystem::path freq_path = frequency_data_file_path;
@@ -44,7 +45,7 @@ StatusOr<UnicodeFrequencies> SegmenterConfigUtil::GetFrequencyData(
     resolved_path = config_path.parent_path() / freq_path;
   }
 
-  return LoadFrequenciesFromRiegeli(resolved_path.c_str());
+  return LoadFrequenciesFromRiegeli(resolved_path.c_str(), filter);
 }
 
 SubsetDefinition SegmenterConfigUtil::SegmentProtoToSubsetDefinition(
@@ -115,7 +116,8 @@ std::vector<SubsetDefinition> SegmenterConfigUtil::ConfigToSegments(
 
 StatusOr<MergeStrategy> SegmenterConfigUtil::ProtoToCostStrategy(
     const CostConfiguration& base, const CostConfiguration& config,
-    CodepointSet& covered_codepoints) {
+    CodepointSet& covered_codepoints,
+    const CodepointSet& font_codepoints) {
   CostConfiguration merged = base;
   merged.MergeFrom(config);
 
@@ -127,8 +129,8 @@ StatusOr<MergeStrategy> SegmenterConfigUtil::ProtoToCostStrategy(
 
   UnicodeFrequencies freq =
       config.has_built_in_freq_data_name()
-          ? TRY(GetFrequencyData(merged.built_in_freq_data_name(), true))
-          : TRY(GetFrequencyData(merged.path_to_frequency_data(), false));
+          ? TRY(GetFrequencyData(merged.built_in_freq_data_name(), true, font_codepoints))
+          : TRY(GetFrequencyData(merged.path_to_frequency_data(), false, font_codepoints));
 
   covered_codepoints = freq.CoveredCodepoints();
 
@@ -184,7 +186,8 @@ SegmenterConfigUtil::ProtoToMergeGroup(
     const std::vector<SubsetDefinition>& segments,
     const flat_hash_map<SegmentId, uint32_t>& id_to_index,
     const HeuristicConfiguration& base_heuristic,
-    const CostConfiguration& base_cost, const MergeGroup& group) {
+    const CostConfiguration& base_cost, const MergeGroup& group,
+    const CodepointSet& font_codepoints) {
   SegmentSet segment_indices;
   for (uint32_t feature_group_id : group.feature_segment_ids().values()) {
     segment_indices.insert(id_to_index.at(
@@ -196,7 +199,7 @@ SegmenterConfigUtil::ProtoToMergeGroup(
   if (group.has_cost_config()) {
     CodepointSet covered_codepoints;
     strategy = TRY(ProtoToCostStrategy(base_cost, group.cost_config(),
-                                       covered_codepoints));
+                                       covered_codepoints, font_codepoints));
 
     if (group.has_segment_ids()) {
       segment_indices.union_set(MapToIndices(group.segment_ids(), id_to_index));
@@ -248,7 +251,7 @@ SegmenterConfigUtil::ConfigToMergeGroups(
   for (const auto& merge_group : config.merge_groups()) {
     merge_groups.insert(TRY(ProtoToMergeGroup(
         segments, segment_id_to_index, config.base_heuristic_config(),
-        config.base_cost_config(), merge_group)));
+        config.base_cost_config(), merge_group, font_codepoints)));
   }
 
   // If provided add a final merge group that applies to any segments not yet

--- a/ift/config/segmenter_config_util.h
+++ b/ift/config/segmenter_config_util.h
@@ -1,6 +1,7 @@
 #ifndef IFT_CONFIG_SEGMENTER_CONFIG_UTIL_H_
 #define IFT_CONFIG_SEGMENTER_CONFIG_UTIL_H_
 
+#include <optional>
 #include "absl/container/btree_map.h"
 #include "absl/status/statusor.h"
 #include "hb.h"
@@ -81,11 +82,13 @@ class SegmenterConfigUtil {
       absl::flat_hash_map<SegmentId, uint32_t>& segment_id_to_index);
 
   absl::StatusOr<ift::freq::UnicodeFrequencies> GetFrequencyData(
-      const std::string& frequency_data_file_path, bool built_in);
+      const std::string& frequency_data_file_path, bool built_in,
+      std::optional<ift::common::CodepointSet> filter = std::nullopt);
 
   absl::StatusOr<ift::encoder::MergeStrategy> ProtoToCostStrategy(
       const CostConfiguration& base, const CostConfiguration& config,
-      ift::common::CodepointSet& covered_codepoints);
+      ift::common::CodepointSet& covered_codepoints,
+      const ift::common::CodepointSet& font_codepoints);
 
   absl::StatusOr<
       std::pair<ift::common::SegmentSet, ift::encoder::MergeStrategy>>
@@ -93,7 +96,8 @@ class SegmenterConfigUtil {
                     const absl::flat_hash_map<SegmentId, uint32_t>& id_to_index,
                     const HeuristicConfiguration& base_heuristic,
                     const CostConfiguration& base_cost,
-                    const MergeGroup& group);
+                    const MergeGroup& group,
+                    const ift::common::CodepointSet& font_codepoints);
 
   static ift::common::SegmentSet MapToIndices(
       const SegmentsProto& segments,

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -58,6 +58,7 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryNextMerge() {
     }
 
     MarkFinished(base_segment_index);
+    strategy_.ProbabilityCalculator()->ResetCache();
   }
 
   return std::nullopt;
@@ -204,6 +205,7 @@ Status Merger::MoveSegmentsToInitFont() {
     }
 
     TRYV(ApplyInitFontMove(*glyphs_for_lowest, total_delta));
+    strategy_.ProbabilityCalculator()->ResetCache();
   } while (true);
 
   VLOG(0) << "Initial font now has "

--- a/ift/freq/bigram_probability_calculator.cc
+++ b/ift/freq/bigram_probability_calculator.cc
@@ -21,9 +21,12 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
     const CodepointSet& codepoints, double best_lower) const {
   auto it = cache_.find(codepoints);
   if (it != cache_.end()) {
+    cache_hit_++;
     double lower = std::max(it->second.Min(), best_lower);
     double upper = std::max(it->second.Max(), lower);
     return ProbabilityBound(lower, upper);
+  } else {
+    cache_miss_++;
   }
 
   unsigned n = codepoints.size();

--- a/ift/freq/bigram_probability_calculator.h
+++ b/ift/freq/bigram_probability_calculator.h
@@ -1,6 +1,8 @@
 #ifndef IFT_FREQ_BIGRAM_PROBABILITY_CALCULATOR_H_
 #define IFT_FREQ_BIGRAM_PROBABILITY_CALCULATOR_H_
 
+
+#include "absl/log/log.h"
 #include "absl/container/flat_hash_map.h"
 #include "ift/common/int_set.h"
 #include "ift/freq/probability_bound.h"
@@ -28,6 +30,15 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
   ProbabilityBound ComputeConjunctiveProbability(
       const std::vector<ProbabilityBound>& bounds) const override;
 
+  void ResetCache() const override {
+    if (cache_hit_ || cache_miss_) {
+        VLOG(1) << "bigram prob cache hit % = " << ((double) cache_hit_ / (double) (cache_hit_ + cache_miss_)) * 100.0;
+    }
+    cache_hit_ = 0;
+    cache_miss_ = 0;
+    cache_.clear();
+  }
+
  private:
   ProbabilityBound BigramProbabilityBound(
       const ift::common::CodepointSet& codepoints,
@@ -39,6 +50,8 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
 
   UnicodeFrequencies frequencies_;
   mutable absl::flat_hash_map<ift::common::CodepointSet, ProbabilityBound> cache_;
+  mutable uint64_t cache_hit_ = 0;
+  mutable uint64_t cache_miss_ = 0;
 };
 
 }  // namespace ift::freq

--- a/ift/freq/probability_calculator.h
+++ b/ift/freq/probability_calculator.h
@@ -31,6 +31,10 @@ class ProbabilityCalculator {
   // to speed up the computation.
   virtual ProbabilityBound ComputeConjunctiveProbability(
       const std::vector<ProbabilityBound>& bounds) const = 0;
+
+  // Signal that if there is internal cached data future calls are unlikely
+  // to hit it again and it can be cleared.
+  virtual void ResetCache() const {}
 };
 
 }  // namespace ift::freq

--- a/ift/freq/unicode_frequencies.cc
+++ b/ift/freq/unicode_frequencies.cc
@@ -32,6 +32,13 @@ UnicodeFrequencies UnicodeFrequenciesBuilder::Build() {
   if (max_count_ > 0) {
     result.unknown_probability_ = 1.0 / (double)max_count_;
     for (const auto& [key, count] : frequencies_) {
+      if (filter_.has_value()) {
+        uint32_t cp1 = key >> 32;
+        uint32_t cp2 = key & (uint64_t)0x00000000FFFFFFFF;
+        if (!filter_->contains(cp1) || !filter_->contains(cp2)) {
+          continue;
+        }
+      }
       result.probabilities_[key] = (double)count / (double)max_count_;
     }
   }
@@ -45,7 +52,7 @@ UnicodeFrequencies::UnicodeFrequencies(
   for (const auto& pair : frequencies) {
     builder.Add(pair.first.first, pair.first.second, pair.second);
   }
-  *this = std::move(builder.Build());
+  *this = builder.Build();
 }
 
 double UnicodeFrequencies::ProbabilityFor(uint32_t cp) const {

--- a/ift/freq/unicode_frequencies.h
+++ b/ift/freq/unicode_frequencies.h
@@ -2,6 +2,7 @@
 #define IFT_FREQ_UNICODE_FREQUENCIES_H_
 
 #include <cstdint>
+#include <optional>
 
 #include "absl/container/flat_hash_map.h"
 #include "hb.h"
@@ -60,7 +61,9 @@ class UnicodeFrequencies {
 
 class UnicodeFrequenciesBuilder {
  public:
-  UnicodeFrequenciesBuilder() = default;
+  UnicodeFrequenciesBuilder(
+      std::optional<ift::common::CodepointSet> filter = std::nullopt)
+      : filter_(std::move(filter)) {}
 
   // Add frequency data for the codepoint pair (cp1, cp2).
   // When cp1 == cp2 this supplies frequency for a single codepoint.
@@ -71,6 +74,7 @@ class UnicodeFrequenciesBuilder {
  private:
   absl::flat_hash_map<uint64_t, uint64_t> frequencies_;
   uint64_t max_count_ = 0;
+  std::optional<ift::common::CodepointSet> filter_;
 };
 
 }  // namespace ift::freq

--- a/ift/freq/unicode_frequencies_test.cc
+++ b/ift/freq/unicode_frequencies_test.cc
@@ -1,8 +1,11 @@
 #include "ift/freq/unicode_frequencies.h"
 
+#include "gmock/gmock.h"
 #include "gtest/gtest.h"
 #include "ift/common/int_set.h"
 
+using testing::Not;
+using testing::DoubleEq;
 using ift::common::CodepointSet;
 
 namespace ift::freq {
@@ -69,6 +72,33 @@ TEST(UnicodeFrequenciesTest, CoveredCodepoints) {
 
   UnicodeFrequencies empty;
   EXPECT_EQ(empty.CoveredCodepoints(), (CodepointSet{}));
+}
+
+TEST(UnicodeFrequenciesTest, FilteredBuilder) {
+  CodepointSet filter{1, 2};
+  UnicodeFrequenciesBuilder builder(filter);
+  UnicodeFrequenciesBuilder unfiltered_builder;
+
+  builder.Add(1, 2, 10); // Kept
+  unfiltered_builder.Add(1, 2, 10);
+
+  builder.Add(2, 3, 20); // Ignored (3 not in filter)
+  unfiltered_builder.Add(2, 3, 20);
+
+  builder.Add(1, 1, 5);  // Kept
+  unfiltered_builder.Add(1, 1, 5);
+
+  UnicodeFrequencies freq = builder.Build();
+  UnicodeFrequencies unfiltered_freq = unfiltered_builder.Build();
+
+  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(1, 2), unfiltered_freq.ProbabilityFor(1, 2));
+  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(1), unfiltered_freq.ProbabilityFor(1));
+  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(2), unfiltered_freq.ProbabilityFor(2));
+  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(3), unfiltered_freq.ProbabilityFor(3));
+
+  // (2, 3) is filtered out and should equal the default probability
+  EXPECT_THAT(freq.ProbabilityFor(2, 3), Not(DoubleEq(unfiltered_freq.ProbabilityFor(2, 3))));
+  EXPECT_DOUBLE_EQ(freq.ProbabilityFor(2, 3), unfiltered_freq.ProbabilityFor(100, 200));
 }
 
 }  // namespace ift::freq


### PR DESCRIPTION
- Only store pair probabilities for codepoints that are in the font being processed. Pairs that are not a subset of the input font will not ever be needed.
- Add periodic reset to the bigram -> probability cache to clear out entries that are no longer needed.