### PR TITLE
Rework patch based merging and enable it by default in auto config.

### DIFF
--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -651,6 +651,7 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
   // ift demo.
   config.mutable_base_cost_config()->set_network_overhead_cost(
       DEFAULT_NETWORK_COST);
+  config.mutable_base_cost_config()->set_experimental_use_patch_merges(true);
 
   for (auto& merge_group : *config.mutable_merge_groups()) {
     ApplyQualityLevelTo(quality, merge_group);

--- a/ift/config/auto_segmenter_config_test.cc
+++ b/ift/config/auto_segmenter_config_test.cc
@@ -106,6 +106,7 @@ base_cost_config {
   network_overhead_cost: 200
   min_group_size: 4
   optimization_cutoff_fraction: 0.005
+  experimental_use_patch_merges: true
 }
 ungrouped_config {
   min_patch_size: 2500

--- a/ift/config/segmenter_config.proto
+++ b/ift/config/segmenter_config.proto
@@ -258,22 +258,24 @@ message CostConfiguration {
   // By default merges under cost strategy are made by joining segments together, if this setting is
   // enabled than an alternate merge type, patch merge, will be considered by the merger. In a patch
   // merge glyphs from two patches are merged together along with the conditions for those patches.
+  // For example if there are two patches:
   //
-  // WARNING: This is currently defaulted off since there are some known issues with this approach
-  // where shapers can make glyph substitutions that are not encoded in GSUB. When patch merges are
-  // used it's possible to have a glyph included a patch, but under some subset definitions the glyph
-  // is not actually reachable. Because it's not reachable it's dependencies may not have been loaded since
-  // they aren't technically needed. However, in some cases such glyphs can be reached in practice by shaper
-  // substitutions which the glyph closure doesn't take into acount (relevant harfbuzz issue:
-  // https://github.com/harfbuzz/harfbuzz/issues/2283).
+  // if (A) -> glyph 1, 2, 3
+  // if (B) -> glyph 7, 8, 9
   //
-  // Segment merges don't run into this issue since they will only ever include reachable glyphs
-  // which means dependencies are always fully satisified. The shaper won't do substitutions if the appropriate
-  // glyph isn't present.
+  // Then a patch merge will generate a new patch wich replaces these with:
   //
-  // Work is planned to fix this issue (either in the harfbuzz closure or with a workaround in the segmenter),
-  // until then it's recommended to not used this except for testing (or if appropriate care has been taken
-  // in producing the input segments to avoid this issue).
+  // if (A or B) -> glyph 1, 2, 3, 7, 8, 9
+  //
+  // Without modifying any segement definitions.
+  //
+  // Patch merges are checked between pairs of non-exclusive patches (those with more than one segment
+  // in their activation condition). Where total cost is reduced patches will be merged. Additionally,
+  // if minimum group sizes are configured then patch merges can be used to raise the effective group
+  // sizes for non-exclusive patches.
+  //
+  // Enabling patch merging will typically result in lower overall costs, but will increase the total
+  // segmentation time due to larger number of patch comparisons made.
   bool experimental_use_patch_merges = 10 [default = false];
 }
 

--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -293,6 +293,7 @@ cc_test(
         "//ift/common:data_file_resolver",
         "//ift/common",
         "//ift/common:test_font_loader",
+        "//ift/freq:mock_probability_calculator",
         "@googletest//:gtest_main",
     ],
 )

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -1,6 +1,7 @@
 #ifndef IFT_ENCODER_ACTIVATION_CONDITION_H_
 #define IFT_ENCODER_ACTIVATION_CONDITION_H_
 
+#include <cstdint>
 #include "ift/common/int_set.h"
 #include "ift/config/segmentation_plan.pb.h"
 #include "ift/encoder/segment.h"
@@ -167,6 +168,16 @@ class ActivationCondition {
     }
 
     return true;
+  }
+
+  uint32_t EffectiveGroupSize() const {
+    uint32_t min = UINT32_MAX;
+    for (const auto& sub_group : conditions_) {
+      if (sub_group.size() < min) {
+        min = sub_group.size();
+      }
+    }
+    return min;
   }
 
   // Compute and return the probability that this condition will be activated

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -2,6 +2,7 @@
 #define IFT_ENCODER_ACTIVATION_CONDITION_H_
 
 #include <cstdint>
+
 #include "ift/common/int_set.h"
 #include "ift/config/segmentation_plan.pb.h"
 #include "ift/encoder/segment.h"

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -516,4 +516,11 @@ TEST(ActivationConditionTest, Intersects) {
   EXPECT_FALSE(b.Intersects({1}));
 }
 
+TEST(ActivationConditionTest, EffectiveGroupSize) {
+  EXPECT_EQ(ActivationCondition::exclusive_segment(5, 0).EffectiveGroupSize(), 1);
+  EXPECT_EQ(ActivationCondition::and_segments({1, 2, 3}, 0).EffectiveGroupSize(), 1);
+  EXPECT_EQ(ActivationCondition::or_segments({1, 2, 3}, 0).EffectiveGroupSize(), 3);
+  EXPECT_EQ(ActivationCondition::composite_condition({{1, 2, 3}, {4, 5, 6, 7}, {7, 8}},  0).EffectiveGroupSize(), 2);
+}
+
 }  // namespace ift::encoder

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -517,10 +517,16 @@ TEST(ActivationConditionTest, Intersects) {
 }
 
 TEST(ActivationConditionTest, EffectiveGroupSize) {
-  EXPECT_EQ(ActivationCondition::exclusive_segment(5, 0).EffectiveGroupSize(), 1);
-  EXPECT_EQ(ActivationCondition::and_segments({1, 2, 3}, 0).EffectiveGroupSize(), 1);
-  EXPECT_EQ(ActivationCondition::or_segments({1, 2, 3}, 0).EffectiveGroupSize(), 3);
-  EXPECT_EQ(ActivationCondition::composite_condition({{1, 2, 3}, {4, 5, 6, 7}, {7, 8}},  0).EffectiveGroupSize(), 2);
+  EXPECT_EQ(ActivationCondition::exclusive_segment(5, 0).EffectiveGroupSize(),
+            1);
+  EXPECT_EQ(
+      ActivationCondition::and_segments({1, 2, 3}, 0).EffectiveGroupSize(), 1);
+  EXPECT_EQ(ActivationCondition::or_segments({1, 2, 3}, 0).EffectiveGroupSize(),
+            3);
+  EXPECT_EQ(ActivationCondition::composite_condition(
+                {{1, 2, 3}, {4, 5, 6, 7}, {7, 8}}, 0)
+                .EffectiveGroupSize(),
+            2);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -128,29 +128,21 @@ StatusOr<InvalidationSet> CandidateMerge::Apply(Merger& merger) {
 }
 
 Status CandidateMerge::ApplyPatchMerge(Merger& merger) {
-  if (!patch_merge_target_conditions_.has_value()) {
-    return absl::InternalError("patch_merge_target_conditions_ is not set for patch merge");
+  if (!patch_merge_target_conditions_.has_value() || !patch_merge_glyphs_.has_value()) {
+    return absl::InternalError("patch_merge_target_conditions_/patch_merge_glyphs_ is not set for patch merge");
   }
-
-  const GlyphSet& glyphs_a =
-      merger.Context().glyph_groupings.ConditionsAndGlyphs().at(
-          patch_merge_target_conditions_->first);
-  const GlyphSet& glyphs_b =
-      merger.Context().glyph_groupings.ConditionsAndGlyphs().at(
-          patch_merge_target_conditions_->second);
 
   VLOG(0) << "  Merged patches from "
           << patch_merge_target_conditions_->first.ToString()
-          << " (" << glyphs_a.size() << " glyphs) with "
+          << " with "
           << patch_merge_target_conditions_->second.ToString()
-          << " (" << glyphs_b.size() << " glyphs)." << std::endl
+          << " up to " << patch_merge_glyphs_->size() << " glyphs." << std::endl
           << "  New patch size " << new_patch_size_ << " bytes. " << std::endl
           << "  Cost delta is " << cost_delta_ << ".";
 
   // CombinePatches() will do invalidation as needed, so nothing else needs to
   // be done to apply this merge.
-  return merger.Context().glyph_groupings.CombinePatches(glyphs_a,
-                                                         glyphs_b);
+  return merger.Context().glyph_groupings.CombinePatches(*patch_merge_glyphs_, {});
 }
 
 static bool WouldMixFeaturesAndCodepoints(
@@ -587,6 +579,8 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
     return 0;
   }
 
+  VLOG(1) << "cost delta for merge of " << merged_segments.ToString() << " = ";
+
   // These are conditions which will be modified by applying the merge. These
   // are conditions that intersect merged_segments.
   //
@@ -721,14 +715,62 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   return cost_delta;
 }
 
+StatusOr<CandidateMerge::PatchMergeDetails> CandidateMerge::ComputePatchMergeDetails(
+  const Merger& merger,
+  const ActivationCondition &condition_a,
+  const ActivationCondition &condition_b) {
+  const auto& condition_and_glyphs = merger.Context().glyph_groupings.ConditionsAndGlyphs();
+
+  auto glyphs_a_it = condition_and_glyphs.find(condition_a);
+  auto glyphs_b_it = condition_and_glyphs.find(condition_b);
+
+  if (glyphs_a_it == condition_and_glyphs.end() ||
+      glyphs_b_it == condition_and_glyphs.end()) {
+    return absl::InternalError(absl::StrCat("Unable to find glyphs for conditions: ",
+      condition_a.ToString(), ", ", condition_b.ToString()));
+  }
+
+  const GlyphSet& glyphs_a = glyphs_a_it->second;
+  const GlyphSet& glyphs_b = glyphs_b_it->second;
+
+  if (glyphs_a.empty() || glyphs_b.empty()) {
+    return absl::InternalError(absl::StrCat("Unexpected empty glyph sets for conditions: ",
+      condition_a.ToString(), ", ", condition_b.ToString()));
+  }
+
+  GlyphSet merged_glyphs = glyphs_a;
+  merged_glyphs.union_set(glyphs_b);
+
+  ActivationCondition merged_condition =
+      ActivationCondition::Or(condition_a, condition_b);
+
+  GlyphSet existing_glyphs;
+  auto existing_condition = merger.Context().glyph_groupings.ConditionsAndGlyphs().find(merged_condition);
+  if (existing_condition != merger.Context().glyph_groupings.ConditionsAndGlyphs().end()) {
+    existing_glyphs = existing_condition->second;
+    merged_glyphs.union_set(existing_condition->second);
+  }
+
+  // It's possible for the new condition to be equal to one of the input conditions,
+  // in this case we don't want to record glyphs_existing since that would cause double
+  // counting of the patches removal in cost assessment.
+  if (condition_a == merged_condition || condition_b == merged_condition) {
+    existing_glyphs.clear();
+  }
+
+  return PatchMergeDetails {
+    .condition_a = condition_a,
+    .condition_b = condition_b,
+    .merged_condition = merged_condition,
+    .glyphs_a = glyphs_a,
+    .glyphs_b = glyphs_b,
+    .glyphs_existing = existing_glyphs,
+    .glyphs_merged = merged_glyphs
+  };
+}
+
 template<bool best_case>
-StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
-    const Merger& merger,
-    const ActivationCondition& condition_a,
-    const GlyphSet& glyphs_a,
-    const ActivationCondition& condition_b,
-    const GlyphSet& glyphs_b,
-    const GlyphSet& merged_glyphs) {
+StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(const Merger& merger) const {
   // For a patch merge only three things are affected:
   // 1. Remove the patch with condition equal to condition_a.
   // 2. Remove the patch with condition equal to condition_b.
@@ -748,24 +790,29 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
 
-  ActivationCondition merged_condition =
-      ActivationCondition::Or(condition_a, condition_b);
+  double size_existing = 0.0;
+  if (!glyphs_existing.empty()) {
+    size_existing = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_existing));
+  }
 
   double merged_patch_size = 0.0;
   if (best_case) {
     double best_case_reduction_fraction =
       merger.Strategy().BestCaseSizeReductionFraction();
-    uint32_t extra = std::min(size_a, size_b);
+    uint32_t total_size = size_a + size_b + size_existing;
+    uint32_t max_size = std::max(std::max(size_a, size_b), size_existing);
+    uint32_t extra = total_size - max_size;
     extra = std::max((uint32_t)(extra * best_case_reduction_fraction),
                        Merger::BEST_CASE_MERGE_SIZE_DELTA);
-    merged_patch_size = std::max(size_a, size_b) + extra;
+    merged_patch_size = max_size + extra;
   } else {
     merged_patch_size =
-      TRY(merger.Context().patch_size_cache->GetPatchSize(merged_glyphs));
+      TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_merged));
   }
 
   size_a += network_overhead;
   size_b += network_overhead;
