### PR TITLE
In auto segmenter config use a higher network request cost (200 bytes)

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -56,9 +56,9 @@ http_archive(
 http_archive(
     name = "ift_spec",
     build_file = "//third_party:ift_spec.BUILD",
-    sha256 = "6c97f8da6a6997794da5417823711b54a7ace6ff8c7beb71824386d1e19a9ac5",
-    strip_prefix = "IFT-9594d696a6b35c22f97b072a1d64db603c204dfb",
-    urls = ["https://github.com/w3c/IFT/archive/9594d696a6b35c22f97b072a1d64db603c204dfb.zip"],
+    sha256 = "cc5efce7af25f9b659244ffd0425edd2a769a81175cb38f525a40175f7e11b4f",
+    strip_prefix = "IFT-8f53e86cb43bed877f74dfe8ac2172b5edfff521",
+    urls = ["https://github.com/w3c/IFT/archive/8f53e86cb43bed877f74dfe8ac2172b5edfff521.zip"],
 )
 
 # Fontations

--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -88,7 +88,7 @@ enum Quality {
 //     Would be reasonable to always have this set to at least the minimum group
 //     size.
 //
-// - condition_analysis_mode: always use CLOSURE_AND_DEP_GRAPH.
+// - condition_analysis_mode: use DEP_GRAPH_ONLY if dependency API is available, otherwise CLOSURE_ONLY.
 //
 // Merge group settings:
 //
@@ -144,6 +144,8 @@ enum Quality {
 
 // TODO(garretrieger): collect data on brotli compression times as a function of
 // quality assuming group sizes of 4 using a CJK font
+
+static constexpr uint32_t DEFAULT_NETWORK_COST = 200;
 
 static bool IsScript(absl::string_view file_name) {
   return absl::StartsWith(file_name, "Script_");
@@ -644,6 +646,10 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
   ApplyQualityLevelTo(quality, *config.mutable_ungrouped_config());
   ApplyQualityLevelTo(quality, *config.mutable_base_cost_config());
 
+  // Based on measured network overhead cost in practice from the
+  // ift demo.
+  config.mutable_base_cost_config()->set_network_overhead_cost(DEFAULT_NETWORK_COST);
+
   for (auto& merge_group : *config.mutable_merge_groups()) {
     ApplyQualityLevelTo(quality, merge_group);
   }
@@ -655,7 +661,11 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
   SegmenterConfig config;
   config.set_generate_table_keyed_segments(true);
   config.set_generate_feature_segments(true);
+#ifdef HB_DEPEND_API
   config.set_condition_analysis_mode(DEP_GRAPH_ONLY);
+#else
+  config.set_condition_analysis_mode(CLOSURE_ONLY);
+#endif
 
   auto* base_plan = config.mutable_base_segmentation_plan();
   base_plan->set_jump_ahead(2);
@@ -706,7 +716,7 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
 
     cost->set_built_in_freq_data_name(script);
     if (script == primary_script_file) {
-      cost->set_initial_font_merge_threshold(-60);
+      cost->set_initial_font_merge_threshold(-(double) DEFAULT_NETWORK_COST * (0.8));
     }
   }
 

--- a/ift/config/auto_segmenter_config_test.cc
+++ b/ift/config/auto_segmenter_config_test.cc
@@ -100,6 +100,7 @@ base_heuristic_config {
 }
 base_cost_config {
   use_bigrams: true
+  network_overhead_cost: 200
   min_group_size: 4
   optimization_cutoff_fraction: 0.005
 }
@@ -126,7 +127,7 @@ merge_groups {
   preprocess_merging_group_size: 1
   cost_config {
     built_in_freq_data_name: "Script_latin.riegeli"
-    initial_font_merge_threshold: -60
+    initial_font_merge_threshold: -160
     initial_font_merge_probability_threshold: 0.25
   }
 }
@@ -149,8 +150,13 @@ base_segmentation_plan {
   use_prefetch_lists: true
 }
 generate_feature_segments: true
-condition_analysis_mode: DEP_GRAPH_ONLY
-)");
+)"
+#ifdef HB_DEPEND_API
+"condition_analysis_mode: DEP_GRAPH_ONLY\n"
+#else
+"condition_analysis_mode: CLOSURE_ONLY\n"
+#endif
+);
 }
 
 TEST_F(AutoSegmenterConfigTest, Roboto_ScriptCyrillic) {


### PR DESCRIPTION
Based on observed network overhead in the IFT demo. Also update to the latest IFT spec version which brings in an update to the default feature registry.