### PR TITLE
Reduce impact of brotli compression size noise on init font merging.

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -20,7 +20,7 @@ bazel_dep(name = "bazel_skylib", version = "1.9.0")
 
 # Frequency Data
 bazel_dep(name = "ift_encoder_data", version = "git")
-git_override(module_name = "ift_encoder_data", remote = "https://github.com/w3c/ift-encoder-data.git", commit = "8f50ef507feac8f8bdf6c39a92f95b7c991dcfda")
+git_override(module_name = "ift_encoder_data", remote = "https://github.com/w3c/ift-encoder-data.git", commit = "d3314fab829cf58d93d0afb224926180be0b8842")
 
 # Non Bazel Modules
 http_archive = use_repo_rule("@bazel_tools//tools/build_defs/repo:http.bzl", "http_archive")

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -355,7 +355,14 @@ static StatusOr<double> CostFor(Merger& merger, const ActivationCondition& condi
 
 StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
     Merger& merger, uint32_t existing_init_font_size,
-    const GlyphSet& moved_glyphs) {
+    const GlyphSet& moved_glyphs,
+    absl::flat_hash_map<ift::common::GlyphSet, uint32_t>& smallest_size_increases
+  ) {
+  // Brotli compression results can be a bit noisy and it's common to see very different
+  // size increase (in both directions) for adding the same glyphs as the base changes.
+  // So to help control some of this noise we use smallest_size_increases to track the smallest
+  // size increase we've seen for moving a specific set of glyphs.
+
   VLOG(1) << "cost_delta for move of glyphs " << moved_glyphs.ToString()
           << " to the initial font =";
 
@@ -379,18 +386,22 @@ StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
   TRYV(ComputeInitFontGlyphDelta(merger, moved_glyphs, new_glyph_closure,
                                  glyph_closure_delta, codepoint_closure_delta));
 
-  double total_delta = 0.0;
-  double before = existing_init_font_size;
-  double after =
-      TRY(merger.Context().patch_size_cache_for_init_font->GetPatchSize(
+  uint32_t after = TRY(merger.Context().patch_size_cache_for_init_font->GetPatchSize(
           new_glyph_closure));
+  uint32_t init_increase = 0;
 
-  if (after > before) {
-    // case where after is < before happen occasionally as the result of
-    // running with lower brotli compression quality. Ignores these in order
-    // to stay consistent with the 'best case' used above.
-    total_delta = after - before;
+  if (after >= existing_init_font_size) {
+    init_increase = after - existing_init_font_size;
+    auto [it, _] = smallest_size_increases.emplace(glyph_closure_delta, UINT32_MAX);
+    if (init_increase < it->second) {
+      it->second = init_increase;
+    } else {
+      init_increase = it->second;
+    }
   }
+
+  double total_delta = init_increase;
+
   VLOG(1) << "    + " << total_delta << " [init font increase]";
 
   SegmentSet modified_segments = merger.Context().SegmentationInfo().SegmentsForCodepoints(codepoint_closure_delta);

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -657,6 +657,10 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
             fallback_changed = true;
           }
         }
+        if (info.glyphs.empty()) {
+          // Patch has no remaining glyphs, so don't add back any cost for it.
+          continue;
+        }
       }
       size = TRY(patch_size_cache->GetPatchSize(info.glyphs));
       if (merger.ShouldRecordMergedSizeReductions()) {

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -157,11 +157,14 @@ struct CandidateMerge {
   // (including those added by closure).
   static absl::StatusOr<std::pair<double, ift::common::GlyphSet>>
   ComputeInitFontCostDelta(Merger& merger, uint32_t existing_init_font_size,
-                           const ift::common::GlyphSet& moved_glyphs);
+                           const ift::common::GlyphSet& moved_glyphs,
+                           absl::flat_hash_map<ift::common::GlyphSet, uint32_t>& smallest_size_increases
+                          );
 
   static absl::StatusOr<double> ComputeBestCaseInitFontCostDelta(
       Merger& merger, uint32_t existing_init_font_size,
-      const ift::common::GlyphSet& moved_glyphs);
+      const ift::common::GlyphSet& moved_glyphs
+  );
 
   static absl::StatusOr<double> ComputePatchMergeCostDelta(
       const Merger& context, segment_index_t base_segment,

--- a/ift/encoder/candidate_merge_test.cc
+++ b/ift/encoder/candidate_merge_test.cc
@@ -3,7 +3,6 @@
 #include <memory>
 #include <optional>
 
-#include "absl/log/globals.h"
 #include "gtest/gtest.h"
 #include "ift/common/font_data.h"
 #include "ift/common/int_set.h"
@@ -16,6 +15,8 @@
 #include "ift/freq/mock_probability_calculator.h"
 #include "ift/freq/probability_bound.h"
 #include "ift/freq/unicode_frequencies.h"
+
+using absl::flat_hash_map;
 
 using ift::config::CLOSURE_ONLY;
 using ift::config::DEP_GRAPH_ONLY;
@@ -529,7 +530,8 @@ TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
   uint32_t i_fi_ffi_size = *context->patch_size_cache_for_init_font->GetPatchSize({g_i, g_fi, g_ffi});
 
   /* Case 1: simple move */
-  auto r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_b});
+  flat_hash_map<GlyphSet, uint32_t> smallest;
+  auto r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_b}, smallest);
   ASSERT_TRUE(r.ok()) << r.status();
   double delta = r->first;
   GlyphSet moved_glyphs = r->second;