+  size_existing += network_overhead;
   merged_patch_size += network_overhead;
 
   double merged_probability = TRY(merged_condition.Probability(
@@ -776,17 +823,27 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
           << condition_b.ToString() << " =";
   double cost_delta = 0.0;
 
-  cost_delta += merged_probability * merged_patch_size;
+  double d = merged_probability * merged_patch_size;
+  cost_delta += d;
   VLOG(1) << "    + (" << merged_probability << " * " << merged_patch_size
-          << ") -> " << cost_delta << " [merged patch]";
+          << ") -> " << d << " [merged patch]";
 
-  cost_delta -= probability_a * size_a;
+  if (!glyphs_existing.empty()) {
+    d = merged_probability * size_existing;
+    cost_delta -= d;
+    VLOG(1) << "    - (" << merged_probability << " * " << size_existing
+          << ") -> " << d << " [removed existing patch]";
+  }
+
+  d = probability_a * size_a;
+  cost_delta -= d;
   VLOG(1) << "    - (" << probability_a << " * " << size_a
-          << ") -> " << cost_delta << " [removed patch A]";
+          << ") -> " << d << " [removed patch A]";
 
-  cost_delta -= probability_b * size_b;
+  d = probability_b * size_b;
+  cost_delta -= d;
   VLOG(1) << "    - (" << probability_b << " * " << size_b
-          << ") -> " << cost_delta << " [removed patch B]";
+          << ") -> " << d << " [removed patch B]";
 
   VLOG(1) << "    = " << cost_delta;
   return cost_delta;
@@ -920,41 +977,19 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
     const ActivationCondition& condition_b,
     const std::optional<CandidateMerge>& best_merge_candidate) {
 
-  const auto& condition_and_glyphs = merger.Context().glyph_groupings.ConditionsAndGlyphs();
+  PatchMergeDetails details = TRY(ComputePatchMergeDetails(merger, condition_a, condition_b));
 
-  auto glyphs_a_it = condition_and_glyphs.find(condition_a);
-  auto glyphs_b_it = condition_and_glyphs.find(condition_b);
-
-  if (glyphs_a_it == condition_and_glyphs.end() ||
-      glyphs_b_it == condition_and_glyphs.end()) {
-    return absl::InternalError(absl::StrCat("Unable to find glyphs for conditions: ",
-      condition_a.ToString(), ", ", condition_b.ToString()));
-  }
-
-  const GlyphSet& glyphs_a = glyphs_a_it->second;
-  const GlyphSet& glyphs_b = glyphs_b_it->second;
-
-  if (glyphs_a.empty() || glyphs_b.empty()) {
-    return absl::InternalError(absl::StrCat("Unexpected empty glyph sets for conditions: ",
-      condition_a.ToString(), ", ", condition_b.ToString()));
-  }
-
-  // A patch merge is straightforward, just the glyphs from the two merged
-  // patches are combined.
-  GlyphSet combined_glyphs = glyphs_a;
-  combined_glyphs.union_set(glyphs_b);
 
   if (merger.Strategy().UseCosts() && best_merge_candidate.has_value()) {
     // Pre-filter, if possible, with a best case computation to avoid computing the merged patch size.
-    double cost_delta = TRY(ComputePatchMergeCostDelta<true>(merger, condition_a, glyphs_a,
-                                                condition_b, glyphs_b, combined_glyphs));
+    double cost_delta = TRY(details.ComputePatchMergeCostDelta<true>(merger));
     if (cost_delta >= best_merge_candidate->CostDelta()) {
       return std::nullopt;
     }
   }
 
   uint32_t new_patch_size =
-      TRY(merger.Context().patch_size_cache->GetPatchSize(combined_glyphs));
+      TRY(merger.Context().patch_size_cache->GetPatchSize(details.glyphs_merged));
 
   if (!merger.Strategy().UseCosts() &&
       new_patch_size > merger.Strategy().PatchSizeMaxBytes()) {
@@ -964,8 +999,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   double cost_delta = 0.0;
   if (merger.Strategy().UseCosts()) {
     // Cost delta values are only needed when using cost based merge strategy.
-    cost_delta = TRY(ComputePatchMergeCostDelta<false>(merger, condition_a, glyphs_a,
-                                                condition_b, glyphs_b, combined_glyphs));
+    cost_delta = TRY(details.ComputePatchMergeCostDelta<false>(merger));
   }
 
   if (best_merge_candidate.has_value() &&
@@ -978,7 +1012,8 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   candidate.base_segment_index_ = 0; // Dummy value, not used for patch merges.
   candidate.segments_to_merge_ = condition_a.TriggeringSegments();
   candidate.segments_to_merge_.union_set(condition_b.TriggeringSegments());
-  candidate.patch_merge_target_conditions_ = std::make_pair(condition_a, condition_b);
+  candidate.patch_merge_target_conditions_ = std::make_pair(std::move(details.condition_a), std::move(details.condition_b));
+  candidate.patch_merge_glyphs_ = details.glyphs_merged;
   candidate.input_segments_are_inert_ = false;
   candidate.new_patch_size_ = new_patch_size;
   candidate.cost_delta_ = cost_delta;

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -721,6 +721,7 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   return cost_delta;
 }
 
+template<bool best_case>
 StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
     const Merger& merger,
     const ActivationCondition& condition_a,
@@ -738,13 +739,11 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
   double network_overhead = merger.Strategy().NetworkOverheadCost();
 
   double size_a = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_a));
-  size_a += network_overhead;
   double probability_a = TRY(condition_a.Probability(
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
 
   double size_b = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_b));
-  size_b += network_overhead;
   double probability_b = TRY(condition_b.Probability(
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
@@ -752,9 +751,23 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
   ActivationCondition merged_condition =
       ActivationCondition::Or(condition_a, condition_b);
 
-  double merged_patch_size =
+  double merged_patch_size = 0.0;
+  if (best_case) {
+    double best_case_reduction_fraction =
+      merger.Strategy().BestCaseSizeReductionFraction();
+    uint32_t extra = std::min(size_a, size_b);
+    extra = std::max((uint32_t)(extra * best_case_reduction_fraction),
+                       Merger::BEST_CASE_MERGE_SIZE_DELTA);
+    merged_patch_size = std::max(size_a, size_b) + extra;
+  } else {
+    merged_patch_size =
       TRY(merger.Context().patch_size_cache->GetPatchSize(merged_glyphs));
+  }
+
+  size_a += network_overhead;
+  size_b += network_overhead;
   merged_patch_size += network_overhead;
+
   double merged_probability = TRY(merged_condition.Probability(
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
@@ -931,6 +944,15 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   GlyphSet combined_glyphs = glyphs_a;
   combined_glyphs.union_set(glyphs_b);
 
+  if (merger.Strategy().UseCosts() && best_merge_candidate.has_value()) {
+    // Pre-filter, if possible, with a best case computation to avoid computing the merged patch size.
+    double cost_delta = TRY(ComputePatchMergeCostDelta<true>(merger, condition_a, glyphs_a,
+                                                condition_b, glyphs_b, combined_glyphs));
+    if (cost_delta >= best_merge_candidate->CostDelta()) {
+      return std::nullopt;
+    }
+  }
+
   uint32_t new_patch_size =
       TRY(merger.Context().patch_size_cache->GetPatchSize(combined_glyphs));
 
@@ -942,7 +964,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   double cost_delta = 0.0;
   if (merger.Strategy().UseCosts()) {
     // Cost delta values are only needed when using cost based merge strategy.
-    cost_delta = TRY(ComputePatchMergeCostDelta(merger, condition_a, glyphs_a,
+    cost_delta = TRY(ComputePatchMergeCostDelta<false>(merger, condition_a, glyphs_a,
                                                 condition_b, glyphs_b, combined_glyphs));
   }
 

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -128,21 +128,24 @@ StatusOr<InvalidationSet> CandidateMerge::Apply(Merger& merger) {
 }
 
 Status CandidateMerge::ApplyPatchMerge(Merger& merger) {
-  if (!patch_merge_target_conditions_.has_value() || !patch_merge_glyphs_.has_value()) {
-    return absl::InternalError("patch_merge_target_conditions_/patch_merge_glyphs_ is not set for patch merge");
+  if (!patch_merge_target_conditions_.has_value() ||
+      !patch_merge_glyphs_.has_value()) {
+    return absl::InternalError(
+        "patch_merge_target_conditions_/patch_merge_glyphs_ is not set for "
+        "patch merge");
   }
 
   VLOG(0) << "  Merged patches from "
-          << patch_merge_target_conditions_->first.ToString()
-          << " with "
-          << patch_merge_target_conditions_->second.ToString()
-          << " up to " << patch_merge_glyphs_->size() << " glyphs." << std::endl
+          << patch_merge_target_conditions_->first.ToString() << " with "
+          << patch_merge_target_conditions_->second.ToString() << " up to "
+          << patch_merge_glyphs_->size() << " glyphs." << std::endl
           << "  New patch size " << new_patch_size_ << " bytes. " << std::endl
           << "  Cost delta is " << cost_delta_ << ".";
 
   // CombinePatches() will do invalidation as needed, so nothing else needs to
   // be done to apply this merge.
-  return merger.Context().glyph_groupings.CombinePatches(*patch_merge_glyphs_, {});
+  return merger.Context().glyph_groupings.CombinePatches(*patch_merge_glyphs_,
+                                                         {});
 }
 
 static bool WouldMixFeaturesAndCodepoints(
@@ -360,8 +363,7 @@ static StatusOr<double> CostFor(Merger& merger,
 StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
     Merger& merger, uint32_t existing_init_font_size,
     const GlyphSet& moved_glyphs,
-    flat_hash_map<ift::common::GlyphSet, uint32_t>&
-        smallest_size_increases) {
+    flat_hash_map<ift::common::GlyphSet, uint32_t>& smallest_size_increases) {
   // Brotli compression results can be a bit noisy and it's common to see very
   // different size increase (in both directions) for adding the same glyphs as
   // the base changes. So to help control some of this noise we use
@@ -715,27 +717,30 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   return cost_delta;
 }
 
-StatusOr<CandidateMerge::PatchMergeDetails> CandidateMerge::ComputePatchMergeDetails(
-  const Merger& merger,
-  const ActivationCondition &condition_a,
-  const ActivationCondition &condition_b) {
-  const auto& condition_and_glyphs = merger.Context().glyph_groupings.ConditionsAndGlyphs();
+StatusOr<CandidateMerge::PatchMergeDetails>
+CandidateMerge::ComputePatchMergeDetails(
+    const Merger& merger, const ActivationCondition& condition_a,
+    const ActivationCondition& condition_b) {
+  const auto& condition_and_glyphs =
+      merger.Context().glyph_groupings.ConditionsAndGlyphs();
 
   auto glyphs_a_it = condition_and_glyphs.find(condition_a);
   auto glyphs_b_it = condition_and_glyphs.find(condition_b);
 
   if (glyphs_a_it == condition_and_glyphs.end() ||
       glyphs_b_it == condition_and_glyphs.end()) {
-    return absl::InternalError(absl::StrCat("Unable to find glyphs for conditions: ",
-      condition_a.ToString(), ", ", condition_b.ToString()));
+    return absl::InternalError(absl::StrCat(
+        "Unable to find glyphs for conditions: ", condition_a.ToString(), ", ",
+        condition_b.ToString()));
   }
 
   const GlyphSet& glyphs_a = glyphs_a_it->second;
   const GlyphSet& glyphs_b = glyphs_b_it->second;
 
   if (glyphs_a.empty() || glyphs_b.empty()) {
-    return absl::InternalError(absl::StrCat("Unexpected empty glyph sets for conditions: ",
-      condition_a.ToString(), ", ", condition_b.ToString()));
+    return absl::InternalError(absl::StrCat(
+        "Unexpected empty glyph sets for conditions: ", condition_a.ToString(),
+        ", ", condition_b.ToString()));
   }
 
   GlyphSet merged_glyphs = glyphs_a;
@@ -745,32 +750,34 @@ StatusOr<CandidateMerge::PatchMergeDetails> CandidateMerge::ComputePatchMergeDet
       ActivationCondition::Or(condition_a, condition_b);
 
   GlyphSet existing_glyphs;
-  auto existing_condition = merger.Context().glyph_groupings.ConditionsAndGlyphs().find(merged_condition);
-  if (existing_condition != merger.Context().glyph_groupings.ConditionsAndGlyphs().end()) {
+  auto existing_condition =
+      merger.Context().glyph_groupings.ConditionsAndGlyphs().find(
+          merged_condition);
+  if (existing_condition !=
+      merger.Context().glyph_groupings.ConditionsAndGlyphs().end()) {
     existing_glyphs = existing_condition->second;
     merged_glyphs.union_set(existing_condition->second);
   }
 
-  // It's possible for the new condition to be equal to one of the input conditions,
-  // in this case we don't want to record glyphs_existing since that would cause double
-  // counting of the patches removal in cost assessment.
+  // It's possible for the new condition to be equal to one of the input
+  // conditions, in this case we don't want to record glyphs_existing since that
+  // would cause double counting of the patches removal in cost assessment.
   if (condition_a == merged_condition || condition_b == merged_condition) {
     existing_glyphs.clear();
   }
 
-  return PatchMergeDetails {
-    .condition_a = condition_a,
-    .condition_b = condition_b,
-    .merged_condition = merged_condition,
-    .glyphs_a = glyphs_a,
-    .glyphs_b = glyphs_b,
-    .glyphs_existing = existing_glyphs,
-    .glyphs_merged = merged_glyphs
-  };
+  return PatchMergeDetails{.condition_a = condition_a,
+                           .condition_b = condition_b,
+                           .merged_condition = merged_condition,
+                           .glyphs_a = glyphs_a,
+                           .glyphs_b = glyphs_b,
+                           .glyphs_existing = existing_glyphs,
+                           .glyphs_merged = merged_glyphs};
 }
 
-template<bool best_case>
-StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(const Merger& merger) const {
+template <bool best_case>
+StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(
+    const Merger& merger) const {
   // For a patch merge only three things are affected:
   // 1. Remove the patch with condition equal to condition_a.
   // 2. Remove the patch with condition equal to condition_b.
@@ -780,34 +787,37 @@ StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(c
 
   double network_overhead = merger.Strategy().NetworkOverheadCost();
 
-  double size_a = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_a));
-  double probability_a = TRY(condition_a.Probability(
-      merger.Context().SegmentationInfo().Segments(),
-      *merger.Strategy().ProbabilityCalculator()));
+  double size_a =
+      TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_a));
+  double probability_a = TRY(
+      condition_a.Probability(merger.Context().SegmentationInfo().Segments(),
+                              *merger.Strategy().ProbabilityCalculator()));
 
-  double size_b = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_b));
-  double probability_b = TRY(condition_b.Probability(
-      merger.Context().SegmentationInfo().Segments(),
-      *merger.Strategy().ProbabilityCalculator()));
+  double size_b =
+      TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_b));
+  double probability_b = TRY(
+      condition_b.Probability(merger.Context().SegmentationInfo().Segments(),
+                              *merger.Strategy().ProbabilityCalculator()));
 
   double size_existing = 0.0;
   if (!glyphs_existing.empty()) {
-    size_existing = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_existing));
+    size_existing =
+        TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_existing));
   }
 
   double merged_patch_size = 0.0;
   if (best_case) {
     double best_case_reduction_fraction =
-      merger.Strategy().BestCaseSizeReductionFraction();
+        merger.Strategy().BestCaseSizeReductionFraction();
     uint32_t total_size = size_a + size_b + size_existing;
     uint32_t max_size = std::max(std::max(size_a, size_b), size_existing);
     uint32_t extra = total_size - max_size;
     extra = std::max((uint32_t)(extra * best_case_reduction_fraction),
-                       Merger::BEST_CASE_MERGE_SIZE_DELTA);
+                     Merger::BEST_CASE_MERGE_SIZE_DELTA);
     merged_patch_size = max_size + extra;
   } else {
     merged_patch_size =
-      TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_merged));
+        TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_merged));
   }
 
   size_a += network_overhead;
@@ -819,8 +829,8 @@ StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(c
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
 
-  VLOG(1) << "cost_delta for patch merge of " << condition_a.ToString() << " with "
-          << condition_b.ToString() << " =";
+  VLOG(1) << "cost_delta for patch merge of " << condition_a.ToString()
+          << " with " << condition_b.ToString() << " =";
   double cost_delta = 0.0;
 
   double d = merged_probability * merged_patch_size;
@@ -832,18 +842,18 @@ StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(c
     d = merged_probability * size_existing;
     cost_delta -= d;
     VLOG(1) << "    - (" << merged_probability << " * " << size_existing
-          << ") -> " << d << " [removed existing patch]";
+            << ") -> " << d << " [removed existing patch]";
   }
 
   d = probability_a * size_a;
   cost_delta -= d;
-  VLOG(1) << "    - (" << probability_a << " * " << size_a
-          << ") -> " << d << " [removed patch A]";
+  VLOG(1) << "    - (" << probability_a << " * " << size_a << ") -> " << d
+          << " [removed patch A]";
 
   d = probability_b * size_b;
   cost_delta -= d;
-  VLOG(1) << "    - (" << probability_b << " * " << size_b
-          << ") -> " << d << " [removed patch B]";
+  VLOG(1) << "    - (" << probability_b << " * " << size_b << ") -> " << d
+          << " [removed patch B]";
 
   VLOG(1) << "    = " << cost_delta;
   return cost_delta;
@@ -972,27 +982,27 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
 }
 
 StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
