### PR TITLE
Switch bigram probability cache to an LRU cache.

### DIFF
--- a/ift/encoder/merger.cc
+++ b/ift/encoder/merger.cc
@@ -59,7 +59,6 @@ StatusOr<std::optional<InvalidationSet>> Merger::TryNextMerge() {
     }
 
     MarkFinished(base_segment_index);
-    strategy_.ProbabilityCalculator()->ResetCache();
   }
 
   // No more base merges remain, so we can start trying patch to patch merging
@@ -254,7 +253,6 @@ Status Merger::MoveSegmentsToInitFont() {
     }
 
     TRYV(ApplyInitFontMove(*glyphs_for_lowest, total_delta));
-    strategy_.ProbabilityCalculator()->ResetCache();
   } while (true);
 
   VLOG(0) << "Initial font now has "

--- a/ift/freq/BUILD
+++ b/ift/freq/BUILD
@@ -17,6 +17,7 @@ cc_library(
         "bigram_probability_calculator.cc",
         "unicode_frequencies.cc",
         "unigram_probability_calculator.cc",
+        "lru_cache.h",
     ],
     hdrs = [
         "bigram_probability_calculator.h",
@@ -30,6 +31,7 @@ cc_library(
         ":common",
         "//ift/encoder:common",
         "@abseil-cpp//absl/container:flat_hash_map",
+        "@abseil-cpp//absl/hash",
         "@harfbuzz",
     ],
 )
@@ -72,5 +74,14 @@ cc_library(
     deps = [
         ":freq",
         "//ift/encoder:common",
+    ],
+)
+
+cc_test(
+    name = "lru_cache_test",
+    srcs = ["lru_cache_test.cc"],
+    deps = [
+        ":freq",
+        "@googletest//:gtest_main",
     ],
 )