@@ -540,7 +542,8 @@ TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
   EXPECT_EQ(moved_glyphs, (GlyphSet {g_b}));
 
   /* Case 2: move + modified conditions (one half of (f AND i) moved) */
-  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_f});
+  smallest.clear();
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_f}, smallest);
   ASSERT_TRUE(r.ok()) << r.status();
   delta = r->first;
   moved_glyphs = r->second;
@@ -556,7 +559,8 @@ TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
   EXPECT_EQ(moved_glyphs, (GlyphSet {g_f}));
 
   /* Case 3: move non exclusive */
-  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_fi, g_ffi});
+  smallest.clear();
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_fi, g_ffi}, smallest);
   ASSERT_TRUE(r.ok()) << r.status();
   delta = r->first;
   moved_glyphs = r->second;
@@ -569,7 +573,8 @@ TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
   EXPECT_EQ(moved_glyphs, (GlyphSet {g_fi, g_ffi}));
 
   /* Case 4: move part of a patch */
-  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_fi});
+  smallest.clear();
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_fi}, smallest);
   ASSERT_TRUE(r.ok()) << r.status();
   delta = r->first;
   moved_glyphs = r->second;
@@ -583,7 +588,8 @@ TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
   EXPECT_EQ(moved_glyphs, (GlyphSet {g_fi}));
 
   /* Case 5: move multiple */
-  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_f, g_i});
+  smallest.clear();
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_f, g_i}, smallest);
   ASSERT_TRUE(r.ok()) << r.status();
   delta = r->first;
   moved_glyphs = r->second;
@@ -596,6 +602,68 @@ TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
     1e-9
   );
   EXPECT_EQ(moved_glyphs, (GlyphSet {g_f, g_i, g_fi, g_ffi}));