-    Merger& merger,
-    const ActivationCondition& condition_a,
+    Merger& merger, const ActivationCondition& condition_a,
     const ActivationCondition& condition_b,
     const std::optional<CandidateMerge>& best_merge_candidate) {
-
   if (condition_a == condition_b) {
     return absl::InternalError("Can't merge condition with itself");
   }
 
-  PatchMergeDetails details = TRY(ComputePatchMergeDetails(merger, condition_a, condition_b));
+  PatchMergeDetails details =
+      TRY(ComputePatchMergeDetails(merger, condition_a, condition_b));
 
   if (merger.Strategy().UseCosts() && best_merge_candidate.has_value()) {
-    // Pre-filter, if possible, with a best case computation to avoid computing the merged patch size.
+    // Pre-filter, if possible, with a best case computation to avoid computing
+    // the merged patch size.
     double cost_delta = TRY(details.ComputePatchMergeCostDelta<true>(merger));
     if (cost_delta >= best_merge_candidate->CostDelta()) {
       return std::nullopt;
     }
   }
 
-  uint32_t new_patch_size =
-      TRY(merger.Context().patch_size_cache->GetPatchSize(details.glyphs_merged));
+  uint32_t new_patch_size = TRY(
+      merger.Context().patch_size_cache->GetPatchSize(details.glyphs_merged));
 
   if (!merger.Strategy().UseCosts() &&
       new_patch_size > merger.Strategy().PatchSizeMaxBytes()) {
@@ -1012,21 +1022,23 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   }
 
   if (cost_delta >= 0) {
-    // Only accept a non-negative delta if the merge would also increase group size of at least one
-    // of the inputs
+    // Only accept a non-negative delta if the merge would also increase group
+    // size of at least one of the inputs
     uint32_t merged_group_size = details.merged_condition.EffectiveGroupSize();
     uint32_t a_group_size = details.condition_a.EffectiveGroupSize();
     uint32_t b_group_size = details.condition_b.EffectiveGroupSize();
-    if (merged_group_size <= a_group_size && merged_group_size <= b_group_size) {
+    if (merged_group_size <= a_group_size &&
+        merged_group_size <= b_group_size) {
       return std::nullopt;
     }
   }
 
   CandidateMerge candidate;
-  candidate.base_segment_index_ = 0; // Dummy value, not used for patch merges.
+  candidate.base_segment_index_ = 0;  // Dummy value, not used for patch merges.
   candidate.segments_to_merge_ = condition_a.TriggeringSegments();
   candidate.segments_to_merge_.union_set(condition_b.TriggeringSegments());
-  candidate.patch_merge_target_conditions_ = std::make_pair(std::move(details.condition_a), std::move(details.condition_b));
+  candidate.patch_merge_target_conditions_ = std::make_pair(
+      std::move(details.condition_a), std::move(details.condition_b));
   candidate.patch_merge_glyphs_ = details.glyphs_merged;
   candidate.input_segments_are_inert_ = false;
   candidate.new_patch_size_ = new_patch_size;

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -977,8 +977,11 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
     const ActivationCondition& condition_b,
     const std::optional<CandidateMerge>& best_merge_candidate) {
 
-  PatchMergeDetails details = TRY(ComputePatchMergeDetails(merger, condition_a, condition_b));
+  if (condition_a == condition_b) {
+    return absl::InternalError("Can't merge condition with itself");
+  }
 
+  PatchMergeDetails details = TRY(ComputePatchMergeDetails(merger, condition_a, condition_b));
 
   if (merger.Strategy().UseCosts() && best_merge_candidate.has_value()) {
     // Pre-filter, if possible, with a best case computation to avoid computing the merged patch size.
@@ -1006,6 +1009,17 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
       cost_delta >= best_merge_candidate->CostDelta()) {
     // Our delta is not smaller, don't bother returning a candidate.
     return std::nullopt;
+  }
+
+  if (cost_delta >= 0) {
+    // Only accept a non-negative delta if the merge would also increase group size of at least one
+    // of the inputs
+    uint32_t merged_group_size = details.merged_condition.EffectiveGroupSize();
+    uint32_t a_group_size = details.condition_a.EffectiveGroupSize();
+    uint32_t b_group_size = details.condition_b.EffectiveGroupSize();
+    if (merged_group_size <= a_group_size && merged_group_size <= b_group_size) {
+      return std::nullopt;
+    }
   }
 
   CandidateMerge candidate;

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -128,25 +128,29 @@ StatusOr<InvalidationSet> CandidateMerge::Apply(Merger& merger) {
 }
 
 Status CandidateMerge::ApplyPatchMerge(Merger& merger) {
-  const GlyphSet& base_glyphs =
-      merger.Context().glyph_groupings.ExclusiveGlyphs(base_segment_index_);
-  const GlyphSet& other_glyphs =
+  if (!patch_merge_target_conditions_.has_value()) {
+    return absl::InternalError("patch_merge_target_conditions_ is not set for patch merge");
+  }
+
+  const GlyphSet& glyphs_a =
       merger.Context().glyph_groupings.ConditionsAndGlyphs().at(
-          ActivationCondition::or_segments(segments_to_merge_, 0));
+          patch_merge_target_conditions_->first);
+  const GlyphSet& glyphs_b =
+      merger.Context().glyph_groupings.ConditionsAndGlyphs().at(
+          patch_merge_target_conditions_->second);
 
   VLOG(0) << "  Merged patches from "
-          << ActivationCondition::exclusive_segment(base_segment_index_, 0)
-                 .ToString()
-          << " (" << base_glyphs.size() << " glyphs) with "
-          << ActivationCondition::or_segments(segments_to_merge_, 0).ToString()
-          << " (" << other_glyphs.size() << " glyphs)." << std::endl
+          << patch_merge_target_conditions_->first.ToString()
+          << " (" << glyphs_a.size() << " glyphs) with "
+          << patch_merge_target_conditions_->second.ToString()
+          << " (" << glyphs_b.size() << " glyphs)." << std::endl
           << "  New patch size " << new_patch_size_ << " bytes. " << std::endl
           << "  Cost delta is " << cost_delta_ << ".";
 
   // CombinePatches() will do invalidation as needed, so nothing else needs to
   // be done to apply this merge.
-  return merger.Context().glyph_groupings.CombinePatches(base_glyphs,
-                                                         other_glyphs);
+  return merger.Context().glyph_groupings.CombinePatches(glyphs_a,
+                                                         glyphs_b);
 }
 
 static bool WouldMixFeaturesAndCodepoints(
@@ -364,7 +368,7 @@ static StatusOr<double> CostFor(Merger& merger,
 StatusOr<std::pair<double, GlyphSet>> CandidateMerge::ComputeInitFontCostDelta(
     Merger& merger, uint32_t existing_init_font_size,
     const GlyphSet& moved_glyphs,
-    absl::flat_hash_map<ift::common::GlyphSet, uint32_t>&
+    flat_hash_map<ift::common::GlyphSet, uint32_t>&
         smallest_size_increases) {
   // Brotli compression results can be a bit noisy and it's common to see very
   // different size increase (in both directions) for adding the same glyphs as
@@ -718,39 +722,36 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
 }
 
 StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
-    const Merger& merger, segment_index_t base_segment,
-    const GlyphSet& base_glyphs, const SegmentSet& target_segments,
-    const GlyphSet& target_glyphs, const GlyphSet& merged_glyphs) {
+    const Merger& merger,
+    const ActivationCondition& condition_a,
+    const GlyphSet& glyphs_a,
+    const ActivationCondition& condition_b,
+    const GlyphSet& glyphs_b,
+    const GlyphSet& merged_glyphs) {
   // For a patch merge only three things are affected:
-  // 1. Remove the exclusive patch associated with base_segment.
-  // 2. Remove the disjunctive patch with condition equal to target_segments.
+  // 1. Remove the patch with condition equal to condition_a.
+  // 2. Remove the patch with condition equal to condition_b.
   // 3. Add a new combined patch that contains all of the glyphs of 1 + 2.
-  //    New condition is {base} union {merged}, with corresponding new
+  //    New condition is (condition_a OR condition_b), with corresponding new
   //    probability.
 
   double network_overhead = merger.Strategy().NetworkOverheadCost();
-  double base_patch_size =
-      TRY(merger.Context().patch_size_cache->GetPatchSize(base_glyphs));
-  base_patch_size += network_overhead;
-  double base_probability = merger.Context()
-                                .SegmentationInfo()
-                                .Segments()
-                                .at(base_segment)
-                                .Probability();
 
-  ActivationCondition target_condition =
-      ActivationCondition::or_segments(target_segments, 0);
-  double target_patch_size =
-      TRY(merger.Context().patch_size_cache->GetPatchSize(target_glyphs));
-  target_patch_size += network_overhead;
-  double target_probability = TRY(target_condition.Probability(
+  double size_a = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_a));
+  size_a += network_overhead;
+  double probability_a = TRY(condition_a.Probability(
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
 
-  SegmentSet merged_segments = target_segments;
-  merged_segments.insert(base_segment);
+  double size_b = TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_b));
+  size_b += network_overhead;
+  double probability_b = TRY(condition_b.Probability(
+      merger.Context().SegmentationInfo().Segments(),
+      *merger.Strategy().ProbabilityCalculator()));
+
   ActivationCondition merged_condition =
-      ActivationCondition::or_segments(merged_segments, 0);
+      ActivationCondition::Or(condition_a, condition_b);
+
   double merged_patch_size =
       TRY(merger.Context().patch_size_cache->GetPatchSize(merged_glyphs));
   merged_patch_size += network_overhead;
@@ -758,21 +759,21 @@ StatusOr<double> CandidateMerge::ComputePatchMergeCostDelta(
       merger.Context().SegmentationInfo().Segments(),
       *merger.Strategy().ProbabilityCalculator()));
 
-  VLOG(1) << "cost_delta for patch merge of " << base_segment << " with "
-          << merged_segments.ToString() << " =";
+  VLOG(1) << "cost_delta for patch merge of " << condition_a.ToString() << " with "
+          << condition_b.ToString() << " =";
   double cost_delta = 0.0;
 
   cost_delta += merged_probability * merged_patch_size;
   VLOG(1) << "    + (" << merged_probability << " * " << merged_patch_size
           << ") -> " << cost_delta << " [merged patch]";
 
-  cost_delta -= base_probability * base_patch_size;
-  VLOG(1) << "    - (" << base_probability << " * " << base_patch_size
-          << ") -> " << cost_delta << " [removed patch]";
+  cost_delta -= probability_a * size_a;
+  VLOG(1) << "    - (" << probability_a << " * " << size_a
+          << ") -> " << cost_delta << " [removed patch A]";
 
-  cost_delta -= target_probability * target_patch_size;
-  VLOG(1) << "    - (" << target_probability << " * " << target_patch_size
-          << ") -> " << cost_delta << " [removed patch]";
+  cost_delta -= probability_b * size_b;
+  VLOG(1) << "    - (" << probability_b << " * " << size_b
+          << ") -> " << cost_delta << " [removed patch B]";
 
   VLOG(1) << "    = " << cost_delta;
   return cost_delta;
@@ -884,7 +885,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
   }
 
   if (best_merge_candidate.has_value() &&
-      cost_delta >= best_merge_candidate.value().cost_delta_) {
+      cost_delta >= best_merge_candidate->CostDelta()) {
     // Our delta is not smaller, don't bother returning a candidate.
     return std::nullopt;
   }
@@ -897,42 +898,39 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
   candidate.cost_delta_ = cost_delta;
   candidate.invalidated_glyphs_ = gid_conditions_to_update;
 
-  if (merger.Strategy().UseCosts()) {
-    const GlyphSet& base_segment_glyphs =
-        merger.Context().glyph_condition_set.GlyphsWithSegment(
-            base_segment_index);
-    candidate.base_size_ = TRY(
-        merger.Context().patch_size_cache->GetPatchSize(base_segment_glyphs));
-    candidate.base_probability_ = segments[base_segment_index].Probability();
-    candidate.network_overhead_ = merger.Strategy().NetworkOverheadCost();
-  }
-
   return candidate;
 }
 
 StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