--- a/ift/freq/bigram_probability_calculator.cc
+++ b/ift/freq/bigram_probability_calculator.cc
@@ -14,19 +14,17 @@ using ift::encoder::SubsetDefinition;
 namespace ift::freq {
 
 BigramProbabilityCalculator::BigramProbabilityCalculator(
-    UnicodeFrequencies frequencies)
-    : frequencies_(std::move(frequencies)) {}
+    UnicodeFrequencies frequencies, size_t max_cache_size)
+    : frequencies_(std::move(frequencies)),
+      cache_("bigram probability", max_cache_size) {}
 
 ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
     const CodepointSet& codepoints, double best_lower) const {
-  auto it = cache_.find(codepoints);
-  if (it != cache_.end()) {
-    cache_hit_++;
-    double lower = std::max(it->second.Min(), best_lower);
-    double upper = std::max(it->second.Max(), lower);
+  std::optional<ProbabilityBound>& cached_bound = cache_[codepoints];
+  if (cached_bound.has_value()) {
+    double lower = std::max(cached_bound->Min(), best_lower);
+    double upper = std::max(cached_bound->Max(), lower);
     return ProbabilityBound(lower, upper);
-  } else {
-    cache_miss_++;
   }
 
   unsigned n = codepoints.size();
@@ -50,7 +48,7 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
   if (max_single_bound >= 1.0) {
     // Bounds can't be lower than [1, 1] stop checking.
     ProbabilityBound bound(1.0, 1.0);
-    cache_.emplace(codepoints, bound);
+    cached_bound = bound;
     return bound;
   }
 
@@ -67,7 +65,7 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
       if (max_pair_bound >= 1.0) {
         // Bounds can't be lower than [1, 1] stop checking.
         ProbabilityBound bound(1.0, 1.0);
-        cache_.emplace(codepoints, bound);
+        cached_bound = bound;
         return bound;
       }
     }
@@ -97,7 +95,7 @@ ProbabilityBound BigramProbabilityCalculator::BigramProbabilityBound(
       std::min(unigram_total - max_partial_bigram_total, 1.0), raw_lower);
 
   ProbabilityBound raw_bound(raw_lower, raw_upper);
-  cache_.emplace(codepoints, raw_bound);
+  cached_bound = raw_bound;
 
   double final_lower = std::max(raw_lower, best_lower);
   double final_upper = std::max(raw_upper, final_lower);

--- a/ift/freq/bigram_probability_calculator.h
+++ b/ift/freq/bigram_probability_calculator.h
@@ -1,14 +1,17 @@
 #ifndef IFT_FREQ_BIGRAM_PROBABILITY_CALCULATOR_H_
 #define IFT_FREQ_BIGRAM_PROBABILITY_CALCULATOR_H_
 
-#include "absl/container/flat_hash_map.h"
-#include "absl/log/log.h"
+#include <optional>
+
 #include "ift/common/int_set.h"
+#include "ift/freq/lru_cache.h"
 #include "ift/freq/probability_bound.h"
 #include "ift/freq/probability_calculator.h"
 #include "ift/freq/unicode_frequencies.h"
 
 namespace ift::freq {
+
+constexpr size_t BIGRAM_PROBABILITY_CACHE_SIZE = 300000;
 
 // The BigramProbabilityCalculator uses unigram and bigram codepoint frequency
 // data to compute probability bounds for codepoint sets. Unlike the unigram
@@ -18,7 +21,9 @@ namespace ift::freq {
 // to compute the true probability.
 class BigramProbabilityCalculator : public ProbabilityCalculator {
  public:
-  explicit BigramProbabilityCalculator(UnicodeFrequencies frequencies);
+  explicit BigramProbabilityCalculator(
+      UnicodeFrequencies frequencies,
+      size_t max_cache_size = BIGRAM_PROBABILITY_CACHE_SIZE);
 
   ProbabilityBound ComputeProbability(
       const ift::encoder::SubsetDefinition& definition) const override;
@@ -28,17 +33,6 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
 
   ProbabilityBound ComputeConjunctiveProbability(
       const std::vector<ProbabilityBound>& bounds) const override;
-
-  void ResetCache() const override {
-    if (cache_hit_ || cache_miss_) {
-      VLOG(1) << "bigram prob cache hit % = "
-              << ((double)cache_hit_ / (double)(cache_hit_ + cache_miss_)) *
-                     100.0;
-    }
-    cache_hit_ = 0;
-    cache_miss_ = 0;
-    cache_.clear();
-  }
 
  private:
   ProbabilityBound BigramProbabilityBound(
@@ -50,10 +44,8 @@ class BigramProbabilityCalculator : public ProbabilityCalculator {
       double best_lower) const;
 
   UnicodeFrequencies frequencies_;
-  mutable absl::flat_hash_map<ift::common::CodepointSet, ProbabilityBound>
+  mutable LruCache<ift::common::CodepointSet, std::optional<ProbabilityBound>>
       cache_;
-  mutable uint64_t cache_hit_ = 0;
-  mutable uint64_t cache_miss_ = 0;
 };
 
 }  // namespace ift::freq

--- a/ift/freq/bigram_probability_calculator_test.cc
+++ b/ift/freq/bigram_probability_calculator_test.cc
@@ -249,4 +249,20 @@ TEST(BigramProbabilityCalculatorTest, ComputeConjunctiveProbabilityNoSegments) {
   ASSERT_DOUBLE_EQ(result.Max(), 1.0);
 }
 
+TEST(BigramProbabilityCalculatorTest, ComputeProbability_LruEviction) {
+  UnicodeFrequencies frequencies{
+      {{'a', 'a'}, 70}, {{'b', 'b'}, 60}, {{'c', 'c'}, 100},
+      {{'a', 'b'}, 40}, {{'a', 'c'}, 50}, {{'b', 'c'}, 60},
+  };
+
+  BigramProbabilityCalculator calc(std::move(frequencies), 2);
+
+  calc.ComputeProbability({'a'});
+  calc.ComputeProbability({'b'});
+  // Third entry will cause evicition
+  calc.ComputeProbability({'c'});
+  // Recompute evicted entry
+  ASSERT_EQ(calc.ComputeProbability({'a'}), (ProbabilityBound{0.7, 0.7}));
+}
+
 }  // namespace ift::freq

--- a/ift/freq/lru_cache.h
+++ b/ift/freq/lru_cache.h
@@ -1,0 +1,93 @@
+#ifndef IFT_FREQ_LRU_CACHE_H_
+#define IFT_FREQ_LRU_CACHE_H_
+
+#include <list>
+#include <utility>
+
+#include "absl/container/flat_hash_map.h"
+#include "absl/hash/hash.h"
+#include "absl/log/log.h"
+#include "absl/strings/string_view.h"
+
+namespace ift::freq {
+
+// A simple LRU cache from Key to Value.
+template <typename Key, typename Value>
+class LruCache {
+ public:
+  explicit LruCache(absl::string_view name, size_t max_size)
+      : max_size_(max_size), name_(name) {}
+
+  // Move only
+  LruCache(const LruCache&) = delete;
+  LruCache& operator=(const LruCache&) = delete;
+  LruCache(LruCache&&) = default;
+  LruCache& operator=(LruCache&&) = default;
+
+  // Lookups up the key in the cache and returns a reference to the existing
+  // value entry, or inserts a new default value and returns reference if one
+  // doesn't exist yet.
+  //
+  // Moves the accessed/inserted item to the front of the LRU list.
+  Value& operator[](const Key& key) {
+    if (total_count_++ % 500000 == 0) {
+      log_stats();
+    }
+    auto it = map_.find(&key);
+    if (it != map_.end()) {
+      hit_count_++;
+      const auto& key_it = it->second;
+      list_.splice(list_.begin(), list_, key_it);
+      return key_it->second;
+    }
+
+    if (list_.size() >= max_size_) {
+      const Key& last_key = list_.back().first;
+      map_.erase(&last_key);
+      list_.pop_back();
+      eviction_count_++;
+    }
+
+    list_.emplace_front(key, Value());
+    map_[&list_.front().first] = list_.begin();
+    return list_.front().second;
+  }
+
+  void clear() {
+    map_.clear();
+    list_.clear();
+  }
+
+  size_t size() const { return map_.size(); }
+  size_t max_size() const { return max_size_; }
+
+ private:
+  void log_stats() const {
+    VLOG(1) << name_ << " cache hit % = "
+            << ((double)hit_count_ / (double)(total_count_)) * 100.0
+            << ", evictions = " << eviction_count_;
+  }
+
+  struct HashPtr {
+    size_t operator()(const Key* k) const { return absl::Hash<Key>()(*k); }
+  };
+  struct EqPtr {
+    bool operator()(const Key* a, const Key* b) const { return *a == *b; }
+  };
+
+  size_t max_size_;
+  std::list<std::pair<Key, Value>> list_;
+  absl::flat_hash_map<const Key*,
+                      typename std::list<std::pair<Key, Value>>::iterator,
+                      HashPtr, EqPtr>
+      map_;
+
+  std::string name_;
+  uint64_t hit_count_ = 0;
+  uint64_t total_count_ = 0;
+  uint64_t eviction_count_ = 0;
+};
+
+}  // namespace ift::freq
+
+#endif  // IFT_FREQ_LRU_CACHE_H_

--- a/ift/freq/lru_cache_test.cc
+++ b/ift/freq/lru_cache_test.cc
@@ -1,0 +1,98 @@
+#include "ift/freq/lru_cache.h"
+
+#include <string>
+
+#include "gtest/gtest.h"
+
+namespace ift::freq {
+namespace {
+
+TEST(LruCacheTest, BasicPutAndGet) {
+  LruCache<std::string, int> cache("test", 3);
+
+  int& val_a = cache["a"];
+  EXPECT_EQ(val_a, 0);  // operator[] inserts default value (0 for int)
+  val_a = 1;
+
+  int& val_b = cache["b"];
+  EXPECT_EQ(val_b, 0);
+  val_b = 2;
+
+  int& val_c = cache["c"];
+  EXPECT_EQ(val_c, 0);
+  val_c = 3;
+
+  EXPECT_EQ(cache.size(), 3);
+
+  EXPECT_EQ(cache["a"], 1);
+  EXPECT_EQ(cache["b"], 2);
+  EXPECT_EQ(cache["c"], 3);
+}
+
+TEST(LruCacheTest, Eviction) {
+  LruCache<std::string, int> cache("test", 3);
+
+  cache["a"] = 1;
+  cache["b"] = 2;
+  cache["c"] = 3;
+
+  // Evict "a" (LRU) when accessing "d"
+  cache["d"];
+  EXPECT_EQ(cache.size(), 3);
+
+  // "a" should be evicted, so accessing it now should insert default value (0)
+  EXPECT_EQ(cache["a"], 0);  // will evict "b"
+  EXPECT_EQ(cache["b"], 0);
+  EXPECT_EQ(cache.size(), 3);
+}
+
+TEST(LruCacheTest, Clear) {
+  LruCache<std::string, int> cache("test", 3);
+
+  cache["a"] = 1;
+  cache["b"] = 2;
+  cache.clear();
+
+  EXPECT_EQ(cache.size(), 0);
+  EXPECT_EQ(cache["a"], 0);
+  EXPECT_EQ(cache.size(), 1);
+}
+
+// Used to track copy's in the no copy test.
+struct MockKey {
+  std::string val;
+  mutable int copy_count = 0;
+
+  MockKey(std::string v) : val(std::move(v)) {}
+  MockKey(const MockKey& o) : val(o.val), copy_count(o.copy_count + 1) {
+    o.copy_count++;
+  }
+
+  MockKey(MockKey&& o) noexcept
+      : val(std::move(o.val)), copy_count(o.copy_count) {}
+
+  bool operator==(const MockKey& o) const { return val == o.val; }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const MockKey& k) {
+    return H::combine(std::move(h), k.val);
+  }
+};
+
+TEST(LruCacheTest, NoKeyCopyOnHit) {
+  LruCache<MockKey, int> cache("test", 3);
+
+  MockKey key1("a");
+  cache[key1] = 1;  // Miss, inserts and copies key1.
+  EXPECT_EQ(key1.copy_count, 1);
+
+  // Now hit it.
+  int& val = cache[key1];
+  EXPECT_EQ(val, 1);
+
+  // Accessing existing key should not copy it.
+  EXPECT_EQ(key1.copy_count, 1);
+}
+
+}  // namespace
+}  // namespace ift::freq

--- a/ift/freq/probability_bound.h
+++ b/ift/freq/probability_bound.h
@@ -13,6 +13,7 @@ struct ProbabilityBound {
   static ProbabilityBound Zero() { return ProbabilityBound{0.0, 0.0}; }
 
   // TODO(garretrieger): XXXXX automatically clamp the min, max values?
+  ProbabilityBound() : min_(0.0), max_(0.0) {}
   ProbabilityBound(double min, double max) : min_(min), max_(max) {}
 
   double Min() const { return min_; }

--- a/ift/freq/probability_calculator.h
+++ b/ift/freq/probability_calculator.h
@@ -31,10 +31,6 @@ class ProbabilityCalculator {
   // to speed up the computation.
   virtual ProbabilityBound ComputeConjunctiveProbability(
       const std::vector<ProbabilityBound>& bounds) const = 0;
-
-  // Signal that if there is internal cached data future calls are unlikely
-  // to hit it again and it can be cleared.
-  virtual void ResetCache() const {}
 };
 
 }  // namespace ift::freq


### PR DESCRIPTION
I've encountered some cases where the probability cache grew to extreme sizes, even with the ResetCache() mechanism. Replaces the basic hash map + periodic reset with a proper LRU cache with a fixed size.