+}
+
+TEST_F(CandidateMergeTest, ComputeInitFontCostDelta_TracksSmallestDelta) {
+  std::vector<Segment> segments = {
+      {{'b'}, ProbabilityBound{0.95, 0.95}},
+      {{'f'}, ProbabilityBound{0.85, 0.85}},
+      {{'i'}, ProbabilityBound{0.75, 0.75}},
+  };
+
+  auto probability_calculator =
+      std::make_unique<freq::MockProbabilityCalculator>(segments);
+
+  ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY);
+  auto context = SegmentationContext::InitializeSegmentationContext(
+      roboto.get(), {'a'}, segments, segmenter.unmapped_glyph_handling(),
+      segmenter.condition_analysis_mode(), segmenter.brotli_quality(),
+      segmenter.init_font_merging_brotli_quality());
+  ASSERT_TRUE(context.ok()) << context.status();
+
+  Merger merger = *Merger::New(
+      *context,
+      MergeStrategy::CostBased(std::move(probability_calculator), 75, 4), all,
+      all);
+
+  glyph_id_t g_a = 69;
+  glyph_id_t g_b = 70;
+
+  MockPatchSizeCache* mock_cache = new MockPatchSizeCache();
+  context->patch_size_cache_for_init_font.reset(mock_cache);
+
+  uint32_t init_size = 1000;
+  mock_cache->SetPatchSize({0, g_a}, init_size);
+  mock_cache->SetPatchSize({0, g_a, g_b}, 1100);
+
+  flat_hash_map<GlyphSet, uint32_t> smallest_size_increases;
+
+  // First call: size increase is 100.
+  auto r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_b}, smallest_size_increases);
+  ASSERT_TRUE(r.ok()) << r.status();
+  double first_delta = r->first;
+  EXPECT_EQ(smallest_size_increases.at({g_b}), 100);
+
+  // Second call: simulated size increase is 200 (1200 - 1000).
+  // But it should use the stored smallest increase (100).
+  mock_cache->SetPatchSize({0, g_a, g_b}, 1200);
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_b}, smallest_size_increases);
+  ASSERT_TRUE(r.ok()) << r.status();
+  double second_delta = r->first;
+
+  EXPECT_EQ(smallest_size_increases.at({g_b}), 100);
+  EXPECT_EQ(first_delta, second_delta);
+
+  // Third call: simulated size increase is 50 (1050 - 1000).
+  // It should update the stored smallest increase to 50 and return a smaller delta.
+  mock_cache->SetPatchSize({0, g_a, g_b}, 1050);
+  r = CandidateMerge::ComputeInitFontCostDelta(merger, init_size, {g_b}, smallest_size_increases);
+  ASSERT_TRUE(r.ok()) << r.status();
+  double third_delta = r->first;
+
+  EXPECT_EQ(smallest_size_increases.at({g_b}), 50);
+
+  EXPECT_LT(third_delta, first_delta);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/dependency_closure.cc
+++ b/ift/encoder/dependency_closure.cc
@@ -100,12 +100,16 @@ Status DependencyClosure::InitNodeConditionsCache() {
     }
   }
 
+  inert_segments_ = ComputeInertSegments(glyph_condition_cache_);
+
   return absl::OkStatus();
 }
 
 void DependencyClosure::UpdateNodeConditionsCache(
     segment_index_t base_segment, const common::SegmentSet& segments) {
   auto affected_nodes = SegmentsToAffectedNodeConditions(segments);
+
+  bool base_is_inert = true;
 
   for (Node node : affected_nodes) {
     auto it = node_condition_cache_.find(node);
@@ -129,9 +133,20 @@ void DependencyClosure::UpdateNodeConditionsCache(
       glyph_condition_cache_.insert({node.Id(), new_condition});
     }
 
+    if (!new_condition.IsUnitary()) {
+      base_is_inert = false;
+    }
+
     for (segment_index_t s : it->second.TriggeringSegments()) {
       node_conditions_with_segment_[s].insert(node);
     }
+  }
+
+  inert_segments_.subtract(segments);
+  if (base_is_inert) {
+    inert_segments_.insert(base_segment);
+  } else {
+    inert_segments_.erase(base_segment);
   }
 }
 
@@ -537,4 +552,15 @@ DependencyClosure::ExtractAllNodeConditions() const {
 
   return conditions;
 }
+
+SegmentSet DependencyClosure::ComputeInertSegments(const absl::flat_hash_map<glyph_id_t, ActivationCondition>& conditions) const {
+  SegmentSet candidates = segmentation_info_->NonEmptySegments();
+  for (const auto& [_, condition] : conditions) {
+    if (!condition.IsUnitary()) {
+      candidates.subtract(condition.TriggeringSegments());
+    }
+  }
+  return candidates;
+}
+
 }  // namespace ift::encoder