-    Merger& merger, segment_index_t base_segment_index,
-    const SegmentSet& segments_to_merge,
+    Merger& merger,
+    const ActivationCondition& condition_a,
+    const ActivationCondition& condition_b,
     const std::optional<CandidateMerge>& best_merge_candidate) {
-  const auto& segments = merger.Context().SegmentationInfo().Segments();
 
-  const GlyphSet& base_glyphs =
-      merger.Context().glyph_groupings.ExclusiveGlyphs(base_segment_index);
-  auto other_glyphs_it =
-      merger.Context().glyph_groupings.ConditionsAndGlyphs().find(
-          ActivationCondition::or_segments(segments_to_merge, 0));
-  if (base_glyphs.empty() ||
-      other_glyphs_it ==
-          merger.Context().glyph_groupings.ConditionsAndGlyphs().end()) {
-    // Can only merge if both base patch and the segments_to_merge patch exist.
-    return std::nullopt;
+  const auto& condition_and_glyphs = merger.Context().glyph_groupings.ConditionsAndGlyphs();
+
+  auto glyphs_a_it = condition_and_glyphs.find(condition_a);
+  auto glyphs_b_it = condition_and_glyphs.find(condition_b);
+
+  if (glyphs_a_it == condition_and_glyphs.end() ||
+      glyphs_b_it == condition_and_glyphs.end()) {
+    return absl::InternalError(absl::StrCat("Unable to find glyphs for conditions: ",
+      condition_a.ToString(), ", ", condition_b.ToString()));
   }
-  const GlyphSet& other_glyphs = other_glyphs_it->second;
+
+  const GlyphSet& glyphs_a = glyphs_a_it->second;
+  const GlyphSet& glyphs_b = glyphs_b_it->second;
+
+  if (glyphs_a.empty() || glyphs_b.empty()) {
+    return absl::InternalError(absl::StrCat("Unexpected empty glyph sets for conditions: ",
+      condition_a.ToString(), ", ", condition_b.ToString()));
+  }
 
   // A patch merge is straightforward, just the glyphs from the two merged
   // patches are combined.
-  GlyphSet combined_glyphs = base_glyphs;
-  combined_glyphs.union_set(other_glyphs);
+  GlyphSet combined_glyphs = glyphs_a;
+  combined_glyphs.union_set(glyphs_b);
+
   uint32_t new_patch_size =
       TRY(merger.Context().patch_size_cache->GetPatchSize(combined_glyphs));
 
@@ -944,20 +942,21 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   double cost_delta = 0.0;
   if (merger.Strategy().UseCosts()) {
     // Cost delta values are only needed when using cost based merge strategy.
-    cost_delta = TRY(ComputePatchMergeCostDelta(merger, base_segment_index,
-                                                base_glyphs, segments_to_merge,
-                                                other_glyphs, combined_glyphs));
+    cost_delta = TRY(ComputePatchMergeCostDelta(merger, condition_a, glyphs_a,
+                                                condition_b, glyphs_b, combined_glyphs));
   }
 
   if (best_merge_candidate.has_value() &&
-      cost_delta >= best_merge_candidate.value().cost_delta_) {
+      cost_delta >= best_merge_candidate->CostDelta()) {
     // Our delta is not smaller, don't bother returning a candidate.
     return std::nullopt;
   }
 
   CandidateMerge candidate;
-  candidate.base_segment_index_ = base_segment_index;
-  candidate.segments_to_merge_ = segments_to_merge;
+  candidate.base_segment_index_ = 0; // Dummy value, not used for patch merges.
+  candidate.segments_to_merge_ = condition_a.TriggeringSegments();
+  candidate.segments_to_merge_.union_set(condition_b.TriggeringSegments());
+  candidate.patch_merge_target_conditions_ = std::make_pair(condition_a, condition_b);
   candidate.input_segments_are_inert_ = false;
   candidate.new_patch_size_ = new_patch_size;
   candidate.cost_delta_ = cost_delta;
@@ -965,13 +964,6 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
   // Since patch merges trigger full recomputation (of the combined patches), no
   // glyphs need to be invalidated by this merge.
   candidate.invalidated_glyphs_ = {};
-
-  if (merger.Strategy().UseCosts()) {
-    candidate.base_size_ =
-        TRY(merger.Context().patch_size_cache->GetPatchSize(base_glyphs));
-    candidate.base_probability_ = segments[base_segment_index].Probability();
-    candidate.network_overhead_ = merger.Strategy().NetworkOverheadCost();
-  }
 
   return candidate;
 }

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -30,6 +30,7 @@ struct CandidateMerge {
   // The conditions of the patch to be merged into the base segment patch.
   // Only used for patch merges (when merged_segment_ is not present).
   std::optional<std::pair<ActivationCondition, ActivationCondition>> patch_merge_target_conditions_;
+  std::optional<common::GlyphSet> patch_merge_glyphs_;
 
   // The result of merge the above segments. If it's not present then
   // that implies this merge is only a merge of the base segment patch
@@ -163,14 +164,25 @@ struct CandidateMerge {
       Merger& merger, uint32_t existing_init_font_size,
       const ift::common::GlyphSet& moved_glyphs);
 
-  template<bool best_case>
-  static absl::StatusOr<double> ComputePatchMergeCostDelta(
-      const Merger& context,
-      const ActivationCondition& condition_a,
-      const ift::common::GlyphSet& glyphs_a,
-      const ActivationCondition& condition_b,
-      const ift::common::GlyphSet& glyphs_b,
-      const ift::common::GlyphSet& merged_glyphs);
+  struct PatchMergeDetails {
+    ActivationCondition condition_a;
+    ActivationCondition condition_b;
+    ActivationCondition merged_condition;
+
+    common::GlyphSet glyphs_a;
+    common::GlyphSet glyphs_b;
+    common::GlyphSet glyphs_existing;
+    common::GlyphSet glyphs_merged;
+
+    template<bool best_case>
+    absl::StatusOr<double> ComputePatchMergeCostDelta(const Merger& merger) const;
+  };
+
+  static absl::StatusOr<PatchMergeDetails> ComputePatchMergeDetails(
+    const Merger& merger,
+    const ActivationCondition& condition_a,
+    const ActivationCondition& condition_b
+  );
 
   static absl::StatusOr<uint32_t> Woff2SizeOf(hb_face_t* original_face,
                                               const SubsetDefinition& def,

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -3,6 +3,7 @@
 
 #include <cstdint>
 #include <optional>
+#include "ift/encoder/activation_condition.h"
 
 #include "absl/status/statusor.h"
 #include "ift/common/int_set.h"
@@ -26,6 +27,10 @@ struct CandidateMerge {
   // The set of segments to be merged into the base_segment_index.
   ift::common::SegmentSet segments_to_merge_;
 
+  // The conditions of the patch to be merged into the base segment patch.
+  // Only used for patch merges (when merged_segment_ is not present).
+  std::optional<std::pair<ActivationCondition, ActivationCondition>> patch_merge_target_conditions_;
+
   // The result of merge the above segments. If it's not present then
   // that implies this merge is only a merge of the base segment patch
   // and the disjunctive patch with the condition segments_to_merge_.
@@ -45,19 +50,12 @@ struct CandidateMerge {
   // merge is applied.
   ift::common::GlyphSet invalidated_glyphs_;
 
-  // Inert probability threshold computation cache
-  double base_size_ = 0.0;
-  double base_probability_ = 0.0;
-  double network_overhead_ = 0.0;
-
   CandidateMerge(Segment merged_segment) : merged_segment_(merged_segment) {}
   CandidateMerge() : merged_segment_(std::nullopt) {}
 
  public:
   static CandidateMerge BaselineCandidate(uint32_t base_segment_index,
-                                          double cost_delta, double base_size,
-                                          double base_probability,
-                                          double network_overhead) {
+                                          double cost_delta) {
     CandidateMerge merge(Segment({}, freq::ProbabilityBound::Zero()));
     merge.base_segment_index_ = base_segment_index;
     merge.segments_to_merge_ = {base_segment_index};
@@ -65,9 +63,6 @@ struct CandidateMerge {
     merge.new_patch_size_ = 0;
     merge.cost_delta_ = cost_delta;
     merge.invalidated_glyphs_ = {};
-    merge.base_size_ = base_size;
-    merge.base_probability_ = base_probability;
-    merge.network_overhead_ = network_overhead;
     return merge;
   }
 
@@ -118,17 +113,18 @@ struct CandidateMerge {
       const ift::common::SegmentSet& segments_to_merge_,
       const std::optional<CandidateMerge>& best_merge_candidate);
 
-  // Assess the resutl of merging together exactly two patches:
+  // Assess the result of merging together exactly two patches:
   // 1. The exclusive patch for base_segment_index.
-  // 2. The patch associated with the disjunctive segments_to_merge_ condition.
+  // 2. The patch associated with target_condition.
   //
   // If the merge is not better than best_merge_candidate or not possible
   // then nullopt will be returned.
   //
   // Returns a candidate merge object which stores information on the merge.
   static absl::StatusOr<std::optional<CandidateMerge>> AssessPatchMerge(
-      Merger& context, segment_index_t base_segment_index,
-      const ift::common::SegmentSet& segments_to_merge_,
+      Merger& context,
+      const ActivationCondition& condition_a,
+      const ActivationCondition& condition_b,
       const std::optional<CandidateMerge>& best_merge_candidate);
 
   // Computes the estimated size of the patch for a segment and returns true if
@@ -168,10 +164,11 @@ struct CandidateMerge {
       const ift::common::GlyphSet& moved_glyphs);
 
   static absl::StatusOr<double> ComputePatchMergeCostDelta(
-      const Merger& context, segment_index_t base_segment,
-      const ift::common::GlyphSet& base_glyphs,
-      const ift::common::SegmentSet& target_segments,
-      const ift::common::GlyphSet& target_glyphs,
+      const Merger& context,
+      const ActivationCondition& condition_a,
+      const ift::common::GlyphSet& glyphs_a,
+      const ActivationCondition& condition_b,
+      const ift::common::GlyphSet& glyphs_b,
       const ift::common::GlyphSet& merged_glyphs);
 
   static absl::StatusOr<uint32_t> Woff2SizeOf(hb_face_t* original_face,

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -3,10 +3,10 @@
 
 #include <cstdint>
 #include <optional>
-#include "ift/encoder/activation_condition.h"
 
 #include "absl/status/statusor.h"
 #include "ift/common/int_set.h"
+#include "ift/encoder/activation_condition.h"
 #include "ift/encoder/invalidation_set.h"
 #include "ift/encoder/segment.h"
 #include "ift/encoder/types.h"
@@ -29,7 +29,8 @@ struct CandidateMerge {
 
   // The conditions of the patch to be merged into the base segment patch.
   // Only used for patch merges (when merged_segment_ is not present).
-  std::optional<std::pair<ActivationCondition, ActivationCondition>> patch_merge_target_conditions_;
+  std::optional<std::pair<ActivationCondition, ActivationCondition>>
+      patch_merge_target_conditions_;
   std::optional<common::GlyphSet> patch_merge_glyphs_;
 
   // The result of merge the above segments. If it's not present then
@@ -123,8 +124,7 @@ struct CandidateMerge {
   //
   // Returns a candidate merge object which stores information on the merge.
   static absl::StatusOr<std::optional<CandidateMerge>> AssessPatchMerge(
-      Merger& context,
-      const ActivationCondition& condition_a,
+      Merger& context, const ActivationCondition& condition_a,
       const ActivationCondition& condition_b,
       const std::optional<CandidateMerge>& best_merge_candidate);
 
@@ -174,15 +174,14 @@ struct CandidateMerge {
     common::GlyphSet glyphs_existing;
     common::GlyphSet glyphs_merged;
 
-    template<bool best_case>
-    absl::StatusOr<double> ComputePatchMergeCostDelta(const Merger& merger) const;
+    template <bool best_case>
+    absl::StatusOr<double> ComputePatchMergeCostDelta(
+        const Merger& merger) const;
   };
 
   static absl::StatusOr<PatchMergeDetails> ComputePatchMergeDetails(
-    const Merger& merger,
-    const ActivationCondition& condition_a,
-    const ActivationCondition& condition_b
-  );
+      const Merger& merger, const ActivationCondition& condition_a,
+      const ActivationCondition& condition_b);
 
   static absl::StatusOr<uint32_t> Woff2SizeOf(hb_face_t* original_face,
                                               const SubsetDefinition& def,

--- a/ift/encoder/candidate_merge.h
+++ b/ift/encoder/candidate_merge.h
@@ -163,6 +163,7 @@ struct CandidateMerge {
       Merger& merger, uint32_t existing_init_font_size,
       const ift::common::GlyphSet& moved_glyphs);
 
+  template<bool best_case>
   static absl::StatusOr<double> ComputePatchMergeCostDelta(
       const Merger& context,
       const ActivationCondition& condition_a,

--- a/ift/encoder/candidate_merge_test.cc
+++ b/ift/encoder/candidate_merge_test.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "ift/common/bazel_data_file_resolver.h"
 #include "ift/common/font_data.h"
+#include "ift/common/font_helper.h"
 #include "ift/common/int_set.h"
 #include "ift/common/test_font_loader.h"
 #include "ift/encoder/closure_glyph_segmenter.h"
@@ -28,6 +29,7 @@ using ift::common::BazelDataFileResolver;
 using ift::common::CodepointSet;
 using ift::common::DataFileResolver;
 using ift::common::FontData;
+using ift::common::FontHelper;
 using ift::common::GlyphSet;
 using ift::common::hb_face_unique_ptr;
 using ift::common::IntSet;
@@ -218,7 +220,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   auto r = CandidateMerge::AssessSegmentMerge(
       merger, 0, {1},
       CandidateMerge::BaselineCandidate(
-          4, 0.0, base_size, 0.95, merger.Strategy().NetworkOverheadCost()));
+          4, 0.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
   CandidateMerge merge = **r;
@@ -229,7 +231,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   r = CandidateMerge::AssessSegmentMerge(
       merger, 0, {1},
       CandidateMerge::BaselineCandidate(
-          4, -500.0, base_size, 0.95, merger.Strategy().NetworkOverheadCost()));
+          4, -500.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_FALSE(r->has_value());
 
@@ -240,7 +242,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   r = CandidateMerge::AssessSegmentMerge(
       merger, 0, {3},
       CandidateMerge::BaselineCandidate(
-          4, 0.0, base_size, 0.95, merger.Strategy().NetworkOverheadCost()));
+          4, 0.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_FALSE(r->has_value());
 
@@ -250,7 +252,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   r = CandidateMerge::AssessSegmentMerge(
       merger, 3, {0},
       CandidateMerge::BaselineCandidate(
-          4, 0.0, base_size, 0.01, merger.Strategy().NetworkOverheadCost()));
+          4, 0.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_FALSE(r->has_value());
 }
@@ -422,7 +424,7 @@ TEST_F(CandidateMergeTest, AssessPatchMerge) {
       all);
 
   // Try merging the patch for {0} and {1 OR 4}.
-  auto r = CandidateMerge::AssessPatchMerge(merger, 0, {1, 4}, std::nullopt);
+  auto r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({1, 4}, 0), std::nullopt);
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
   CandidateMerge merge = **r;
@@ -432,7 +434,7 @@ TEST_F(CandidateMergeTest, AssessPatchMerge) {
   ASSERT_LT(merge.CostDelta(), 0);
 
   // Try merging the patch for {0} and {2 OR 3}.
-  r = CandidateMerge::AssessPatchMerge(merger, 0, {2, 3}, std::nullopt);
+  r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({2, 3}, 0), std::nullopt);
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
   merge = **r;
@@ -475,16 +477,85 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_RequiresPatches) {
       all);
 
   // Try merging the patch for {0} and {1}.
-  auto r = CandidateMerge::AssessPatchMerge(merger, 0, {1}, std::nullopt);
-  ASSERT_TRUE(r.ok()) << r.status();
+  auto r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({1}, 0), std::nullopt);
   // segment 1 has no patch associated with it, so no merge is possible.
-  ASSERT_FALSE(r->has_value());
+  ASSERT_TRUE(absl::IsInternal(r.status())) << r.status();
 
   // Try merging the patch for {0} and {0 or 1}.
-  r = CandidateMerge::AssessPatchMerge(merger, 0, {0, 1}, std::nullopt);
-  ASSERT_TRUE(r.ok()) << r.status();
+  r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({0, 1}, 0), std::nullopt);
   // {0 or 1} has no patch associated with it, so no merge is possible.
-  ASSERT_FALSE(r->has_value());
+  ASSERT_TRUE(absl::IsInternal(r.status())) << r.status();
+}
+
+TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
+  std::vector<Segment> segments =  {
+      {{'A'}, ProbabilityBound{0.95, 0.95}},
+      {{'B'}, ProbabilityBound{0.85, 0.85}},
+      {{'C'}, ProbabilityBound{0.75, 0.75}},
+  };
+  std::vector<Segment> segments_with_merges = segments;
+  segments_with_merges.push_back({{'A', 'B'}, ProbabilityBound{0.90, 0.90}});
+  segments_with_merges.push_back({{'A', 'C'}, ProbabilityBound{0.92, 0.92}});
+
+  auto probability_calculator =
+      std::make_unique<freq::MockProbabilityCalculator>(segments_with_merges);
+
+  MockPatchSizeCache* size_cache = new MockPatchSizeCache();
+
+  ClosureGlyphSegmenter segmenter(8, 8, PATCH, CLOSURE_ONLY, resolver);
+  auto context = SegmentationContext::InitializeSegmentationContext(
+      roboto.get(), {}, segments, segmenter.unmapped_glyph_handling(),
+      segmenter.condition_analysis_mode(), segmenter.brotli_quality(),
+      segmenter.init_font_merging_brotli_quality(), resolver);
+  ASSERT_TRUE(context.ok()) << context.status();
+
+  Merger merger = *Merger::New(
+      *context,
+      MergeStrategy::CostBased(std::move(probability_calculator), 75, 1), all,
+      all);
+
+  glyph_id_t gid_B = *FontHelper::GetNominalGlyph(roboto.get(), 'B');
+  size_cache->SetPatchSize({gid_B}, 200);
+
+  // Manually set up a conjunctive condition for gid_d: s1 AND s2.
+  context->glyph_condition_set.AddAndCondition(gid_B, 1);
+  context->glyph_condition_set.AddAndCondition(gid_B, 2);
+
+  ActivationCondition conj_cond = ActivationCondition::and_segments({1, 2}, 0);
+
+  // We also need a base patch to exist.
+  glyph_id_t gid_A = *FontHelper::GetNominalGlyph(roboto.get(), 'A');
+  size_cache->SetPatchSize({gid_A}, 100);
+  size_cache->SetPatchSize({gid_A, gid_B}, 250);
+  context->glyph_condition_set.AddAndCondition(gid_A, 0);
+
+  // Update glyph groupings.
+  auto sc = context->glyph_groupings.GroupGlyphs(
+      context->SegmentationInfo(), context->glyph_condition_set,
+      *context->glyph_closure_cache, std::nullopt, {gid_A, gid_B}, {0, 1, 2}, false);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  for (const auto& [c, g] : context->glyph_groupings.ConditionsAndGlyphs()) {
+    std::cerr << c.ToString() << " => "  << g.ToString() << std::endl;
+  }
+
+  context->patch_size_cache.reset(size_cache);
+
+  auto r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), conj_cond, std::nullopt);
+  ASSERT_TRUE(r.ok()) << r.status();
+  ASSERT_TRUE(r->has_value());
+
+  // Delta =
+  // - (s0) * (size(gid_A) + 75)
+  // - (s1 AND s2) * (size(gid_B) + 75)
+  // + (s0 OR s1) and (s0 OR s2)) * (size(gid_A, gid_b) + 75)
+  ASSERT_EQ((*r)->CostDelta(),
+    - 0.95 * (100 + 75)
+    - (0.85 * 0.75) * (200 + 75)
+    + (0.90 * 0.92) * (250 + 75));
+
+  CandidateMerge merge = **r;
+  ASSERT_EQ(merge.SegmentsToMerge(), SegmentSet({0, 1, 2}));
 }
 
 TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {

--- a/ift/encoder/candidate_merge_test.cc
+++ b/ift/encoder/candidate_merge_test.cc
@@ -218,9 +218,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   // Case 1: merge high frequency segments {0, 1}. Best current merge is set at
   // 0, assess merge should return a better candidate.
   auto r = CandidateMerge::AssessSegmentMerge(
-      merger, 0, {1},
-      CandidateMerge::BaselineCandidate(
-          4, 0.0));
+      merger, 0, {1}, CandidateMerge::BaselineCandidate(4, 0.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
   CandidateMerge merge = **r;
@@ -229,9 +227,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   // Case 2: merge high frequency segments {0, 1}. Best current merge is set at
   // -500, assess merge should not return a better candidate.
   r = CandidateMerge::AssessSegmentMerge(
-      merger, 0, {1},
-      CandidateMerge::BaselineCandidate(
-          4, -500.0));
+      merger, 0, {1}, CandidateMerge::BaselineCandidate(4, -500.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_FALSE(r->has_value());
 
@@ -240,9 +236,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   // network overhead cost reduction. Overall cost should be positive. Baseline
   // is set at 0 so no candidate is expected from the return.
   r = CandidateMerge::AssessSegmentMerge(
-      merger, 0, {3},
-      CandidateMerge::BaselineCandidate(
-          4, 0.0));
+      merger, 0, {3}, CandidateMerge::BaselineCandidate(4, 0.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_FALSE(r->has_value());
 
@@ -250,9 +244,7 @@ TEST_F(CandidateMergeTest, AssessMerge_WithBestCandidate) {
   base_size =
       *context->patch_size_cache->GetPatchSize({'s', 't', 'u', 'v', 'w', 'x'});
   r = CandidateMerge::AssessSegmentMerge(
-      merger, 3, {0},
-      CandidateMerge::BaselineCandidate(
-          4, 0.0));
+      merger, 3, {0}, CandidateMerge::BaselineCandidate(4, 0.0));
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_FALSE(r->has_value());
 }
@@ -424,7 +416,9 @@ TEST_F(CandidateMergeTest, AssessPatchMerge) {
       all);
 
   // Try merging the patch for {0} and {1 OR 4}.
-  auto r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({1, 4}, 0), std::nullopt);
+  auto r = CandidateMerge::AssessPatchMerge(
+      merger, ActivationCondition::exclusive_segment(0, 0),
+      ActivationCondition::or_segments({1, 4}, 0), std::nullopt);
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
   CandidateMerge merge = **r;
@@ -434,7 +428,9 @@ TEST_F(CandidateMergeTest, AssessPatchMerge) {
   ASSERT_LT(merge.CostDelta(), 0);
 
   // Try merging the patch for {0} and {2 OR 3}.
-  r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({2, 3}, 0), std::nullopt);
+  r = CandidateMerge::AssessPatchMerge(
+      merger, ActivationCondition::exclusive_segment(0, 0),
+      ActivationCondition::or_segments({2, 3}, 0), std::nullopt);
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
   merge = **r;
@@ -477,18 +473,22 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_RequiresPatches) {
       all);
 
   // Try merging the patch for {0} and {1}.
-  auto r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({1}, 0), std::nullopt);
+  auto r = CandidateMerge::AssessPatchMerge(
+      merger, ActivationCondition::exclusive_segment(0, 0),
+      ActivationCondition::or_segments({1}, 0), std::nullopt);
   // segment 1 has no patch associated with it, so no merge is possible.
   ASSERT_TRUE(absl::IsInternal(r.status())) << r.status();
 
   // Try merging the patch for {0} and {0 or 1}.
-  r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), ActivationCondition::or_segments({0, 1}, 0), std::nullopt);
+  r = CandidateMerge::AssessPatchMerge(
+      merger, ActivationCondition::exclusive_segment(0, 0),
+      ActivationCondition::or_segments({0, 1}, 0), std::nullopt);
   // {0 or 1} has no patch associated with it, so no merge is possible.
   ASSERT_TRUE(absl::IsInternal(r.status())) << r.status();
 }
 
 TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
-  std::vector<Segment> segments =  {
+  std::vector<Segment> segments = {
       {{'A'}, ProbabilityBound{0.95, 0.95}},
       {{'B'}, ProbabilityBound{0.85, 0.85}},
       {{'C'}, ProbabilityBound{0.75, 0.75}},
@@ -532,16 +532,19 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
   // Update glyph groupings.
   auto sc = context->glyph_groupings.GroupGlyphs(
       context->SegmentationInfo(), context->glyph_condition_set,
-      *context->glyph_closure_cache, std::nullopt, {gid_A, gid_B}, {0, 1, 2}, false);
+      *context->glyph_closure_cache, std::nullopt, {gid_A, gid_B}, {0, 1, 2},
+      false);
   ASSERT_TRUE(sc.ok()) << sc;
 
   for (const auto& [c, g] : context->glyph_groupings.ConditionsAndGlyphs()) {
-    std::cerr << c.ToString() << " => "  << g.ToString() << std::endl;
+    std::cerr << c.ToString() << " => " << g.ToString() << std::endl;
   }
 
   context->patch_size_cache.reset(size_cache);
 
-  auto r = CandidateMerge::AssessPatchMerge(merger, ActivationCondition::exclusive_segment(0, 0), conj_cond, std::nullopt);
+  auto r = CandidateMerge::AssessPatchMerge(
+      merger, ActivationCondition::exclusive_segment(0, 0), conj_cond,
+      std::nullopt);
   ASSERT_TRUE(r.ok()) << r.status();
   ASSERT_TRUE(r->has_value());
 
@@ -549,10 +552,8 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
   // - (s0) * (size(gid_A) + 75)
   // - (s1 AND s2) * (size(gid_B) + 75)
   // + (s0 OR s1) and (s0 OR s2)) * (size(gid_A, gid_b) + 75)
-  ASSERT_EQ((*r)->CostDelta(),
-    - 0.95 * (100 + 75)
-    - (0.85 * 0.75) * (200 + 75)
-    + (0.90 * 0.92) * (250 + 75));
+  ASSERT_EQ((*r)->CostDelta(), -0.95 * (100 + 75) - (0.85 * 0.75) * (200 + 75) +
+                                   (0.90 * 0.92) * (250 + 75));
 
   CandidateMerge merge = **r;
   ASSERT_EQ(merge.SegmentsToMerge(), SegmentSet({0, 1, 2}));

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -1176,12 +1176,10 @@ TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {
 
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
-p0: { gid117, gid169, gid700 }
+p0: { gid117, gid169, gid640, gid700 }
 p1: { gid37, gid39 }
-p2: { gid640 }
 if (s2) then p0
 if ((s0 OR s1 OR s2)) then p1
-if (s0 AND s2) then p2
 )");
 }
 

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -1003,6 +1003,81 @@ if ((s1 OR s3) AND (s2 OR s3)) then p4
 )");
 }
 
+TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge_MinGroupSize) {
+  UnicodeFrequencies frequencies{
+      {{' ', ' '}, 1000},
+      {{'A', 'A'}, 1},
+      {{'C', 'C'}, 1},
+      {{0xC1, 0xC1}, 1}, /* Aacute */
+      {{0x106, 0x106}, 1}, /* Cacute */
+  };
+
+  MergeStrategy strategy =
+      *MergeStrategy::CostBased(std::move(frequencies), 75, 2);
+  strategy.SetOptimizationCutoffFraction(0.0);
+  strategy.SetUsePatchMerges(true);
+
+  auto segmentation =
+        segmenter_dep_graph_only.CodepointToGlyphSegments(
+            roboto.get(), {}, {
+                {'A'},
+                {'C'},
+                {0xC1}, /* Aacute */
+                {0x106}, /* Cacute */
+            },
+            strategy);
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  std::vector<SubsetDefinition> expected_segments = {
+      {'A'},
+      {'C'},
+      {0xC1},
+      {0x106},
+  };
+  ASSERT_EQ(segmentation->Segments(), expected_segments);
+
+  // When min group size is 2, there's no merging done since merges are unfavourable
+  // and the minimum is met.
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid37 }
+p1: { gid39 }
+p2: { gid117, gid169 }
+p3: { gid640 }
+p4: { gid700 }
+if ((s0 OR s2)) then p0
+if ((s1 OR s3)) then p1
+if ((s2 OR s3)) then p2
+if ((s0 OR s2) AND (s2 OR s3)) then p3
+if ((s1 OR s3) AND (s2 OR s3)) then p4
+)");
+
+  // Now with min group size larger merges will be done to reach min group size
+  strategy.SetMinimumGroupSize(3);
+  segmentation =
+        segmenter_dep_graph_only.CodepointToGlyphSegments(
+            roboto.get(), {}, {
+                {'A'},
+                {'C'},
+                {0xC1}, /* Aacute */
+                {0x106}, /* Cacute */
+            },
+            strategy);
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+  ASSERT_EQ(segmentation->Segments(), expected_segments);
+  // Group size minimum is met for everything other than the last condition
+  // which has no other candidates to merge with.
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid37, gid117, gid169 }
+p1: { gid39, gid640 }
+p2: { gid700 }
+if ((s0 OR s2 OR s3)) then p0
+if ((s1 OR s2 OR s3)) then p1
+if ((s1 OR s3) AND (s2 OR s3)) then p2
+)");
+}
+
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoCostCutoff) {
   UnicodeFrequencies frequencies{
       {{' ', ' '}, 100},

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -947,6 +947,7 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge) {
   };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
+#ifdef HB_DEPEND_API
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
 p0: { gid117, gid169, gid640, gid700 }
@@ -954,6 +955,15 @@ p1: { gid37, gid39 }
 if ((s2 OR s3)) then p0
 if ((s0 OR s1 OR s2 OR s3)) then p1
 )");
+#else
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid117, gid169 }
+p1: { gid37, gid39, gid640, gid700 }
+if ((s2 OR s3)) then p0
+if ((s0 OR s1 OR s2 OR s3)) then p1
+)");
+#endif
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoPatchMerge) {
@@ -988,6 +998,7 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoPatchMerge) {
   };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
+#ifdef HB_DEPEND_API
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
 p0: { gid37 }
@@ -1001,6 +1012,19 @@ if ((s2 OR s3)) then p2
 if ((s0 OR s2) AND (s2 OR s3)) then p3
 if ((s1 OR s3) AND (s2 OR s3)) then p4
 )");
+#else
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid37 }
+p1: { gid39 }
+p2: { gid117, gid169 }
+p3: { gid640, gid700 }
+if ((s0 OR s2)) then p0
+if ((s1 OR s3)) then p1
+if ((s2 OR s3)) then p2
+if ((s0 OR s1 OR s2 OR s3)) then p3
+)");
+#endif
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge_MinGroupSize) {
@@ -1036,6 +1060,7 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge_MinGroupSize) {
 
   // When min group size is 2, there's no merging done since merges are
   // unfavourable and the minimum is met.
+#ifdef HB_DEPEND_API
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
 p0: { gid37 }
@@ -1049,6 +1074,19 @@ if ((s2 OR s3)) then p2
 if ((s0 OR s2) AND (s2 OR s3)) then p3
 if ((s1 OR s3) AND (s2 OR s3)) then p4
 )");
+#else
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid37 }
+p1: { gid39 }
+p2: { gid117, gid169 }
+p3: { gid640, gid700 }
+if ((s0 OR s2)) then p0
+if ((s1 OR s3)) then p1
+if ((s2 OR s3)) then p2
+if ((s0 OR s1 OR s2 OR s3)) then p3
+)");
+#endif
 
   // Now with min group size larger merges will be done to reach min group size
   strategy.SetMinimumGroupSize(3);
@@ -1065,6 +1103,7 @@ if ((s1 OR s3) AND (s2 OR s3)) then p4
   ASSERT_EQ(segmentation->Segments(), expected_segments);
   // Group size minimum is met for everything other than the last condition
   // which has no other candidates to merge with.
+#ifdef HB_DEPEND_API
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
 p0: { gid37, gid117, gid169 }
@@ -1074,6 +1113,17 @@ if ((s0 OR s2 OR s3)) then p0
 if ((s1 OR s2 OR s3)) then p1
 if ((s1 OR s3) AND (s2 OR s3)) then p2
 )");