--- a/ift/encoder/dependency_closure.h
+++ b/ift/encoder/dependency_closure.h
@@ -101,6 +101,10 @@ class DependencyClosure {
       const common::SegmentSet& segments) const;
 #endif
 
+  const ift::common::SegmentSet& InertSegments() const {
+    return inert_segments_;
+  }
+
   // This structure caches information derived from the segmentation info
   // segments. These two function signal that segmentation info segments have
   // changed and recomputes the internal cached information.
@@ -138,6 +142,8 @@ class DependencyClosure {
   // graph.
   absl::StatusOr<absl::flat_hash_map<dep_graph::Node, ActivationCondition>>
   ExtractAllNodeConditions() const;
+
+  ift::common::SegmentSet ComputeInertSegments(const absl::flat_hash_map<glyph_id_t, ActivationCondition>& conditions) const;
 
   absl::flat_hash_map<dep_graph::Node, ActivationCondition>
   InitializeConditions() const;
@@ -191,6 +197,11 @@ class DependencyClosure {
 
   ift::common::GlyphSet context_glyphs_;
   ift::common::GlyphSet init_font_context_glyphs_;
+
+  // Inert segments are segments that:
+  // - Appear only in a single unitary condition, that is
+  //   they do not interact with any other segments.
+  ift::common::SegmentSet inert_segments_;
 
   absl::flat_hash_map<glyph_id_t, ActivationCondition> glyph_condition_cache_;
   absl::flat_hash_map<dep_graph::Node, ActivationCondition>

--- a/ift/encoder/dependency_closure.h
+++ b/ift/encoder/dependency_closure.h
@@ -99,11 +99,11 @@ class DependencyClosure {
 
   absl::flat_hash_set<dep_graph::Node> SegmentsToAffectedNodeConditions(
       const common::SegmentSet& segments) const;
-#endif
 
   const ift::common::SegmentSet& InertSegments() const {
     return inert_segments_;
   }
+#endif
 
   // This structure caches information derived from the segmentation info
   // segments. These two function signal that segmentation info segments have

--- a/ift/encoder/dependency_closure_test.cc
+++ b/ift/encoder/dependency_closure_test.cc
@@ -235,6 +235,38 @@ TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_InitFont) {
   ASSERT_EQ(conditions.at(77).ToString(), "if (s1) then p0");
 }
 
+TEST_F(DependencyClosureTest, InertSegments) {
+  Reconfigure(face.get(), WithDefaultFeatures({}),
+              {
+                  /* 0 */ {{'a'}, ProbabilityBound::Zero()},
+                  /* 1 */ {{'b'}, ProbabilityBound::Zero()},
+                  /* 2 */ {{'f'}, ProbabilityBound::Zero()},
+                  /* 3 */ {{'i'}, ProbabilityBound::Zero()},
+              });
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0, 1}));
+
+  Reconfigure(face.get(), WithDefaultFeatures({}),
+              {
+                  /* 0 */ {{'a'}, ProbabilityBound::Zero()},
+                  /* 1 */ {{'b'}, ProbabilityBound::Zero()},
+                  /* 2 */ {{'f', 'i'}, ProbabilityBound::Zero()},
+              });
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0, 1, 2}));
+}
+
+TEST_F(DependencyClosureTest, InertSegments_InitFont) {
+  Reconfigure(face.get(), WithDefaultFeatures({'f'}),
+              {
+                  /* 0 */ {{'a'}, ProbabilityBound::Zero()},
+                  /* 1 */ {{'b'}, ProbabilityBound::Zero()},
+                  /* 2 */ {{'i'}, ProbabilityBound::Zero()},
+              });
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0, 1, 2}));
+}
+
 TEST_F(DependencyClosureTest, ExtractAllGlyphConditions_Composite) {
   SubsetDefinition aalt;
   aalt.feature_tags.insert(HB_TAG('a', 'a', 'l', 't'));
@@ -770,6 +802,22 @@ TEST_F(DependencyClosureTest, SegmentsMerged_GlyphConditionsUpdate) {
   EXPECT_EQ(conditions.at(444).ToString(), "if (s2) then p0");
 }
 
+TEST_F(DependencyClosureTest, SegmentsMerged_InertSegments) {
+  Reconfigure(WithDefaultFeatures(),
+              {
+                  /* 0 */ {{'a'}, ProbabilityBound::Zero()},
+                  /* 1 */ {{'f'}, ProbabilityBound::Zero()},
+                  /* 2 */ {{'i'}, ProbabilityBound::Zero()},
+              });
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0}));
+
+  Status s = dependency_closure->SegmentsMerged(2, {1, 2});
+  ASSERT_TRUE(s.ok()) << s;
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0, 2}));
+}
+
 TEST_F(DependencyClosureTest, InitFontChanged_GlyphConditionsUpdate) {
   Reconfigure(face.get(), WithDefaultFeatures(),
               {
@@ -793,6 +841,26 @@ TEST_F(DependencyClosureTest, InitFontChanged_GlyphConditionsUpdate) {
   EXPECT_FALSE(conditions.contains(74 /* f */));
   // 'fi' should now only depend on 'i' (s2)
   EXPECT_EQ(conditions.at(444 /* fi */).ToString(), "if (s2) then p0");
+}
+
+TEST_F(DependencyClosureTest, InitFontChanged_InertSegments) {
+  Reconfigure(face.get(), WithDefaultFeatures(),
+              {
+                  /* 0 */ {{'a'}, ProbabilityBound::Zero()},
+                  /* 1 */ {{'f'}, ProbabilityBound::Zero()},
+                  /* 2 */ {{'i'}, ProbabilityBound::Zero()},
+              });
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0}));
+
+  Status s = segmentation_info->ReassignInitSubset(closure_cache,
+                                                   WithDefaultFeatures({'f'}));
+  ASSERT_TRUE(s.ok()) << s;
+
+  s = dependency_closure->InitFontChanged(SegmentSet::all());
+  ASSERT_TRUE(s.ok()) << s;
+
+  ASSERT_EQ(dependency_closure->InertSegments(), (SegmentSet {0, 2}));
 }
 
 TEST_F(DependencyClosureTest, SegmentsThatInteractWith_Nodes) {

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -13,6 +13,7 @@
 #include "ift/encoder/types.h"
 
 using absl::btree_map;
+using absl::flat_hash_map;
 using absl::Status;
 using absl::StatusOr;
 using ift::common::GlyphSet;
@@ -146,6 +147,8 @@ Status Merger::MoveSegmentsToInitFont() {
   // to non-batch processing where all candidate conditions are checked
   // and moved one at a time.
 
+  flat_hash_map<ift::common::GlyphSet, uint32_t> smallest_size_increases;
+
   bool batch_mode = true;
   VLOG(0) << " batch checking inert segments for move to init font.";
   do {
@@ -172,7 +175,7 @@ Status Merger::MoveSegmentsToInitFont() {
       }
 
       auto [delta, all_glyphs] = TRY(CandidateMerge::ComputeInitFontCostDelta(
-          *this, init_font_size, glyphs));
+          *this, init_font_size, glyphs, smallest_size_increases));
       if (delta >= lowest_delta) {
         continue;
       }

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -366,6 +366,7 @@ void SegmentationContext::TransferDependencyGraphGlyphConditions(
     }
     glyph_condition_set.SetCondition(g, condition);
   }
+  inert_segments_ = (*dependency_closure_)->InertSegments();
 #endif
 }
 


### PR DESCRIPTION
I've noticed a cases of good merges to the init font being passed up due to noise in brotli compressed sizes (the size delta for the same glyphs will vary signficantly against different base glyphs, particularily seeing larger increases somewhat randomly). This adds a cache of the lowest seen size increase and uses that instead of the value computed per iteration. In general the rough expectation is that size increase for a set of glyphs roughly decreases as the the base size increases due to more opportunities for data sharing.

Also fixes missing inert segment calculation when in dep graph only mode.