+#else
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid39 }
+p1: { gid37, gid117, gid169 }
+p2: { gid640, gid700 }
+if ((s1 OR s3)) then p0
+if ((s0 OR s2 OR s3)) then p1
+if ((s0 OR s1 OR s2 OR s3)) then p2
+)");
+#endif
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoCostCutoff) {

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -13,9 +13,9 @@
 #include "ift/encoder/glyph_segmentation.h"
 #include "ift/encoder/merge_strategy.h"
 #include "ift/encoder/subset_definition.h"
+#include "ift/freq/mock_probability_calculator.h"
 #include "ift/freq/unicode_frequencies.h"
 #include "ift/freq/unigram_probability_calculator.h"
-#include "ift/freq/mock_probability_calculator.h"
 
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
 using ift::config::CLOSURE_ONLY;
@@ -35,10 +35,10 @@ using ift::common::hb_face_unique_ptr;
 using ift::common::IntSet;
 using ift::common::make_hb_face;
 using ift::common::SegmentSet;
+using ift::freq::MockProbabilityCalculator;
 using ift::freq::ProbabilityBound;
 using ift::freq::UnicodeFrequencies;
 using ift::freq::UnigramProbabilityCalculator;
-using ift::freq::MockProbabilityCalculator;
 
 namespace ift::encoder {
 
@@ -919,7 +919,7 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge) {
   UnicodeFrequencies frequencies{
       {{'A', 'A'}, 1000},
       {{'C', 'C'}, 1000},
-      {{0xC1, 0xC1}, 1}, /* Aacute */
+      {{0xC1, 0xC1}, 1},   /* Aacute */
       {{0x106, 0x106}, 1}, /* Cacute */
   };
 
@@ -928,15 +928,15 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge) {
   strategy.SetOptimizationCutoffFraction(0.0);
   strategy.SetUsePatchMerges(true);
 
-  auto segmentation =
-        segmenter_dep_graph_only.CodepointToGlyphSegments(
-            roboto.get(), {}, {
-                {'A'},
-                {'C'},
-                {0xC1}, /* Aacute */
-                {0x106}, /* Cacute */
-            },
-            strategy);
+  auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
+      roboto.get(), {},
+      {
+          {'A'},
+          {'C'},
+          {0xC1},  /* Aacute */
+          {0x106}, /* Cacute */
+      },
+      strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
   std::vector<SubsetDefinition> expected_segments = {
@@ -957,10 +957,10 @@ if ((s0 OR s1 OR s2 OR s3)) then p1
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoPatchMerge) {
-    UnicodeFrequencies frequencies{
+  UnicodeFrequencies frequencies{
       {{'A', 'A'}, 1000},
       {{'C', 'C'}, 1000},
-      {{0xC1, 0xC1}, 1}, /* Aacute */
+      {{0xC1, 0xC1}, 1},   /* Aacute */
       {{0x106, 0x106}, 1}, /* Cacute */
   };
 
@@ -969,15 +969,15 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoPatchMerge) {
   strategy.SetOptimizationCutoffFraction(0.0);
   strategy.SetUsePatchMerges(false);
 
-  auto segmentation =
-        segmenter_dep_graph_only.CodepointToGlyphSegments(
-            roboto.get(), {}, {
-                {'A'},
-                {'C'},
-                {0xC1}, /* Aacute */
-                {0x106}, /* Cacute */
-            },
-            strategy);
+  auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
+      roboto.get(), {},
+      {
+          {'A'},
+          {'C'},
+          {0xC1},  /* Aacute */
+          {0x106}, /* Cacute */
+      },
+      strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
   std::vector<SubsetDefinition> expected_segments = {
@@ -1005,11 +1005,9 @@ if ((s1 OR s3) AND (s2 OR s3)) then p4
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge_MinGroupSize) {
   UnicodeFrequencies frequencies{
-      {{' ', ' '}, 1000},
-      {{'A', 'A'}, 1},
-      {{'C', 'C'}, 1},
-      {{0xC1, 0xC1}, 1}, /* Aacute */
-      {{0x106, 0x106}, 1}, /* Cacute */
+      {{' ', ' '}, 1000},  {{'A', 'A'}, 1},
+      {{'C', 'C'}, 1},     {{0xC1, 0xC1}, 1}, /* Aacute */
+      {{0x106, 0x106}, 1},                    /* Cacute */
   };
 
   MergeStrategy strategy =
@@ -1017,15 +1015,15 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge_MinGroupSize) {
   strategy.SetOptimizationCutoffFraction(0.0);
   strategy.SetUsePatchMerges(true);
 
-  auto segmentation =
-        segmenter_dep_graph_only.CodepointToGlyphSegments(
-            roboto.get(), {}, {
-                {'A'},
-                {'C'},
-                {0xC1}, /* Aacute */
-                {0x106}, /* Cacute */
-            },
-            strategy);
+  auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
+      roboto.get(), {},
+      {
+          {'A'},
+          {'C'},
+          {0xC1},  /* Aacute */
+          {0x106}, /* Cacute */
+      },
+      strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
   std::vector<SubsetDefinition> expected_segments = {
@@ -1036,8 +1034,8 @@ TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge_MinGroupSize) {
   };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
-  // When min group size is 2, there's no merging done since merges are unfavourable
-  // and the minimum is met.
+  // When min group size is 2, there's no merging done since merges are
+  // unfavourable and the minimum is met.
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
 p0: { gid37 }
@@ -1054,15 +1052,15 @@ if ((s1 OR s3) AND (s2 OR s3)) then p4
 
   // Now with min group size larger merges will be done to reach min group size
   strategy.SetMinimumGroupSize(3);
-  segmentation =
-        segmenter_dep_graph_only.CodepointToGlyphSegments(
-            roboto.get(), {}, {
-                {'A'},
-                {'C'},
-                {0xC1}, /* Aacute */
-                {0x106}, /* Cacute */
-            },
-            strategy);
+  segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
+      roboto.get(), {},
+      {
+          {'A'},
+          {'C'},
+          {0xC1},  /* Aacute */
+          {0x106}, /* Cacute */
+      },
+      strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
   ASSERT_EQ(segmentation->Segments(), expected_segments);
   // Group size minimum is met for everything other than the last condition

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -15,6 +15,7 @@
 #include "ift/encoder/subset_definition.h"
 #include "ift/freq/unicode_frequencies.h"
 #include "ift/freq/unigram_probability_calculator.h"
+#include "ift/freq/mock_probability_calculator.h"
 
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
 using ift::config::CLOSURE_ONLY;
@@ -34,8 +35,10 @@ using ift::common::hb_face_unique_ptr;
 using ift::common::IntSet;
 using ift::common::make_hb_face;
 using ift::common::SegmentSet;
+using ift::freq::ProbabilityBound;
 using ift::freq::UnicodeFrequencies;
 using ift::freq::UnigramProbabilityCalculator;
+using ift::freq::MockProbabilityCalculator;
 
 namespace ift::encoder {
 
@@ -914,58 +917,89 @@ TEST_F(ClosureGlyphSegmenterTest, NonDisjointCodepoints) {
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_PatchMerge) {
   UnicodeFrequencies frequencies{
-      {{' ', ' '}, 1000},
-      {{'a', 'a'}, 1000},
-      {{'!', '!'}, 999},
-      {{0x203C, 0x203C}, 1}  // !!
+      {{'A', 'A'}, 1000},
+      {{'C', 'C'}, 1000},
+      {{0xC1, 0xC1}, 1}, /* Aacute */
+      {{0x106, 0x106}, 1}, /* Cacute */
   };
 
   MergeStrategy strategy =
       *MergeStrategy::CostBased(std::move(frequencies), 75, 1);
+  strategy.SetOptimizationCutoffFraction(0.0);
   strategy.SetUsePatchMerges(true);
 
-  auto segmentation = CodepointToGlyphSegments(
-      roboto.get(), {}, {{'a'}, {'!'}, {0x203C}}, strategy);
+  auto segmentation =
+        segmenter_dep_graph_only.CodepointToGlyphSegments(
+            roboto.get(), {}, {
+                {'A'},
+                {'C'},
+                {0xC1}, /* Aacute */
+                {0x106}, /* Cacute */
+            },
+            strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  std::vector<SubsetDefinition> expected_segments = {{'a'}, {'!'}, {0x203C}};
+  std::vector<SubsetDefinition> expected_segments = {
+      {'A'},
+      {'C'},
+      {0xC1},
+      {0x106},
+  };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
-p0: { gid989 }
-p1: { gid5, gid69 }
-if (s2) then p0
-if ((s0 OR s1 OR s2)) then p1
+p0: { gid117, gid169, gid640, gid700 }
+p1: { gid37, gid39 }
+if ((s2 OR s3)) then p0
+if ((s0 OR s1 OR s2 OR s3)) then p1
 )");
 }
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoPatchMerge) {
-  UnicodeFrequencies frequencies{
-      {{' ', ' '}, 1000},
-      {{'a', 'a'}, 1000},
-      {{'!', '!'}, 999},
-      {{0x203C, 0x203C}, 1}  // !!
+    UnicodeFrequencies frequencies{
+      {{'A', 'A'}, 1000},
+      {{'C', 'C'}, 1000},
+      {{0xC1, 0xC1}, 1}, /* Aacute */
+      {{0x106, 0x106}, 1}, /* Cacute */
   };
 
   MergeStrategy strategy =
       *MergeStrategy::CostBased(std::move(frequencies), 75, 1);
+  strategy.SetOptimizationCutoffFraction(0.0);
   strategy.SetUsePatchMerges(false);
 
-  auto segmentation = CodepointToGlyphSegments(
-      roboto.get(), {}, {{'a'}, {'!'}, {0x203C}}, strategy);
+  auto segmentation =
+        segmenter_dep_graph_only.CodepointToGlyphSegments(
+            roboto.get(), {}, {
+                {'A'},
+                {'C'},
+                {0xC1}, /* Aacute */
+                {0x106}, /* Cacute */
+            },
+            strategy);
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
-  // Because the condition for ! OR !! has high probability it get's merged with
-  // a
   std::vector<SubsetDefinition> expected_segments = {
-      {'a', '!', 0x203c}, {}, {}};
+      {'A'},
+      {'C'},
+      {0xC1},
+      {0x106},
+  };
   ASSERT_EQ(segmentation->Segments(), expected_segments);
 
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
-p0: { gid5, gid69, gid989 }
-if (s0) then p0
+p0: { gid37 }
+p1: { gid39 }
+p2: { gid117, gid169 }
+p3: { gid640 }
+p4: { gid700 }
+if ((s0 OR s2)) then p0
+if ((s1 OR s3)) then p1
+if ((s2 OR s3)) then p2
+if ((s0 OR s2) AND (s2 OR s3)) then p3
+if ((s1 OR s3) AND (s2 OR s3)) then p4
 )");
 }
 
@@ -1152,7 +1186,7 @@ TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {
   MergeStrategy strategy =
       *MergeStrategy::CostBased(std::move(frequencies), 75, 1);
   strategy.SetOptimizationCutoffFraction(0.0);
-  strategy.SetUsePatchMerges(true);
+  strategy.SetUsePatchMerges(false);
 
   auto segmentation = CodepointToGlyphSegments(roboto.get(), {},
                                                {
@@ -1176,10 +1210,14 @@ TEST_F(ClosureGlyphSegmenterTest, NoGlyphSegments_CostMerging) {
 
   ASSERT_EQ(segmentation->ToString(),
             R"(initial font: { gid0 }
-p0: { gid117, gid169, gid640, gid700 }
-p1: { gid37, gid39 }
-if (s2) then p0
-if ((s0 OR s1 OR s2)) then p1
+p0: { gid37 }
+p1: { gid117, gid169, gid700 }
+p2: { gid39 }
+p3: { gid640 }
+if (s0) then p0
+if (s2) then p1
+if ((s1 OR s2)) then p2
+if (s0 AND s2) then p3
 )");
 }
 

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -72,11 +72,10 @@ void GlyphGroupings::InvalidateGlyphInformation(uint32_t gid) {
 
 void GlyphGroupings::RemoveAllCombinedConditions() {
   combined_patches_dirty_ = true;
-  for (const auto& [segments, _] : combined_or_glyph_groups_) {
-    RemoveConditionAndGlyphs(ActivationCondition::or_segments(segments, 0),
-                             false);
+  for (const auto& condition : combined_conditions_) {
+    RemoveConditionAndGlyphs(condition, false);
   }
-  combined_or_glyph_groups_.clear();
+  combined_conditions_.clear();
   combined_exclusive_segments_.clear();
 }
 
@@ -388,131 +387,72 @@ Status GlyphGroupings::FindFallbackGlyphConditions(
 }
 
 Status GlyphGroupings::RecomputeCombinedConditions() {
-  // TODO XXXXX now that we can arbitrarily combine activation conditions,
-  // we should be able to support patch merging on arbitrary conditions
-  // including conjunctive and/or mixed ones. Rework this to not be limited just
-  // to exclusive and purely disjunctive cases.
-  //
-  // Will also need to update the merger/candidate_merge code that selects patch
-  // merges to consider all cases.
-
-  // To minimize the amount of work we need to do we first detect which segments
-  // are potentially affected by the patch combination mechanism and then limit
-  // processing just to those.
-  SegmentSet exclusive_segments;
-  btree_set<SegmentSet> or_conditions;
-  TRYV(ConditionsAffectedByCombination(exclusive_segments, or_conditions));
-
-  flat_hash_map<glyph_id_t, SegmentSet> merged_conditions;
-  flat_hash_map<glyph_id_t, GlyphSet> merged_glyphs;
-  TRYV(ComputeConditionExpansionMap(exclusive_segments, or_conditions,
-                                    merged_conditions, merged_glyphs));
-
-  for (const auto& [rep, segments] : merged_conditions) {
-    const GlyphSet& gids = merged_glyphs.at(rep);
-    ActivationCondition condition =
-        ActivationCondition::or_segments(segments, 0);
-    if (segments.size() == 1 && exclusive_segments.contains(*segments.min())) {
-      // This is actually an exclusive condition, and is not expanded.
-      condition = ActivationCondition::exclusive_segment(*segments.min(), 0);
-    } else {
-      SegmentSet segments_copy = segments;
-      combined_or_glyph_groups_[segments_copy] = gids;
-    }
-
-    TRYV(AddConditionAndGlyphs(condition, gids, false));
-  }
-
-  combined_patches_dirty_ = false;
-  return absl::OkStatus();
-}
-
-Status GlyphGroupings::ConditionsAffectedByCombination(
-    SegmentSet& exclusive_segments,
-    btree_set<SegmentSet>& or_conditions) const {
+  // Find all conditions that are affected by combined_patches_.
+  btree_set<ActivationCondition> affected_conditions;
   for (const GlyphSet& gids : TRY(combined_patches_.NonIdentityGroups())) {
     for (glyph_id_t gid : gids) {
-      const auto& cond =
-          conditions_and_glyphs_pre_combination_.GlyphToCondition().at(gid);
-      if (cond.IsExclusive()) {
-        exclusive_segments.insert(*cond.TriggeringSegments().begin());
-      } else if (cond.conditions().size() == 1) {
-        or_conditions.insert(cond.TriggeringSegments());
+      auto it = conditions_and_glyphs_pre_combination_.GlyphToCondition().find(gid);
+      if (it != conditions_and_glyphs_pre_combination_.GlyphToCondition().end()) {
+        affected_conditions.insert(it->second);
       }
     }
   }
-  return absl::OkStatus();
-}
 
-Status GlyphGroupings::ComputeConditionExpansionMap(
-    const SegmentSet& exclusive_segments,
-    const btree_set<SegmentSet>& or_conditions,
-    flat_hash_map<glyph_id_t, SegmentSet>& merged_conditions,
-    flat_hash_map<glyph_id_t, GlyphSet>& merged_glyphs) {
+  if (affected_conditions.empty()) {
+    combined_patches_dirty_ = false;
+    return absl::OkStatus();
+  }
+
   // Form the complete partition incorporating combined_patches_ across all of
   // the affected groups. This complete partition specifies how groups will be
   // merged together.
   GlyphPartition partition = combined_patches_;
-  for (segment_index_t s : exclusive_segments) {
-    TRYV(partition.Union(exclusive_glyph_groups_.at(s)));
+  for (const auto& cond : affected_conditions) {
+    const GlyphSet& gids =
+        conditions_and_glyphs_pre_combination_.ConditionsAndGlyphs().at(cond);
+    TRYV(partition.Union(gids));
   }
 
-  for (const auto& segments : or_conditions) {
-    TRYV(partition.Union(or_glyph_groups_.at(segments)));
-  }
+  // Map representative to combined condition and glyphs.
+  flat_hash_map<glyph_id_t, ActivationCondition> merged_conditions;
+  flat_hash_map<glyph_id_t, GlyphSet> merged_glyphs;
 
-  // Each group can be mapped to a representative, where there is one
-  // representative for each combined grouping. We can then collect up all of
-  // the combined segments and and glyphs to each representative.
-  //
-  // During this processing we remove/add conditions as need. Where a existing
-  // group will be combined, the uncombined condition is removed. Where a
-  // condition is not going to be combined then the condition is added back.
-  // Adding back is needed in rare cases where a condition was previously
-  // combined, but due to changes it no longer is. If the condition is already
-  // present then addition is a noop.
-  for (segment_index_t s : exclusive_segments) {
-    const GlyphSet& gids = exclusive_glyph_groups_.at(s);
+  for (const auto& cond : affected_conditions) {
+    const GlyphSet& gids =
+        conditions_and_glyphs_pre_combination_.ConditionsAndGlyphs().at(cond);
     std::optional<glyph_id_t> first = gids.min();
     if (!first.has_value()) {
       continue;
     }
 
     glyph_id_t rep = TRY(partition.Find(*first));
+
     if (gids != TRY(partition.GlyphsFor(rep))) {
-      // Only record cases where merges happen, if the glyph set is unmodifed
-      // then there will be no merge.
-      merged_conditions[rep].insert(s);
+      // Only record cases where merges happen.
+      RemoveConditionAndGlyphs(cond, false);
+
+      if (cond.IsExclusive()) {
+        combined_exclusive_segments_.insert(*cond.TriggeringSegments().begin());
+      }
+
+      auto [it, inserted] = merged_conditions.insert({rep, cond});
+      if (!inserted) {
+        it->second = ActivationCondition::Or(it->second, cond);
+      }
       merged_glyphs[rep].union_set(gids);
-      RemoveConditionAndGlyphs(ActivationCondition::exclusive_segment(s, 0),
-                               false);
-      // Record s as having been removed via combination.
-      combined_exclusive_segments_.insert(s);
     } else {
-      TRYV(AddConditionAndGlyphs(ActivationCondition::exclusive_segment(s, 0),
-                                 gids, false));
+      TRYV(AddConditionAndGlyphs(cond, gids, false));
     }
   }
 
-  for (const auto& segments : or_conditions) {
-    const GlyphSet& gids = or_glyph_groups_.at(segments);
-    std::optional<glyph_id_t> first = gids.min();
-    if (!first.has_value()) {
-      continue;
-    }
-
-    glyph_id_t rep = TRY(partition.Find(*first));
-    if (gids != TRY(partition.GlyphsFor(rep))) {
-      merged_conditions[rep].union_set(segments);
-      merged_glyphs[rep].union_set(gids);
-      RemoveConditionAndGlyphs(ActivationCondition::or_segments(segments, 0),
-                               false);
-    } else {
-      TRYV(AddConditionAndGlyphs(ActivationCondition::or_segments(segments, 0),
-                                 gids, false));
-    }
+  // Add the new combined conditions.
+  for (const auto& [rep, condition] : merged_conditions) {
+    const GlyphSet& gids = merged_glyphs.at(rep);
+    TRYV(AddConditionAndGlyphs(condition, gids, false));
+    combined_conditions_.insert(condition);
   }
 
+  combined_patches_dirty_ = false;
   return absl::OkStatus();
 }
 

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -391,8 +391,10 @@ Status GlyphGroupings::RecomputeCombinedConditions() {
   btree_set<ActivationCondition> affected_conditions;
   for (const GlyphSet& gids : TRY(combined_patches_.NonIdentityGroups())) {
     for (glyph_id_t gid : gids) {
-      auto it = conditions_and_glyphs_pre_combination_.GlyphToCondition().find(gid);
-      if (it != conditions_and_glyphs_pre_combination_.GlyphToCondition().end()) {
+      auto it =
+          conditions_and_glyphs_pre_combination_.GlyphToCondition().find(gid);
+      if (it !=
+          conditions_and_glyphs_pre_combination_.GlyphToCondition().end()) {
         affected_conditions.insert(it->second);
       }
     }

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -5,6 +5,7 @@
 
 #include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_set.h"
 #include "ift/common/int_set.h"
 #include "ift/encoder/activation_condition.h"
 #include "ift/encoder/condition_to_glyphs_index.h"
@@ -28,7 +29,7 @@ class GlyphGroupings {
   bool operator==(const GlyphGroupings& other) {
     return or_glyph_groups_ == other.or_glyph_groups_ &&
            exclusive_glyph_groups_ == other.exclusive_glyph_groups_ &&
-           combined_or_glyph_groups_ == other.combined_or_glyph_groups_ &&
+           combined_conditions_ == other.combined_conditions_ &&
            conditions_and_glyphs_ == other.conditions_and_glyphs_ &&
            conditions_and_glyphs_pre_combination_ ==
                other.conditions_and_glyphs_pre_combination_ &&
@@ -260,11 +261,10 @@ class GlyphGroupings {
   absl::flat_hash_map<segment_index_t, ift::common::GlyphSet>
       exclusive_glyph_groups_;
 
-  // This is a set of disjunctive conditions which have been combined by the
+  // This is a set of conditions which have been combined by the
   // CombinePatches() mechanism. Does not store groupings which have not been
-  // modified the the mechanism.
-  absl::flat_hash_map<ift::common::SegmentSet, ift::common::GlyphSet>
-      combined_or_glyph_groups_;
+  // modified by the mechanism.
+  absl::flat_hash_set<ActivationCondition> combined_conditions_;
 
   // This is a set of segments which are normally exclusive but have been
   // combined via the patch combination mechanism and are no longer present.

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -448,7 +448,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_Noop) {
   ASSERT_EQ(expected, glyph_groupings_.ConditionsAndGlyphs());
 }
 
-TEST_F(GlyphGroupingsTest, CombinePatches_DoesntAffectConjunction) {
+TEST_F(GlyphGroupingsTest, CombinePatches_AffectsConjunction) {
   auto sc = glyph_groupings_.CombinePatches(ToGlyphs({'d'}), ToGlyphs({'e'}));
   ASSERT_TRUE(sc.ok()) << sc;
 
@@ -457,20 +457,21 @@ TEST_F(GlyphGroupingsTest, CombinePatches_DoesntAffectConjunction) {
                                     std::nullopt, glyphs_to_group_, {});
   ASSERT_TRUE(sc.ok()) << sc;
 
-  // Condition map:
-  // s0 -> {a, b}
-  // s1 -> {c, d}
-  // s3 -> {k}
-  // s2 AND s3 -> {e, f}
-  // s2 OR s3 -> {j}
-  // s3 OR s4 -> {g, h}
+  // Condition map after merging 'd' and 'e':
+  // 'd' is in s1.
+  // 'e' is in s2 AND s3.
+  // Resulting condition: (s1 OR s2) AND (s1 OR s3).
+  // Glyphs: {c, d} U {e, f} = {c, d, e, f}.
+  
+  ActivationCondition merged_cond = ActivationCondition::composite_condition(
+      {SegmentSet({1, 2}), SegmentSet({1, 3})}, 0);
+
   flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(0, 0), ToGlyphs({'a', 'b'})},
-      {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k', 'k'})},
-      {ActivationCondition::and_segments({2, 3}, 0), ToGlyphs({'e', 'f'})},
       {ActivationCondition::or_segments({2, 3}, 0), ToGlyphs({'j'})},
       {ActivationCondition::or_segments({3, 4}, 0), ToGlyphs({'g', 'h'})},
+      {merged_cond, ToGlyphs({'c', 'd', 'e', 'f'})},
   };
 
   ASSERT_EQ(expected, glyph_groupings_.ConditionsAndGlyphs());

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -462,7 +462,7 @@ TEST_F(GlyphGroupingsTest, CombinePatches_AffectsConjunction) {
   // 'e' is in s2 AND s3.
   // Resulting condition: (s1 OR s2) AND (s1 OR s3).
   // Glyphs: {c, d} U {e, f} = {c, d, e, f}.
-  
+
   ActivationCondition merged_cond = ActivationCondition::composite_condition(
       {SegmentSet({1, 2}), SegmentSet({1, 3})}, 0);
 

--- a/ift/encoder/merge_strategy.h
+++ b/ift/encoder/merge_strategy.h
@@ -137,6 +137,10 @@ class MergeStrategy {
     return probability_calculator_.get();
   }
 
+  void SetMinimumGroupSize(uint32_t value) {
+    min_group_size_ = value;
+  }
+
   // Configures the threshold for when to stop optimizing segments.
   //
   // For the set of segments which account for less than this fraction of the

--- a/ift/encoder/merge_strategy.h
+++ b/ift/encoder/merge_strategy.h
@@ -137,9 +137,7 @@ class MergeStrategy {
     return probability_calculator_.get();
   }
 
-  void SetMinimumGroupSize(uint32_t value) {
-    min_group_size_ = value;
-  }
+  void SetMinimumGroupSize(uint32_t value) { min_group_size_ = value; }
 
   // Configures the threshold for when to stop optimizing segments.
   //

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -86,7 +86,12 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryNextPatchMerge() {
                                   *strategy_.ProbabilityCalculator())));
   }
   std::sort(ordered_candidates.begin(), ordered_candidates.end(),
-            [](const auto& a, const auto& b) { return a.second > b.second; });
+            [](const auto& a, const auto& b) {
+              if (a.second != b.second) {
+                return a.second > b.second;
+              }
+              return a.first < b.first;
+            });
 
   while (!ordered_candidates.empty()) {
     ActivationCondition base = ordered_candidates.begin()->first;
@@ -658,6 +663,9 @@ GlyphSet Merger::ComputeCandidatePatchMergeGlyphs(
 
     SegmentSet triggering_segments = condition.TriggeringSegments();
 
+    // TODO XXXX optimization cutoff should filter the "B" patch (once min group size is met), all
+    // inscope patches need to be considered as the "A" patch for minimum group
+    // size merging.
     std::optional<unsigned> min = triggering_segments.min();
     if (min.has_value() && min >= optimization_cutoff_segment) {
       // Don't consider merges where all triggering segment are cutoff

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -454,10 +454,11 @@ StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(const Activ
     return absl::InternalError("Patch merging is disabled.");
   }
 
-  // TODO XXXXX only use 0 baseline once min group size is met.
-  //            non-negative merges are only allowed when group size would increase as a result of the
-  //            merge.
-  std::optional<CandidateMerge> smallest_candidate_merge = CandidateMerge::BaselineCandidate(0, 0.0);
+  std::optional<CandidateMerge> smallest_candidate_merge = std::nullopt;
+  if (base.EffectiveGroupSize() >= strategy_.MinimumGroupSize()) {
+    // If minimum group size is met then we can filter non-negative candidates.
+    smallest_candidate_merge = CandidateMerge::BaselineCandidate(0, 0.0);
+  }
 
   for (const auto& [next, probability] : ordered_candidates) {
     if (next == base) {
@@ -470,7 +471,7 @@ StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(const Activ
     }
   }
 
-  if (smallest_candidate_merge->SegmentsToMerge() == SegmentSet {0}) {
+  if (!smallest_candidate_merge.has_value() || smallest_candidate_merge->SegmentsToMerge() == SegmentSet {0}) {
     // baseline was not beat, so don't apply.
     return std::nullopt;
   }

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -62,6 +62,47 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryNextMerge() {
     strategy_.ProbabilityCalculator()->ResetCache();
   }
 
+  // No more base merges remain, so we can start trying patch to patch merging
+  // of non-exclusive patches.
+  return TryNextPatchMerge();
+}
+
+StatusOr<std::optional<InvalidationSet>> Merger::TryNextPatchMerge() {
+
+  if (!strategy_.UsePatchMerges()) {
+    return std::nullopt;
+  }
+
+  // Work through the candidate composite conditions in order of descending probability.
+  std::vector<std::pair<ActivationCondition, double>> ordered_candidates;
+  for (const auto& [condition, glyphs] : Context().glyph_groupings.ConditionsAndGlyphs()) {
+    if (!glyphs.intersects(candidate_patch_merge_glyphs_)) {
+      continue;
+    }
+    ordered_candidates.emplace_back(condition, TRY(condition.Probability(Context().SegmentationInfo().Segments(), *strategy_.ProbabilityCalculator())));
+  }
+  std::sort(ordered_candidates.begin(), ordered_candidates.end(), [](const auto& a, const auto& b) {
+    return a.second > b.second;
+  });
+
+  while (true) {
+    if (ordered_candidates.empty()) {
+      break;
+    }
+
+    ActivationCondition base = ordered_candidates.begin()->first;
+    GlyphSet base_glyphs = Context().glyph_groupings.ConditionsAndGlyphs().at(base);
+
+    auto invalidation = TRY(PatchMergeWithCosts(base, ordered_candidates));
+    if (!invalidation.has_value()) {
+      // No merges left for this base, remove it from the candidate list.
+      ordered_candidates.erase(ordered_candidates.begin());
+      candidate_patch_merge_glyphs_.subtract(base_glyphs);
+    } else {
+      return invalidation;
+    }
+  }
+
   return std::nullopt;
 }
 
@@ -408,6 +449,32 @@ StatusOr<std::optional<InvalidationSet>> Merger::MergeSegmentWithCosts(
   return smallest_candidate_merge->Apply(*this);
 }
 
+StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(const ActivationCondition& base, const std::vector<std::pair<ActivationCondition, double>>& ordered_candidates) {
+  if (!strategy_.UsePatchMerges()) {
+    return absl::InternalError("Patch merging is disabled.");
+  }
+
+  std::optional<CandidateMerge> smallest_candidate_merge = CandidateMerge::BaselineCandidate(0, 0.0);
+
+  for (const auto& [next, probability] : ordered_candidates) {
+    if (next == base) {
+      continue;
+    }
+
+    auto candidate = TRY(CandidateMerge::AssessPatchMerge(*this, base, next, smallest_candidate_merge));
+    if (candidate.has_value()) {
+      smallest_candidate_merge = *candidate;
+    }
+  }
+
+  if (smallest_candidate_merge->SegmentsToMerge() == SegmentSet {0}) {
+    // baseline was not beat, so don't apply.
+    return std::nullopt;
+  }
+
+  return smallest_candidate_merge->Apply(*this);
+}
+
 double Merger::BestCaseInertProbabilityThreshold(
     uint32_t base_patch_size, double base_probability,
     double lowest_cost_delta) const {
@@ -559,20 +626,49 @@ Status Merger::CollectCompositeCandidateMerges(
     if (candidate_merge.has_value()) {
       smallest_candidate_merge = *candidate_merge;
     }
-
-    if (strategy_.UsePatchMerges()) {
-      // Also consider merging just the patches together (if enabled).
-      auto candidate_merge = TRY(CandidateMerge::AssessPatchMerge(
-          *this, ActivationCondition::exclusive_segment(base_segment_index, 0), next_condition,
-          smallest_candidate_merge));
-      if (candidate_merge.has_value() && candidate_merge->CostDelta() < 0) {
-        // For patch merges we only ever use them if they have negative cost delta.
-        // This prevents using patch merges soley to meet minimum group sizes.
-        smallest_candidate_merge = *candidate_merge;
-      }
-    }
   }
   return absl::OkStatus();
+}
+
+GlyphSet Merger::ComputeCandidatePatchMergeGlyphs(
+      SegmentationContext& context, const MergeStrategy& strategy,
+      const SegmentSet& candidate_segments,
+      const SegmentSet& inscope_segments,
+      segment_index_t optimization_cutoff_segment) {
+
+  GlyphSet out;
+
+  ActivationCondition last_exclusive =
+    ActivationCondition::exclusive_segment(UINT32_MAX, 0);
+  for (auto it = context.glyph_groupings.OrderedConditions().lower_bound(
+           last_exclusive);
+       it != context.glyph_groupings.OrderedConditions().end(); it++) {
+    const auto& condition = *it;
+
+    if (condition.IsFallback() || condition.IsExclusive()) {
+      continue;
+    }
+
+    SegmentSet triggering_segments = condition.TriggeringSegments();
+
+    std::optional<unsigned> min = triggering_segments.min();
+    if (min.has_value() && min >= optimization_cutoff_segment) {
+      // Don't consider merges where all triggering segment are cutoff
+      // the probability of these is too low to significantly impact overall
+      // cost
+      continue;
+    }
+
+    if (!triggering_segments.intersects(candidate_segments) ||
+        !triggering_segments.is_subset_of(inscope_segments)) {
+      // all triggering segments must be inscope otherwise this merge crosses
+      // merge group boundaries.
+      continue;
+    }
+
+    out.union_set(context.glyph_groupings.ConditionsAndGlyphs().at(condition));
+  }
+  return out;
 }
 
 StatusOr<std::optional<InvalidationSet>> Merger::MergeSegmentWithHeuristic(

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -69,7 +69,7 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryNextMerge() {
 
 StatusOr<std::optional<InvalidationSet>> Merger::TryNextPatchMerge() {
 
-  if (!strategy_.UsePatchMerges()) {
+  if (!strategy_.UsePatchMerges() || !strategy_.UseCosts()) {
     return std::nullopt;
   }
 
@@ -454,6 +454,9 @@ StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(const Activ
     return absl::InternalError("Patch merging is disabled.");
   }
 
+  // TODO XXXXX only use 0 baseline once min group size is met.
+  //            non-negative merges are only allowed when group size would increase as a result of the
+  //            merge.
   std::optional<CandidateMerge> smallest_candidate_merge = CandidateMerge::BaselineCandidate(0, 0.0);
 
   for (const auto& [next, probability] : ordered_candidates) {

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -68,30 +68,30 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryNextMerge() {
 }
 
 StatusOr<std::optional<InvalidationSet>> Merger::TryNextPatchMerge() {
-
   if (!strategy_.UsePatchMerges() || !strategy_.UseCosts()) {
     return std::nullopt;
   }
 
-  // Work through the candidate composite conditions in order of descending probability.
+  // Work through the candidate composite conditions in order of descending
+  // probability.
   std::vector<std::pair<ActivationCondition, double>> ordered_candidates;
-  for (const auto& [condition, glyphs] : Context().glyph_groupings.ConditionsAndGlyphs()) {
+  for (const auto& [condition, glyphs] :
+       Context().glyph_groupings.ConditionsAndGlyphs()) {
     if (!glyphs.intersects(candidate_patch_merge_glyphs_)) {
       continue;
     }
-    ordered_candidates.emplace_back(condition, TRY(condition.Probability(Context().SegmentationInfo().Segments(), *strategy_.ProbabilityCalculator())));
+    ordered_candidates.emplace_back(
+        condition,
+        TRY(condition.Probability(Context().SegmentationInfo().Segments(),
+                                  *strategy_.ProbabilityCalculator())));
   }
-  std::sort(ordered_candidates.begin(), ordered_candidates.end(), [](const auto& a, const auto& b) {
-    return a.second > b.second;
-  });
+  std::sort(ordered_candidates.begin(), ordered_candidates.end(),
+            [](const auto& a, const auto& b) { return a.second > b.second; });
 
-  while (true) {
-    if (ordered_candidates.empty()) {
-      break;
-    }
-
+  while (!ordered_candidates.empty()) {
     ActivationCondition base = ordered_candidates.begin()->first;
-    GlyphSet base_glyphs = Context().glyph_groupings.ConditionsAndGlyphs().at(base);
+    GlyphSet base_glyphs =
+        Context().glyph_groupings.ConditionsAndGlyphs().at(base);
 
     auto invalidation = TRY(PatchMergeWithCosts(base, ordered_candidates));
     if (!invalidation.has_value()) {
@@ -417,8 +417,8 @@ StatusOr<std::optional<InvalidationSet>> Merger::MergeSegmentWithCosts(
     // If min group size is met, then we will no longer consider merge's that
     // have a positive cost delta so start with an existing smallest candidate
     // set to cost delta 0 which will filter out positive cost delta candidates.
-    smallest_candidate_merge = CandidateMerge::BaselineCandidate(
-        base_segment_index, 0.0);
+    smallest_candidate_merge =
+        CandidateMerge::BaselineCandidate(base_segment_index, 0.0);
   }
 
   // TODO(garretrieger): On each iteration we should consider all merge pairs
@@ -449,7 +449,10 @@ StatusOr<std::optional<InvalidationSet>> Merger::MergeSegmentWithCosts(
   return smallest_candidate_merge->Apply(*this);
 }
 
-StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(const ActivationCondition& base, const std::vector<std::pair<ActivationCondition, double>>& ordered_candidates) {
+StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(
+    const ActivationCondition& base,
+    const std::vector<std::pair<ActivationCondition, double>>&
+        ordered_candidates) {
   if (!strategy_.UsePatchMerges()) {
     return absl::InternalError("Patch merging is disabled.");
   }
@@ -465,13 +468,15 @@ StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(const Activ
       continue;
     }
 
-    auto candidate = TRY(CandidateMerge::AssessPatchMerge(*this, base, next, smallest_candidate_merge));
+    auto candidate = TRY(CandidateMerge::AssessPatchMerge(
+        *this, base, next, smallest_candidate_merge));
     if (candidate.has_value()) {
       smallest_candidate_merge = *candidate;
     }
   }
 
-  if (!smallest_candidate_merge.has_value() || smallest_candidate_merge->SegmentsToMerge() == SegmentSet {0}) {
+  if (!smallest_candidate_merge.has_value() ||
+      smallest_candidate_merge->SegmentsToMerge() == SegmentSet{0}) {
     // baseline was not beat, so don't apply.
     return std::nullopt;
   }
@@ -635,15 +640,13 @@ Status Merger::CollectCompositeCandidateMerges(
 }
 
 GlyphSet Merger::ComputeCandidatePatchMergeGlyphs(
-      SegmentationContext& context, const MergeStrategy& strategy,
-      const SegmentSet& candidate_segments,
-      const SegmentSet& inscope_segments,
-      segment_index_t optimization_cutoff_segment) {
-
+    SegmentationContext& context, const MergeStrategy& strategy,
+    const SegmentSet& candidate_segments, const SegmentSet& inscope_segments,
+    segment_index_t optimization_cutoff_segment) {
   GlyphSet out;
 
   ActivationCondition last_exclusive =
-    ActivationCondition::exclusive_segment(UINT32_MAX, 0);
+      ActivationCondition::exclusive_segment(UINT32_MAX, 0);
   for (auto it = context.glyph_groupings.OrderedConditions().lower_bound(
            last_exclusive);
        it != context.glyph_groupings.OrderedConditions().end(); it++) {

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -376,11 +376,8 @@ StatusOr<std::optional<InvalidationSet>> Merger::MergeSegmentWithCosts(
     // If min group size is met, then we will no longer consider merge's that
     // have a positive cost delta so start with an existing smallest candidate
     // set to cost delta 0 which will filter out positive cost delta candidates.
-    unsigned base_size =
-        TRY(context_->patch_size_cache->GetPatchSize(base_segment_glyphs));
     smallest_candidate_merge = CandidateMerge::BaselineCandidate(
-        base_segment_index, 0.0, base_size, base_segment.Probability(),
-        strategy_.NetworkOverheadCost());
+        base_segment_index, 0.0);
   }
 
   // TODO(garretrieger): On each iteration we should consider all merge pairs
@@ -563,13 +560,14 @@ Status Merger::CollectCompositeCandidateMerges(
       smallest_candidate_merge = *candidate_merge;
     }
 
-    if (strategy_.UsePatchMerges() && next_condition.conditions().size() == 1) {
-      // For disjunctive composite patches, also consider merging just the
-      // patches together (if enabled).
+    if (strategy_.UsePatchMerges()) {
+      // Also consider merging just the patches together (if enabled).
       auto candidate_merge = TRY(CandidateMerge::AssessPatchMerge(
-          *this, base_segment_index, triggering_segments,
+          *this, ActivationCondition::exclusive_segment(base_segment_index, 0), next_condition,
           smallest_candidate_merge));
-      if (candidate_merge.has_value()) {
+      if (candidate_merge.has_value() && candidate_merge->CostDelta() < 0) {
+        // For patch merges we only ever use them if they have negative cost delta.
+        // This prevents using patch merges soley to meet minimum group sizes.
         smallest_candidate_merge = *candidate_merge;
       }
     }

--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -473,6 +473,14 @@ StatusOr<std::optional<InvalidationSet>> Merger::PatchMergeWithCosts(
       continue;
     }
 
+    std::optional<segment_index_t> min = next.TriggeringSegments().min();
+    if (smallest_candidate_merge.has_value() && min.has_value() &&
+        min >= optimization_cutoff_segment_) {
+      // This condition is below the optimization cutoff, so we won't evaluate
+      // it unless we still need to select at least one candidate.
+      continue;
+    }
+
     auto candidate = TRY(CandidateMerge::AssessPatchMerge(
         *this, base, next, smallest_candidate_merge));
     if (candidate.has_value()) {
@@ -662,17 +670,6 @@ GlyphSet Merger::ComputeCandidatePatchMergeGlyphs(
     }
 
     SegmentSet triggering_segments = condition.TriggeringSegments();
-
-    // TODO XXXX optimization cutoff should filter the "B" patch (once min group size is met), all
-    // inscope patches need to be considered as the "A" patch for minimum group
-    // size merging.
-    std::optional<unsigned> min = triggering_segments.min();
-    if (min.has_value() && min >= optimization_cutoff_segment) {
-      // Don't consider merges where all triggering segment are cutoff
-      // the probability of these is too low to significantly impact overall
-      // cost
-      continue;
-    }
 
     if (!triggering_segments.intersects(candidate_segments) ||
         !triggering_segments.is_subset_of(inscope_segments)) {

--- a/ift/encoder/merger.h
+++ b/ift/encoder/merger.h
@@ -4,6 +4,7 @@
 #include <cstdint>
 
 #include "ift/common/int_set.h"
+#include "ift/encoder/activation_condition.h"
 #include "ift/encoder/candidate_merge.h"
 #include "ift/encoder/invalidation_set.h"
 #include "ift/encoder/merge_strategy.h"
@@ -104,6 +105,9 @@ class Merger {
         inscope_segments_(inscope_segments),
         candidate_segments_(
             ComputeCandidateSegments(*context_, strategy_, inscope_segments_)),
+        candidate_patch_merge_glyphs_(ComputeCandidatePatchMergeGlyphs(
+            *context_, strategy_, candidate_segments_, inscope_segments,
+            optimization_cutoff_segment)),
         inscope_segments_for_init_move_(inscope_segments_for_init_move),
         optimization_cutoff_segment_(optimization_cutoff_segment) {}
 
@@ -111,11 +115,23 @@ class Merger {
       SegmentationContext& context, const MergeStrategy& strategy,
       const ift::common::SegmentSet& inscope_segments);
 
+  static ift::common::GlyphSet ComputeCandidatePatchMergeGlyphs(
+      SegmentationContext& context, const MergeStrategy& strategy,
+      const ift::common::SegmentSet& candidate_segments,
+      const ift::common::SegmentSet& inscope_segments,
+      segment_index_t optimization_cutoff_segment
+    );
+
+  absl::StatusOr<std::optional<InvalidationSet>> TryNextPatchMerge();
+
   absl::Status InitOptimizationCutoff();
   absl::StatusOr<segment_index_t> ComputeSegmentCutoff() const;
 
   absl::StatusOr<std::optional<InvalidationSet>> MergeSegmentWithCosts(
       uint32_t base_segment_index);
+
+  absl::StatusOr<std::optional<InvalidationSet>> PatchMergeWithCosts(
+    const ActivationCondition& base, const std::vector<std::pair<ActivationCondition, double>>& ordered_candidates);
 
   absl::Status CollectExclusiveCandidateMerges(
       uint32_t base_segment_index,
@@ -179,6 +195,7 @@ class Merger {
   // The current set of segments under consideration for being merged.
   const ift::common::SegmentSet inscope_segments_;
   ift::common::SegmentSet candidate_segments_;
+  ift::common::GlyphSet candidate_patch_merge_glyphs_;
 
   // This is the set of segments under consideration for being merged into the
   // init font. Typically contains segments that were removed from

--- a/ift/encoder/merger.h
+++ b/ift/encoder/merger.h
@@ -119,8 +119,7 @@ class Merger {
       SegmentationContext& context, const MergeStrategy& strategy,
       const ift::common::SegmentSet& candidate_segments,
       const ift::common::SegmentSet& inscope_segments,
-      segment_index_t optimization_cutoff_segment
-    );
+      segment_index_t optimization_cutoff_segment);
 
   absl::StatusOr<std::optional<InvalidationSet>> TryNextPatchMerge();
 
@@ -131,7 +130,9 @@ class Merger {
       uint32_t base_segment_index);
 
   absl::StatusOr<std::optional<InvalidationSet>> PatchMergeWithCosts(
-    const ActivationCondition& base, const std::vector<std::pair<ActivationCondition, double>>& ordered_candidates);
+      const ActivationCondition& base,
+      const std::vector<std::pair<ActivationCondition, double>>&
+          ordered_candidates);
 
   absl::Status CollectExclusiveCandidateMerges(
       uint32_t base_segment_index,


### PR DESCRIPTION
Patch based merging was previously disabled due to a lack of unicode composition/decomposition closure, which was just fixed in #228. This turns on patch merging in auto generated segmenter configs.

Patch merging functionality has been extended to be more general. Previously it would only work between an exclusive segment and non-exclusive purely disjunctive patch. The mechanism now supports merging arbitrary patches, including ones with mixed conjunction/disjunction.

Patch merging has been moved to be a separate phase after segment merging finishes which looks for non-exclusive patch pairs and merges them if cost is improved or as needed to meet minimum group sizes.