### PR TITLE
Add new condition analysis mode DEP_GRAPH_ONLY_WITH_SIMPLIFICATION

### DIFF
--- a/ift/common/font_helper.cc
+++ b/ift/common/font_helper.cc
@@ -278,6 +278,7 @@ flat_hash_map<uint32_t, CodepointSet> FontHelper::GidToUnicodeMap(
 CodepointSet FontHelper::ToCodepointsSet(hb_face_t* face) {
   hb_set_unique_ptr codepoints = make_hb_set();
   hb_face_collect_unicodes(face, codepoints.get());
+  hb_face_collect_variation_selectors(face, codepoints.get());
   return CodepointSet(codepoints);
 }
 

--- a/ift/common/font_helper_test.cc
+++ b/ift/common/font_helper_test.cc
@@ -686,6 +686,17 @@ TEST_F(FontHelperTest, GetNominalGlyph) {
   EXPECT_TRUE(absl::IsNotFound(g_invalid.status()));
 }
 
+TEST_F(FontHelperTest, ToCodepointsSet_IncludesVariationSelectors) {
+  auto loader = TestFontLoader::Default().value();
+  auto face =
+      loader->LoadFace("ift/common/testdata/NotoSansJP-VF.cmap14.ttf").value();
+
+  CodepointSet codepoints = FontHelper::ToCodepointsSet(face.get());
+
+  EXPECT_EQ(codepoints, (CodepointSet{0x6406, 0x640F, 0x6717, 0x7891, 0x798F,
+                                       0xFE00, 0xE0100}));
+}
+
 // TODO test BuildFont...
 
 }  // namespace ift::common

--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -87,8 +87,9 @@ enum Quality {
 //     size.
 //
 // - condition_analysis_mode: use DEP_GRAPH_ONLY if dependency API is available,
-// otherwise CLOSURE_ONLY. DEP_GRAPH_ONLY_WITH_SIMPLIFICATION can significantly speed up
-// cases with high condition complexity, at the cost of less specific final conditions.
+// otherwise CLOSURE_ONLY. DEP_GRAPH_ONLY_WITH_SIMPLIFICATION can significantly
+// speed up cases with high condition complexity, at the cost of less specific
+// final conditions.
 //
 // Merge group settings:
 //

--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -28,15 +28,14 @@ static constexpr uint32_t kMinimumGroupSize = 4;
 
 // clang-format off
 // Quality Table:
-// Quality | bigrams | init font merging | init brotli | non init brotli | init font merge threshold | opt cut off | preprocess merging | preprocess threshold
-// 1       | No      | No                | 0           | 0               | na                        | 5%          | Yes                | 5%
-// 2       | Yes     | No                | 0           | 0               | na                        | 4%          | Yes                | 4%
-// 3       | Yes     | Yes               | 0           | 0               | 60%                       | 3%          | Yes                | 3%
-// 4       | Yes     | Yes               | 0           | 9               | 50%                       | 2%          | Yes                | 2%
-// 5       | Yes     | Yes               | 9           | 9               | 40%                       | 1%          | Yes                | 1%
-// 6       | Yes     | Yes               | 9           | 11              | 30%                       | 0.5%        | Yes                | 0.5%
-// 7       | Yes     | Yes               | 11          | 11              | 25%                       | 0.5%        | Yes                | 0.05%
-// 8       | Yes     | Yes               | 11          | 11              | 25%                       | 0.5%        | No                 | na
+// Quality | bigrams | simplificiation | init brotli | non init brotli | init font merge threshold | opt cut off | preprocess merging threshold
+// 1       | No      | Yes             | 0           | 0               | 60%                       | 5%          | 5%
+// 2       | No      | No              | 0           | 0               | 54%                       | 4%          | 4%
+// 3       | Yes     | No              | 0           | 0               | 48%                       | 3%          | 3%
+// 4       | Yes     | No              | 0           | 9               | 42%                       | 2%          | 2%
+// 5       | Yes     | No              | 9           | 9               | 36%                       | 1%          | 1%
+// 6       | Yes     | No              | 9           | 11              | 30%                       | 0.5%        | 0.5%
+// 7       | Yes     | No              | 11          | 11              | 25%                       | 0.5%        | 0.05%
 // clang-format on
 enum Quality {
   MIN = 1,  // Alias for ONE
@@ -47,8 +46,7 @@ enum Quality {
   FIVE = 5,
   SIX = 6,
   SEVEN = 7,
-  EIGHT = 8,
-  MAX = 8,  // Alias for EIGHT
+  MAX = 7,  // Alias for SEVEN
 };
 
 // TODO(garretrieger): do something analagous to brotli quality levels
@@ -89,7 +87,8 @@ enum Quality {
 //     size.
 //
 // - condition_analysis_mode: use DEP_GRAPH_ONLY if dependency API is available,
-// otherwise CLOSURE_ONLY.
+// otherwise CLOSURE_ONLY. DEP_GRAPH_ONLY_WITH_SIMPLIFICATION can significantly speed up
+// cases with high condition complexity, at the cost of less specific final conditions.
 //
 // Merge group settings:
 //
@@ -502,7 +501,7 @@ static void ApplyQualityLevelTo(Quality quality,
 static void ApplyQualityLevelTo(Quality quality, CostConfiguration& config) {
   config.set_min_group_size(kMinimumGroupSize);
 
-  if (quality == ONE) {
+  if (quality == ONE || quality == TWO) {
     config.set_use_bigrams(false);
   } else {
     config.set_use_bigrams(true);
@@ -526,7 +525,6 @@ static void ApplyQualityLevelTo(Quality quality, CostConfiguration& config) {
       break;
     case SIX:
     case SEVEN:
-    case EIGHT:
     default:
       config.set_optimization_cutoff_fraction(0.005);
       break;
@@ -535,15 +533,7 @@ static void ApplyQualityLevelTo(Quality quality, CostConfiguration& config) {
 
 static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
   if (merge_group.has_cost_config()) {
-    if (quality == ONE || quality == TWO) {
-      merge_group.mutable_cost_config()->clear_initial_font_merge_threshold();
-    }
-
-    if (quality >= ONE && quality <= SEVEN) {
-      merge_group.set_preprocess_merging_group_size(kMinimumGroupSize);
-    } else {
-      merge_group.set_preprocess_merging_group_size(1);
-    }
+    merge_group.set_preprocess_merging_group_size(kMinimumGroupSize);
 
     switch (quality) {
       case ONE:
@@ -565,34 +555,38 @@ static void ApplyQualityLevelTo(Quality quality, MergeGroup& merge_group) {
         merge_group.set_preprocess_merging_probability_threshold(0.005);
         break;
       case SEVEN:
-        merge_group.set_preprocess_merging_probability_threshold(0.0005);
-        break;
-      case EIGHT:
       default:
-        merge_group.clear_preprocess_merging_probability_threshold();
+        merge_group.set_preprocess_merging_probability_threshold(0.0005);
         break;
     }
 
     if (merge_group.mutable_cost_config()->has_initial_font_merge_threshold()) {
       switch (quality) {
-        case THREE:
+        case ONE:
           merge_group.mutable_cost_config()
               ->set_initial_font_merge_probability_threshold(0.60);
           break;
+        case TWO:
+          merge_group.mutable_cost_config()
+              ->set_initial_font_merge_probability_threshold(0.54);
+          break;
+        case THREE:
+          merge_group.mutable_cost_config()
+              ->set_initial_font_merge_probability_threshold(0.48);
+          break;
         case FOUR:
           merge_group.mutable_cost_config()
-              ->set_initial_font_merge_probability_threshold(0.50);
+              ->set_initial_font_merge_probability_threshold(0.42);
           break;
         case FIVE:
           merge_group.mutable_cost_config()
-              ->set_initial_font_merge_probability_threshold(0.40);
+              ->set_initial_font_merge_probability_threshold(0.36);
           break;
         case SIX:
           merge_group.mutable_cost_config()
               ->set_initial_font_merge_probability_threshold(0.30);
           break;
         case SEVEN:
-        case EIGHT:
         default:
           merge_group.mutable_cost_config()
               ->set_initial_font_merge_probability_threshold(0.25);
@@ -607,6 +601,16 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
 
   config.set_unmapped_glyph_handling(MOVE_TO_INIT_FONT);
 
+#ifdef HB_DEPEND_API
+  if (quality == ONE) {
+    config.set_condition_analysis_mode(DEP_GRAPH_ONLY_WITH_SIMPLIFICATION);
+  } else {
+    config.set_condition_analysis_mode(DEP_GRAPH_ONLY);
+  }
+#else
+  config.set_condition_analysis_mode(CLOSURE_ONLY);
+#endif
+
   switch (quality) {
     case ONE:
     case TWO:
@@ -619,7 +623,6 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
       break;
     case SIX:
     case SEVEN:
-    case EIGHT:
     default:
       config.set_brotli_quality(11);
       break;
@@ -637,7 +640,6 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
       config.set_brotli_quality_for_initial_font_merging(9);
       break;
     case SEVEN:
-    case EIGHT:
     default:
       config.set_brotli_quality_for_initial_font_merging(11);
       break;
@@ -665,11 +667,6 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
   SegmenterConfig config;
   config.set_generate_table_keyed_segments(true);
   config.set_generate_feature_segments(true);
-#ifdef HB_DEPEND_API
-  config.set_condition_analysis_mode(DEP_GRAPH_ONLY);
-#else
-  config.set_condition_analysis_mode(CLOSURE_ONLY);
-#endif
 
   auto* base_plan = config.mutable_base_segmentation_plan();
   base_plan->set_jump_ahead(2);
@@ -683,6 +680,9 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
   // TODO(garretrieger): more sophisticated scheme for auto picking quality
   // level. roughly we want to estimate the expected cost of each quality level
   // and pick based on that.
+
+  // TODO XXXXX redo this based on latest batch results, including using quality
+  // 1 for extreme cases (high condition complexity)
   Quality quality = THREE;
   if (cp_count <= 1000) {
     quality = MAX;

--- a/ift/config/auto_segmenter_config_test.cc
+++ b/ift/config/auto_segmenter_config_test.cc
@@ -114,21 +114,24 @@ ungrouped_config {
 preprocess_merging_group_size_for_ungrouped: 12
 merge_groups {
   name: "Cyrillic"
-  preprocess_merging_group_size: 1
+  preprocess_merging_group_size: 4
+  preprocess_merging_probability_threshold: 0.0005
   cost_config {
     built_in_freq_data_name: "Script_cyrillic.riegeli"
   }
 }
 merge_groups {
   name: "Greek"
-  preprocess_merging_group_size: 1
+  preprocess_merging_group_size: 4
+  preprocess_merging_probability_threshold: 0.0005
   cost_config {
     built_in_freq_data_name: "Script_greek.riegeli"
   }
 }
 merge_groups {
   name: "Latin"
-  preprocess_merging_group_size: 1
+  preprocess_merging_group_size: 4
+  preprocess_merging_probability_threshold: 0.0005
   cost_config {
     built_in_freq_data_name: "Script_latin.riegeli"
     initial_font_merge_threshold: -160
@@ -137,14 +140,16 @@ merge_groups {
 }
 merge_groups {
   name: "Symbols"
-  preprocess_merging_group_size: 1
+  preprocess_merging_group_size: 4
+  preprocess_merging_probability_threshold: 0.0005
   cost_config {
     built_in_freq_data_name: "Script_symbols.riegeli"
   }
 }
 merge_groups {
   name: "Fallback"
-  preprocess_merging_group_size: 1
+  preprocess_merging_group_size: 4
+  preprocess_merging_probability_threshold: 0.0005
   cost_config {
     built_in_freq_data_name: "fallback.riegeli"
   }

--- a/ift/config/segmenter_config.proto
+++ b/ift/config/segmenter_config.proto
@@ -33,6 +33,12 @@ enum ConditionAnalysisMode {
   //
   // This is currently the recommended analysis mode.
   DEP_GRAPH_ONLY = 3;
+
+  // Same as DEP_GRAPH_ONLY however composite conditions (those with conjunction and
+  // disjunction) will be simplified down to purely disjunctive superset conditions.
+  // This is useful for fonts that have extremely complex conditions which are too
+  // slow to analyze using the true conditions.
+  DEP_GRAPH_ONLY_WITH_SIMPLIFICATION = 4;
 }
 
 // This messages provides the configuration details for util/gen_ift_segmentation_plan.cc

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -223,16 +223,16 @@ ActivationCondition ActivationCondition::NonCompositeSuperset() const {
   // we can freely drop any number of the sub groups and remain a superset
   // since AND always further restricts activation.
   //
-  // Given that, we use a heuristic to pick a super set that is either all conjunctive
-  // or disjunctive and roughly minimizes the activation probability of the new
-  // condition.
+  // Given that, we use a heuristic to pick a super set that is either all
+  // conjunctive or disjunctive and roughly minimizes the activation probability
+  // of the new condition.
   //
-  // If the original condition has one or more sub groups with only one segment then
-  // the return a conjunctive superset of just those subgroups.
+  // If the original condition has one or more sub groups with only one segment
+  // then the return a conjunctive superset of just those subgroups.
   //
-  // Otherwise select one subgroup to keep which has the largest min segment index
-  // (since segments are ordered by decreasing probability), break ties by selecting
-  // the smaller subgroup.
+  // Otherwise select one subgroup to keep which has the largest min segment
+  // index (since segments are ordered by decreasing probability), break ties by
+  // selecting the smaller subgroup.
 
   if (IsPurelyConjunctive() || IsPurelyDisjunctive() || IsAlwaysTrue()) {
     return *this;
@@ -253,7 +253,8 @@ ActivationCondition ActivationCondition::NonCompositeSuperset() const {
     }
 
     segment_index_t min = *sub_group.min();
-    if (!keep || min > highest_s || (min == highest_s && sub_group.size() < keep->size())) {
+    if (!keep || min > highest_s ||
+        (min == highest_s && sub_group.size() < keep->size())) {
       highest_s = min;
       keep = &sub_group;
     }
@@ -268,7 +269,7 @@ ActivationCondition ActivationCondition::NonCompositeSuperset() const {
 
   if (!conjunctive.empty()) {
     for (segment_index_t s : conjunctive) {
-      out.conditions_.push_back(SegmentSet {s});
+      out.conditions_.push_back(SegmentSet{s});
     }
     if (out.conditions_.size() == 1) {
       out.is_exclusive_ = true;

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -218,6 +218,72 @@ ActivationCondition ActivationCondition::RemoveIntersectingSubgroups(
   return new_condition;
 }
 
+ActivationCondition ActivationCondition::NonCompositeSuperset() const {
+  // With a mixed condition (sub group 1) AND (sub group 2) AND ...
+  // we can freely drop any number of the sub groups and remain a superset
+  // since AND always further restricts activation.
+  //
+  // Given that, we use a heuristic to pick a super set that is either all conjunctive
+  // or disjunctive and roughly minimizes the activation probability of the new
+  // condition.
+  //
+  // If the original condition has one or more sub groups with only one segment then
+  // the return a conjunctive superset of just those subgroups.
+  //
+  // Otherwise select one subgroup to keep which has the largest min segment index
+  // (since segments are ordered by decreasing probability), break ties by selecting
+  // the smaller subgroup.
+
+  if (IsPurelyConjunctive() || IsPurelyDisjunctive() || IsAlwaysTrue()) {
+    return *this;
+  }
+
+  SegmentSet conjunctive;
+  segment_index_t highest_s = 0;
+  const SegmentSet* keep = nullptr;
+
+  for (const auto& sub_group : conditions_) {
+    if (sub_group.size() == 1) {
+      conjunctive.insert(*sub_group.min());
+      continue;
+    }
+
+    if (!conjunctive.empty() || sub_group.empty()) {
+      continue;
+    }
+
+    segment_index_t min = *sub_group.min();
+    if (!keep || min > highest_s || (min == highest_s && sub_group.size() < keep->size())) {
+      highest_s = min;
+      keep = &sub_group;
+    }
+  }
+
+  ActivationCondition out;
+  out.is_fallback_ = is_fallback_;
+  out.is_exclusive_ = is_exclusive_;
+  out.conditions_ = {};
+  out.activated_ = activated_;
+  out.encoding_ = encoding_;
+
+  if (!conjunctive.empty()) {
+    for (segment_index_t s : conjunctive) {
+      out.conditions_.push_back(SegmentSet {s});
+    }
+    if (out.conditions_.size() == 1) {
+      out.is_exclusive_ = true;
+    }
+    return out;
+  }
+
+  if (!keep) {
+    return out;
+  }
+
+  out.conditions_ = {*keep};
+  return out;
+}
+
 std::string ActivationCondition::ToString() const {
   std::stringstream out;
   out << "if (";

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -133,6 +133,13 @@ class ActivationCondition {
   ActivationCondition RemoveIntersectingSubgroups(
       const common::SegmentSet& segments) const;
 
+  // Returns a condition which is a superset of this one and contains
+  // purely disjunction or conjunction (and not a mix of the two)
+  //
+  // Superset means the condition will activate at least whenever the original
+  // one would have.
+  ActivationCondition NonCompositeSuperset() const;
+
   /*
    * Returns a human readable string representation of this condition.
    */

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -530,42 +530,45 @@ TEST(ActivationConditionTest, EffectiveGroupSize) {
 }
 
 TEST(ActivationConditionTest, NonCompositeSuperset) {
-  EXPECT_EQ(
-    ActivationCondition::True(12).NonCompositeSuperset(),
-    ActivationCondition::True(12));
+  EXPECT_EQ(ActivationCondition::True(12).NonCompositeSuperset(),
+            ActivationCondition::True(12));
 
   EXPECT_EQ(
-    ActivationCondition::exclusive_segment(12, 14).NonCompositeSuperset(),
-    ActivationCondition::exclusive_segment(12, 14));
+      ActivationCondition::exclusive_segment(12, 14).NonCompositeSuperset(),
+      ActivationCondition::exclusive_segment(12, 14));
 
   EXPECT_EQ(
-    ActivationCondition::or_segments({2, 8, 21}, 12).NonCompositeSuperset(),
-    ActivationCondition::or_segments({2, 8, 21}, 12));
+      ActivationCondition::or_segments({2, 8, 21}, 12).NonCompositeSuperset(),
+      ActivationCondition::or_segments({2, 8, 21}, 12));
 
   EXPECT_EQ(
-    ActivationCondition::and_segments({2, 8, 21}, 12).NonCompositeSuperset(),
-    ActivationCondition::and_segments({2, 8, 21}, 12));
+      ActivationCondition::and_segments({2, 8, 21}, 12).NonCompositeSuperset(),
+      ActivationCondition::and_segments({2, 8, 21}, 12));
 
   // Picks the single segment subgroups
+  EXPECT_EQ(ActivationCondition::composite_condition({{0, 1}, {1, 7}, {3}}, 12)
+                .NonCompositeSuperset(),
+            ActivationCondition::exclusive_segment(3, 12));
   EXPECT_EQ(
-    ActivationCondition::composite_condition({{0, 1}, {1, 7}, {3}}, 12).NonCompositeSuperset(),
-    ActivationCondition::exclusive_segment(3, 12));
-  EXPECT_EQ(
-    ActivationCondition::composite_condition({{0, 1}, {1, 7}, {3}, {8}}, 12).NonCompositeSuperset(),
-    ActivationCondition::and_segments({3, 8}, 12));
+      ActivationCondition::composite_condition({{0, 1}, {1, 7}, {3}, {8}}, 12)
+          .NonCompositeSuperset(),
+      ActivationCondition::and_segments({3, 8}, 12));
 
   // Picks one subgroup (largest min segment and smallest size)
-  EXPECT_EQ(
-    ActivationCondition::composite_condition({{0, 1}, {3, 100}, {8, 9}, {2, 1}}, 12).NonCompositeSuperset(),
-    ActivationCondition::or_segments({8, 9}, 12));
+  EXPECT_EQ(ActivationCondition::composite_condition(
+                {{0, 1}, {3, 100}, {8, 9}, {2, 1}}, 12)
+                .NonCompositeSuperset(),
+            ActivationCondition::or_segments({8, 9}, 12));
 
   // if min segment is tied then the smaller group is prefered
-  EXPECT_EQ(
-    ActivationCondition::composite_condition({{0, 1}, {3, 4, 5}, {3, 100}}, 12).NonCompositeSuperset(),
-    ActivationCondition::or_segments({3, 100}, 12));
-  EXPECT_EQ(
-    ActivationCondition::composite_condition({{3, 100}, {0, 1}, {3, 4, 5}}, 12).NonCompositeSuperset(),
-    ActivationCondition::or_segments({3, 100}, 12));
+  EXPECT_EQ(ActivationCondition::composite_condition(
+                {{0, 1}, {3, 4, 5}, {3, 100}}, 12)
+                .NonCompositeSuperset(),
+            ActivationCondition::or_segments({3, 100}, 12));
+  EXPECT_EQ(ActivationCondition::composite_condition(
+                {{3, 100}, {0, 1}, {3, 4, 5}}, 12)
+                .NonCompositeSuperset(),
+            ActivationCondition::or_segments({3, 100}, 12));
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -529,4 +529,43 @@ TEST(ActivationConditionTest, EffectiveGroupSize) {
             2);
 }
 
+TEST(ActivationConditionTest, NonCompositeSuperset) {
+  EXPECT_EQ(
+    ActivationCondition::True(12).NonCompositeSuperset(),
+    ActivationCondition::True(12));
+
+  EXPECT_EQ(
+    ActivationCondition::exclusive_segment(12, 14).NonCompositeSuperset(),
+    ActivationCondition::exclusive_segment(12, 14));
+
+  EXPECT_EQ(
+    ActivationCondition::or_segments({2, 8, 21}, 12).NonCompositeSuperset(),
+    ActivationCondition::or_segments({2, 8, 21}, 12));
+
+  EXPECT_EQ(
+    ActivationCondition::and_segments({2, 8, 21}, 12).NonCompositeSuperset(),
+    ActivationCondition::and_segments({2, 8, 21}, 12));
+
+  // Picks the single segment subgroups
+  EXPECT_EQ(
+    ActivationCondition::composite_condition({{0, 1}, {1, 7}, {3}}, 12).NonCompositeSuperset(),
+    ActivationCondition::exclusive_segment(3, 12));
+  EXPECT_EQ(
+    ActivationCondition::composite_condition({{0, 1}, {1, 7}, {3}, {8}}, 12).NonCompositeSuperset(),
+    ActivationCondition::and_segments({3, 8}, 12));
+
+  // Picks one subgroup (largest min segment and smallest size)
+  EXPECT_EQ(
+    ActivationCondition::composite_condition({{0, 1}, {3, 100}, {8, 9}, {2, 1}}, 12).NonCompositeSuperset(),
+    ActivationCondition::or_segments({8, 9}, 12));
+
+  // if min segment is tied then the smaller group is prefered
+  EXPECT_EQ(
+    ActivationCondition::composite_condition({{0, 1}, {3, 4, 5}, {3, 100}}, 12).NonCompositeSuperset(),
+    ActivationCondition::or_segments({3, 100}, 12));
+  EXPECT_EQ(
+    ActivationCondition::composite_condition({{3, 100}, {0, 1}, {3, 4, 5}}, 12).NonCompositeSuperset(),
+    ActivationCondition::or_segments({3, 100}, 12));
+}
+
 }  // namespace ift::encoder

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -748,6 +748,10 @@ CandidateMerge::ComputePatchMergeDetails(
 
   ActivationCondition merged_condition =
       ActivationCondition::Or(condition_a, condition_b);
+  if (merger.Context().GetConditionAnalysisMode() == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION) {
+    // Merged condition will be simplified, so do the same here.
+    merged_condition = merged_condition.NonCompositeSuperset();
+  }
 
   GlyphSet existing_glyphs;
   auto existing_condition =
@@ -928,7 +932,7 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessSegmentMerge(
   uint32_t new_patch_size = 0;
   std::optional<GlyphSet> exclusive_gids;
   if (!merger.Strategy().UseCosts() ||
-      merger.Context().GetConditionAnalysisMode() != config::DEP_GRAPH_ONLY) {
+      !merger.Context().IsPureDepGraphAnalysisMode()) {
     if (!segments_to_merge_are_inert) {
       // When we're not in pure depgraph mode then glyph conditions are
       // incomplete. To help improve accuracy run a closure to find the new set

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -721,8 +721,9 @@ StatusOr<CandidateMerge::PatchMergeDetails>
 CandidateMerge::ComputePatchMergeDetails(
     const Merger& merger, const ActivationCondition& condition_a,
     const ActivationCondition& condition_b) {
-  const auto& condition_and_glyphs =
-      merger.Context().glyph_groupings.ConditionsAndGlyphs();
+
+  const auto& glyph_groupings = merger.Context().glyph_groupings;
+  const auto& condition_and_glyphs = glyph_groupings.ConditionsAndGlyphs();
 
   auto glyphs_a_it = condition_and_glyphs.find(condition_a);
   auto glyphs_b_it = condition_and_glyphs.find(condition_b);
@@ -746,8 +747,29 @@ CandidateMerge::ComputePatchMergeDetails(
   GlyphSet merged_glyphs = glyphs_a;
   merged_glyphs.union_set(glyphs_b);
 
-  ActivationCondition merged_condition =
-      ActivationCondition::Or(condition_a, condition_b);
+  // When computing the new merged condition utilize the original pre-combination conditions.
+  // Doing it this way avoids applying simplification multiple times which could result in
+  // a different merged condition (since condition_a and condition_b may already be merged + simplified).
+  flat_hash_set<ActivationCondition> original_conditions;
+  for (glyph_id_t g : merged_glyphs) {
+    auto condition = glyph_groupings.GlyphToConditionPrecombination(g);
+    if (!condition.has_value()) {
+      return absl::InternalError(absl::StrCat("Cannot find precombination condition for g", g));
+    }
+    original_conditions.insert(*condition);
+  }
+
+  if (original_conditions.empty()) {
+    return absl::InternalError(absl::StrCat("Unexpected empty original conditions."));
+  }
+
+  auto it = original_conditions.begin();
+  ActivationCondition merged_condition = *it++;
+  while (it != original_conditions.end()) {
+    merged_condition = ActivationCondition::Or(merged_condition, *it);
+    it++;
+  }
+
   if (merger.Context().GetConditionAnalysisMode() == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION) {
     // Merged condition will be simplified, so do the same here.
     merged_condition = merged_condition.NonCompositeSuperset();
@@ -760,7 +782,6 @@ CandidateMerge::ComputePatchMergeDetails(
   if (existing_condition !=
       merger.Context().glyph_groupings.ConditionsAndGlyphs().end()) {
     existing_glyphs = existing_condition->second;
-    merged_glyphs.union_set(existing_condition->second);
   }
 
   // It's possible for the new condition to be equal to one of the input
@@ -820,8 +841,10 @@ StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(
                      Merger::BEST_CASE_MERGE_SIZE_DELTA);
     merged_patch_size = max_size + extra;
   } else {
+    GlyphSet merged_patch_glyphs = glyphs_merged;
+    merged_patch_glyphs.union_set(glyphs_existing);
     merged_patch_size =
-        TRY(merger.Context().patch_size_cache->GetPatchSize(glyphs_merged));
+        TRY(merger.Context().patch_size_cache->GetPatchSize(merged_patch_glyphs));
   }
 
   size_a += network_overhead;
@@ -1005,8 +1028,10 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
     }
   }
 
+  GlyphSet new_patch_glyphs = details.glyphs_merged;
+  new_patch_glyphs.union_set(details.glyphs_existing);
   uint32_t new_patch_size = TRY(
-      merger.Context().patch_size_cache->GetPatchSize(details.glyphs_merged));
+      merger.Context().patch_size_cache->GetPatchSize(new_patch_glyphs));
 
   if (!merger.Strategy().UseCosts() &&
       new_patch_size > merger.Strategy().PatchSizeMaxBytes()) {

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -721,7 +721,6 @@ StatusOr<CandidateMerge::PatchMergeDetails>
 CandidateMerge::ComputePatchMergeDetails(
     const Merger& merger, const ActivationCondition& condition_a,
     const ActivationCondition& condition_b) {
-
   const auto& glyph_groupings = merger.Context().glyph_groupings;
   const auto& condition_and_glyphs = glyph_groupings.ConditionsAndGlyphs();
 
@@ -747,20 +746,24 @@ CandidateMerge::ComputePatchMergeDetails(
   GlyphSet merged_glyphs = glyphs_a;
   merged_glyphs.union_set(glyphs_b);
 
-  // When computing the new merged condition utilize the original pre-combination conditions.
-  // Doing it this way avoids applying simplification multiple times which could result in
-  // a different merged condition (since condition_a and condition_b may already be merged + simplified).
+  // When computing the new merged condition utilize the original
+  // pre-combination conditions. Doing it this way avoids applying
+  // simplification multiple times which could result in a different merged
+  // condition (since condition_a and condition_b may already be merged +
+  // simplified).
   flat_hash_set<ActivationCondition> original_conditions;
   for (glyph_id_t g : merged_glyphs) {
     auto condition = glyph_groupings.GlyphToConditionPrecombination(g);
     if (!condition.has_value()) {
-      return absl::InternalError(absl::StrCat("Cannot find precombination condition for g", g));
+      return absl::InternalError(
+          absl::StrCat("Cannot find precombination condition for g", g));
     }
     original_conditions.insert(*condition);
   }
 
   if (original_conditions.empty()) {
-    return absl::InternalError(absl::StrCat("Unexpected empty original conditions."));
+    return absl::InternalError(
+        absl::StrCat("Unexpected empty original conditions."));
   }
 
   auto it = original_conditions.begin();
@@ -770,7 +773,8 @@ CandidateMerge::ComputePatchMergeDetails(
     it++;
   }
 
-  if (merger.Context().GetConditionAnalysisMode() == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION) {
+  if (merger.Context().GetConditionAnalysisMode() ==
+      config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION) {
     // Merged condition will be simplified, so do the same here.
     merged_condition = merged_condition.NonCompositeSuperset();
   }
@@ -843,8 +847,8 @@ StatusOr<double> CandidateMerge::PatchMergeDetails::ComputePatchMergeCostDelta(
   } else {
     GlyphSet merged_patch_glyphs = glyphs_merged;
     merged_patch_glyphs.union_set(glyphs_existing);
-    merged_patch_size =
-        TRY(merger.Context().patch_size_cache->GetPatchSize(merged_patch_glyphs));
+    merged_patch_size = TRY(
+        merger.Context().patch_size_cache->GetPatchSize(merged_patch_glyphs));
   }
 
   size_a += network_overhead;
@@ -1030,8 +1034,8 @@ StatusOr<std::optional<CandidateMerge>> CandidateMerge::AssessPatchMerge(
 
   GlyphSet new_patch_glyphs = details.glyphs_merged;
   new_patch_glyphs.union_set(details.glyphs_existing);
-  uint32_t new_patch_size = TRY(
-      merger.Context().patch_size_cache->GetPatchSize(new_patch_glyphs));
+  uint32_t new_patch_size =
+      TRY(merger.Context().patch_size_cache->GetPatchSize(new_patch_glyphs));
 
   if (!merger.Strategy().UseCosts() &&
       new_patch_size > merger.Strategy().PatchSizeMaxBytes()) {

--- a/ift/encoder/candidate_merge_test.cc
+++ b/ift/encoder/candidate_merge_test.cc
@@ -572,7 +572,8 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive_WithSimplification) {
 
   MockPatchSizeCache* size_cache = new MockPatchSizeCache();
 
-  ClosureGlyphSegmenter segmenter(8, 8, PATCH, DEP_GRAPH_ONLY_WITH_SIMPLIFICATION, resolver);
+  ClosureGlyphSegmenter segmenter(8, 8, PATCH,
+                                  DEP_GRAPH_ONLY_WITH_SIMPLIFICATION, resolver);
   auto context = SegmentationContext::InitializeSegmentationContext(
       roboto.get(), {}, segments, segmenter.unmapped_glyph_handling(),
       segmenter.condition_analysis_mode(), segmenter.brotli_quality(),
@@ -608,7 +609,8 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive_WithSimplification) {
 
   context->patch_size_cache.reset(size_cache);
 
-  // s0 merge with (s1 AND s2) => (s0 OR s1) AND (s0 OR s2) =simplifies=> (s0 or s1)
+  // s0 merge with (s1 AND s2) => (s0 OR s1) AND (s0 OR s2) =simplifies=> (s0 or
+  // s1)
   auto r = CandidateMerge::AssessPatchMerge(
       merger, ActivationCondition::exclusive_segment(0, 0), conj_cond,
       std::nullopt);
@@ -629,9 +631,8 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive_WithSimplification) {
   ASSERT_TRUE(s.ok()) << s.status();
 
   // gid A and gid B should now be in the same partition.
-  ASSERT_EQ(
-    *context->glyph_groupings.CombinedPatches().Find(gid_A),
-    *context->glyph_groupings.CombinedPatches().Find(gid_B));
+  ASSERT_EQ(*context->glyph_groupings.CombinedPatches().Find(gid_A),
+            *context->glyph_groupings.CombinedPatches().Find(gid_B));
 }
 #endif
 

--- a/ift/encoder/candidate_merge_test.cc
+++ b/ift/encoder/candidate_merge_test.cc
@@ -23,6 +23,7 @@ using absl::flat_hash_map;
 
 using ift::config::CLOSURE_ONLY;
 using ift::config::DEP_GRAPH_ONLY;
+using ift::config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION;
 using ift::config::PATCH;
 
 using ift::common::BazelDataFileResolver;
@@ -517,7 +518,7 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
   glyph_id_t gid_B = *FontHelper::GetNominalGlyph(roboto.get(), 'B');
   size_cache->SetPatchSize({gid_B}, 200);
 
-  // Manually set up a conjunctive condition for gid_d: s1 AND s2.
+  // Manually set up a conjunctive condition for gid_B: s1 AND s2.
   context->glyph_condition_set.AddAndCondition(gid_B, 1);
   context->glyph_condition_set.AddAndCondition(gid_B, 2);
 
@@ -535,10 +536,6 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
       *context->glyph_closure_cache, std::nullopt, {gid_A, gid_B}, {0, 1, 2},
       false);
   ASSERT_TRUE(sc.ok()) << sc;
-
-  for (const auto& [c, g] : context->glyph_groupings.ConditionsAndGlyphs()) {
-    std::cerr << c.ToString() << " => " << g.ToString() << std::endl;
-  }
 
   context->patch_size_cache.reset(size_cache);
 
@@ -558,6 +555,85 @@ TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive) {
   CandidateMerge merge = **r;
   ASSERT_EQ(merge.SegmentsToMerge(), SegmentSet({0, 1, 2}));
 }
+
+#ifdef HB_DEPEND_API
+TEST_F(CandidateMergeTest, AssessPatchMerge_NonDisjunctive_WithSimplification) {
+  std::vector<Segment> segments = {
+      {{'A'}, ProbabilityBound{0.95, 0.95}},
+      {{'B'}, ProbabilityBound{0.85, 0.85}},
+      {{'C'}, ProbabilityBound{0.75, 0.75}},
+  };
+  std::vector<Segment> segments_with_merges = segments;
+  segments_with_merges.push_back({{'A', 'B'}, ProbabilityBound{0.90, 0.90}});
+  segments_with_merges.push_back({{'A', 'C'}, ProbabilityBound{0.92, 0.92}});
+
+  auto probability_calculator =
+      std::make_unique<freq::MockProbabilityCalculator>(segments_with_merges);
+
+  MockPatchSizeCache* size_cache = new MockPatchSizeCache();
+
+  ClosureGlyphSegmenter segmenter(8, 8, PATCH, DEP_GRAPH_ONLY_WITH_SIMPLIFICATION, resolver);
+  auto context = SegmentationContext::InitializeSegmentationContext(
+      roboto.get(), {}, segments, segmenter.unmapped_glyph_handling(),
+      segmenter.condition_analysis_mode(), segmenter.brotli_quality(),
+      segmenter.init_font_merging_brotli_quality(), resolver);
+  ASSERT_TRUE(context.ok()) << context.status();
+
+  Merger merger = *Merger::New(
+      *context,
+      MergeStrategy::CostBased(std::move(probability_calculator), 75, 1), all,
+      all);
+
+  glyph_id_t gid_B = *FontHelper::GetNominalGlyph(roboto.get(), 'B');
+  size_cache->SetPatchSize({gid_B}, 200);
+
+  // Manually set up a conjunctive condition for gid_B: s1 AND s2.
+  context->glyph_condition_set.AddAndCondition(gid_B, 1);
+  context->glyph_condition_set.AddAndCondition(gid_B, 2);
+
+  ActivationCondition conj_cond = ActivationCondition::and_segments({1, 2}, 0);
+
+  // We also need a base patch to exist.
+  glyph_id_t gid_A = *FontHelper::GetNominalGlyph(roboto.get(), 'A');
+  size_cache->SetPatchSize({gid_A}, 100);
+  size_cache->SetPatchSize({gid_A, gid_B}, 250);
+  context->glyph_condition_set.AddAndCondition(gid_A, 0);
+
+  // Update glyph groupings.
+  auto sc = context->glyph_groupings.GroupGlyphs(
+      context->SegmentationInfo(), context->glyph_condition_set,
+      *context->glyph_closure_cache, std::nullopt, {gid_A, gid_B}, {0, 1, 2},
+      false);
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  context->patch_size_cache.reset(size_cache);
+
+  // s0 merge with (s1 AND s2) => (s0 OR s1) AND (s0 OR s2) =simplifies=> (s0 or s1)
+  auto r = CandidateMerge::AssessPatchMerge(
+      merger, ActivationCondition::exclusive_segment(0, 0), conj_cond,
+      std::nullopt);
+  ASSERT_TRUE(r.ok()) << r.status();
+  ASSERT_TRUE(r->has_value());
+
+  // Delta =
+  // - (s0) * (size(gid_A) + 75)
+  // - (s1 AND s2) * (size(gid_B) + 75)
+  // + (s0 OR s1)) * (size(gid_A, gid_b) + 75)
+  ASSERT_EQ((*r)->CostDelta(), -0.95 * (100 + 75) - (0.85 * 0.75) * (200 + 75) +
+                                   (0.90) * (250 + 75));
+
+  CandidateMerge merge = **r;
+  ASSERT_EQ(merge.SegmentsToMerge(), SegmentSet({0, 1, 2}));
+
+  auto s = merge.Apply(merger);
+  ASSERT_TRUE(s.ok()) << s.status();
+
+  // gid A and gid B should now be in the same partition.
+  ASSERT_EQ(
+    *context->glyph_groupings.CombinedPatches().Find(gid_A),
+    *context->glyph_groupings.CombinedPatches().Find(gid_B));
+}
+#endif
 
 TEST_F(CandidateMergeTest, ComputeInitFontCostDelta) {
   std::vector<Segment> segments = {

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -60,7 +60,8 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
         segmenter_dep_graph(8, 8, PATCH, CLOSURE_AND_VALIDATE_DEP_GRAPH,
                             resolver),
         segmenter_dep_graph_only(8, 8, PATCH, DEP_GRAPH_ONLY, resolver),
-        segmenter_dep_graph_only_with_simplification(8, 8, PATCH, DEP_GRAPH_ONLY_WITH_SIMPLIFICATION, resolver),
+        segmenter_dep_graph_only_with_simplification(
+            8, 8, PATCH, DEP_GRAPH_ONLY_WITH_SIMPLIFICATION, resolver),
         segmenter_find_conditions_dep_graph(
             8, 8, FIND_CONDITIONS, CLOSURE_AND_VALIDATE_DEP_GRAPH, resolver),
         segmenter_move_to_init_font_dep_graph(
@@ -68,7 +69,8 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
 #else
         segmenter_dep_graph(8, 8, PATCH, CLOSURE_ONLY, resolver),
         segmenter_dep_graph_only(8, 8, PATCH, CLOSURE_ONLY, resolver),
-        segmenter_dep_graph_only_with_simplification(8, 8, PATCH, CLOSURE_ONLY, resolver),
+        segmenter_dep_graph_only_with_simplification(8, 8, PATCH, CLOSURE_ONLY,
+                                                     resolver),
         segmenter_find_conditions_dep_graph(8, 8, FIND_CONDITIONS, CLOSURE_ONLY,
                                             resolver),
         segmenter_move_to_init_font_dep_graph(8, 8, MOVE_TO_INIT_FONT,
@@ -687,9 +689,10 @@ if ((s1 OR s2) AND (s3 OR s4)) then p9
 }
 
 TEST_F(ClosureGlyphSegmenterTest, DepGraphOnly_WithSimplification) {
-  auto segmentation = segmenter_dep_graph_only_with_simplification.CodepointToGlyphSegments(
-      noto_nastaliq_urdu.get(), {},
-      {{0x20}, {0x62a}, {0x62b}, {0x62c}, {0x62d}});
+  auto segmentation =
+      segmenter_dep_graph_only_with_simplification.CodepointToGlyphSegments(
+          noto_nastaliq_urdu.get(), {},
+          {{0x20}, {0x62a}, {0x62b}, {0x62c}, {0x62d}});
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
   ASSERT_TRUE(segmentation->UnmappedGlyphs().empty())
@@ -1174,9 +1177,12 @@ TEST_F(ClosureGlyphSegmenterTest, PatchMerge_WithSimplification) {
   strategy.SetUsePatchMerges(true);
 
   auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
-      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}}, strategy);
-  auto segmentation_with_simplification = segmenter_dep_graph_only_with_simplification.CodepointToGlyphSegments(
-      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}}, strategy);
+      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}},
+      strategy);
+  auto segmentation_with_simplification =
+      segmenter_dep_graph_only_with_simplification.CodepointToGlyphSegments(
+          noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}},
+          strategy);
 
   ASSERT_TRUE(segmentation.ok()) << segmentation.status();
 
@@ -1214,7 +1220,6 @@ if (s3) then p3
 if ((s2 OR s3)) then p4
 if ((s0 OR s1 OR s2 OR s3)) then p5
 )");
-
 }
 #endif
 

--- a/ift/encoder/closure_glyph_segmenter_test.cc
+++ b/ift/encoder/closure_glyph_segmenter_test.cc
@@ -20,6 +20,7 @@
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
 using ift::config::CLOSURE_ONLY;
 using ift::config::DEP_GRAPH_ONLY;
+using ift::config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION;
 using ift::config::FIND_CONDITIONS;
 using ift::config::MOVE_TO_INIT_FONT;
 using ift::config::PATCH;
@@ -59,6 +60,7 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
         segmenter_dep_graph(8, 8, PATCH, CLOSURE_AND_VALIDATE_DEP_GRAPH,
                             resolver),
         segmenter_dep_graph_only(8, 8, PATCH, DEP_GRAPH_ONLY, resolver),
+        segmenter_dep_graph_only_with_simplification(8, 8, PATCH, DEP_GRAPH_ONLY_WITH_SIMPLIFICATION, resolver),
         segmenter_find_conditions_dep_graph(
             8, 8, FIND_CONDITIONS, CLOSURE_AND_VALIDATE_DEP_GRAPH, resolver),
         segmenter_move_to_init_font_dep_graph(
@@ -66,6 +68,7 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
 #else
         segmenter_dep_graph(8, 8, PATCH, CLOSURE_ONLY, resolver),
         segmenter_dep_graph_only(8, 8, PATCH, CLOSURE_ONLY, resolver),
+        segmenter_dep_graph_only_with_simplification(8, 8, PATCH, CLOSURE_ONLY, resolver),
         segmenter_find_conditions_dep_graph(8, 8, FIND_CONDITIONS, CLOSURE_ONLY,
                                             resolver),
         segmenter_move_to_init_font_dep_graph(8, 8, MOVE_TO_INIT_FONT,
@@ -191,6 +194,7 @@ class ClosureGlyphSegmenterTest : public ::testing::Test {
   ClosureGlyphSegmenter segmenter_move_to_init_font;
   ClosureGlyphSegmenter segmenter_dep_graph;
   ClosureGlyphSegmenter segmenter_dep_graph_only;
+  ClosureGlyphSegmenter segmenter_dep_graph_only_with_simplification;
   ClosureGlyphSegmenter segmenter_find_conditions_dep_graph;
   ClosureGlyphSegmenter segmenter_move_to_init_font_dep_graph;
 };
@@ -681,6 +685,36 @@ if ((s1 OR s2) AND s3) then p8
 if ((s1 OR s2) AND (s3 OR s4)) then p9
 )");
 }
+
+TEST_F(ClosureGlyphSegmenterTest, DepGraphOnly_WithSimplification) {
+  auto segmentation = segmenter_dep_graph_only_with_simplification.CodepointToGlyphSegments(
+      noto_nastaliq_urdu.get(), {},
+      {{0x20}, {0x62a}, {0x62b}, {0x62c}, {0x62d}});
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  ASSERT_TRUE(segmentation->UnmappedGlyphs().empty())
+      << segmentation->UnmappedGlyphs().ToString();
+
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid1 }
+p1: { gid3, gid9, gid155 }
+p2: { gid4, gid10, gid156 }
+p3: { gid5, gid6, gid11, gid157 }
+p4: { gid158 }
+p5: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid64, gid68, gid77, gid139, gid140, gid153, gid172 }
+p6: { gid14, gid33, gid47, gid60, gid73, gid74, gid75, gid76, gid83, gid91, gid111, gid112, gid145, gid149, gid152, gid190, gid191 }
+p7: { gid174 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+if (s3) then p3
+if (s4) then p4
+if ((s1 OR s2)) then p5
+if ((s3 OR s4)) then p6
+if ((s1 OR s2 OR s3 OR s4)) then p7
+)");
+}
 #endif
 
 TEST_F(ClosureGlyphSegmenterTest, UnmappedGlyphs_FindConditions_IsFallback) {
@@ -1125,6 +1159,64 @@ if ((s0 OR s1 OR s2 OR s3)) then p2
 )");
 #endif
 }
+
+#ifdef HB_DEPEND_API
+TEST_F(ClosureGlyphSegmenterTest, PatchMerge_WithSimplification) {
+  UnicodeFrequencies frequencies{
+      {{0x62a, 0x62a}, 100},
+      {{0x62b, 0x62b}, 10},
+      {{0x62c, 0x62c}, 1},
+      {{0x62d, 0x62d}, 1},
+  };
+  MergeStrategy strategy =
+      *MergeStrategy::CostBased(std::move(frequencies), 75, 1);
+  strategy.SetOptimizationCutoffFraction(0.0);
+  strategy.SetUsePatchMerges(true);
+
+  auto segmentation = segmenter_dep_graph_only.CodepointToGlyphSegments(
+      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}}, strategy);
+  auto segmentation_with_simplification = segmenter_dep_graph_only_with_simplification.CodepointToGlyphSegments(
+      noto_nastaliq_urdu.get(), {}, {{0x62a}, {0x62b}, {0x62c}, {0x62d}}, strategy);
+
+  ASSERT_TRUE(segmentation.ok()) << segmentation.status();
+
+  ASSERT_EQ(segmentation->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid3, gid9, gid155 }
+p1: { gid4, gid10, gid156 }
+p2: { gid5, gid6, gid157 }
+p3: { gid158 }
+p4: { gid14, gid33, gid47, gid60, gid73, gid74, gid75, gid76, gid83, gid91, gid111, gid112, gid145, gid149, gid152, gid190, gid191 }
+p5: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid64, gid68, gid77, gid139, gid140, gid153, gid172, gid174 }
+p6: { gid11 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+if (s3) then p3
+if ((s2 OR s3)) then p4
+if ((s0 OR s1 OR s2 OR s3)) then p5
+if ((s0 OR s1) AND s2) then p6
+)");
+
+  // With simplification there's no more composite conditions:
+  ASSERT_EQ(segmentation_with_simplification->ToString(),
+            R"(initial font: { gid0 }
+p0: { gid3, gid9, gid155 }
+p1: { gid4, gid10, gid156 }
+p2: { gid5, gid6, gid11, gid157 }
+p3: { gid158 }
+p4: { gid14, gid33, gid47, gid60, gid73, gid74, gid75, gid76, gid83, gid91, gid111, gid112, gid145, gid149, gid152, gid190, gid191 }
+p5: { gid12, gid13, gid24, gid30, gid38, gid39, gid57, gid59, gid62, gid64, gid68, gid77, gid139, gid140, gid153, gid172, gid174 }
+if (s0) then p0
+if (s1) then p1
+if (s2) then p2
+if (s3) then p3
+if ((s2 OR s3)) then p4
+if ((s0 OR s1 OR s2 OR s3)) then p5
+)");
+
+}
+#endif
 
 TEST_F(ClosureGlyphSegmenterTest, SimpleSegmentation_NoCostCutoff) {
   UnicodeFrequencies frequencies{

--- a/ift/encoder/condition_to_glyphs_index.h
+++ b/ift/encoder/condition_to_glyphs_index.h
@@ -4,6 +4,7 @@
 #include <optional>
 
 #include "absl/container/btree_set.h"
+#include "absl/strings/str_cat.h"
 #include "ift/common/int_set.h"
 #include "ift/encoder/activation_condition.h"
 #include "ift/encoder/types.h"
@@ -84,7 +85,10 @@ class ConditionToGlyphsIndex {
           glyph_to_condition_.insert(std::pair(gid, condition));
       if (!did_insert && it->second != condition) {
         return absl::InternalError(
-            "glyph_to_condition mapping does not match existing one.");
+            absl::StrCat("glyph_to_condition mapping for g", gid,
+                         " does not match existing one. New condition = ",
+                         condition.ToString(),
+                         ", existing condition = ", it->second.ToString()));
       }
     }
 

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -466,6 +466,18 @@ Status GlyphGroupings::RecomputeCombinedConditions() {
     // with an existing patch that has the same condition.
     TRYV(UnionConditionAndGlyphs(condition, gids, false));
     combined_conditions_.insert(condition);
+
+    // There may be precombination conditions that happen to have the same
+    // condition as this merged conditions. We need to also pull those glyphs
+    // into the final combined condition mapping as well if they are not,
+    // yet included via the combination analysis.
+    auto it = conditions_and_glyphs_pre_combination_.ConditionsAndGlyphs().find(
+        condition);
+    if (it !=
+        conditions_and_glyphs_pre_combination_.ConditionsAndGlyphs().end() &&
+        !affected_conditions.contains(condition)) {
+      TRYV(UnionConditionAndGlyphs(condition, it->second, false));
+    }
   }
 
   combined_patches_dirty_ = false;

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -30,9 +30,15 @@ void GlyphGroupings::InvalidateGlyphInformation(uint32_t gid) {
   unmapped_glyphs_.erase(gid);
   found_condition_glyphs_.erase(gid);
 
-  conditions_and_glyphs_.Invalidate(gid);
+  std::optional<ActivationCondition> post_combination_condition_or =
+      conditions_and_glyphs_.Invalidate(gid);
   std::optional<ActivationCondition> pre_combination_condition_or =
       conditions_and_glyphs_pre_combination_.Invalidate(gid);
+
+  if (post_combination_condition_or.has_value() &&
+      combined_conditions_.contains(*post_combination_condition_or)) {
+    RemoveAllCombinedConditions();
+  }
 
   if (!pre_combination_condition_or.has_value()) {
     return;
@@ -440,9 +446,6 @@ Status GlyphGroupings::RecomputeCombinedConditions() {
       auto [it, inserted] = merged_conditions.insert({rep, cond});
       if (!inserted) {
         it->second = ActivationCondition::Or(it->second, cond);
-        if (simplify_combined_) {
-          it->second = it->second.NonCompositeSuperset();
-        }
       }
       merged_glyphs[rep].union_set(gids);
     } else {
@@ -450,10 +453,18 @@ Status GlyphGroupings::RecomputeCombinedConditions() {
     }
   }
 
+  if (simplify_combined_) {
+    for (auto& cond : merged_conditions) {
+      cond.second = cond.second.NonCompositeSuperset();
+    }
+  }
+
   // Add the new combined conditions.
   for (const auto& [rep, condition] : merged_conditions) {
     const GlyphSet& gids = merged_glyphs.at(rep);
-    TRYV(AddConditionAndGlyphs(condition, gids, false));
+    // Union is used here because the merged condition may collide
+    // with an existing patch that has the same condition.
+    TRYV(UnionConditionAndGlyphs(condition, gids, false));
     combined_conditions_.insert(condition);
   }
 

--- a/ift/encoder/glyph_groupings.cc
+++ b/ift/encoder/glyph_groupings.cc
@@ -440,6 +440,9 @@ Status GlyphGroupings::RecomputeCombinedConditions() {
       auto [it, inserted] = merged_conditions.insert({rep, cond});
       if (!inserted) {
         it->second = ActivationCondition::Or(it->second, cond);
+        if (simplify_combined_) {
+          it->second = it->second.NonCompositeSuperset();
+        }
       }
       merged_glyphs[rep].union_set(gids);
     } else {

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -3,7 +3,6 @@
 
 #include <cstdint>
 
-#include "absl/container/btree_map.h"
 #include "absl/container/btree_set.h"
 #include "absl/container/flat_hash_set.h"
 #include "ift/common/int_set.h"
@@ -24,12 +23,13 @@ namespace ift::encoder {
  */
 class GlyphGroupings {
  public:
-  GlyphGroupings(uint32_t glyph_count) : combined_patches_(glyph_count) {}
+  GlyphGroupings(uint32_t glyph_count, bool simplify_combined = false) : combined_patches_(glyph_count), simplify_combined_(simplify_combined) {}
 
   bool operator==(const GlyphGroupings& other) {
     return or_glyph_groups_ == other.or_glyph_groups_ &&
            exclusive_glyph_groups_ == other.exclusive_glyph_groups_ &&
            combined_conditions_ == other.combined_conditions_ &&
+           simplify_combined_ == other.simplify_combined_ &&
            conditions_and_glyphs_ == other.conditions_and_glyphs_ &&
            conditions_and_glyphs_pre_combination_ ==
                other.conditions_and_glyphs_pre_combination_ &&
@@ -255,6 +255,7 @@ class GlyphGroupings {
   // can't be joined together in the same fashion.
   GlyphPartition combined_patches_;
   bool combined_patches_dirty_ = false;
+  bool simplify_combined_;
 
   absl::flat_hash_map<ift::common::SegmentSet, ift::common::GlyphSet>
       or_glyph_groups_;

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -43,6 +43,11 @@ class GlyphGroupings {
     return conditions_and_glyphs_.ConditionsAndGlyphs();
   }
 
+  const absl::flat_hash_map<ActivationCondition, ift::common::GlyphSet>&
+  ConditionsAndGlyphsPreCombination() const {
+    return conditions_and_glyphs_pre_combination_.ConditionsAndGlyphs();
+  }
+
   const absl::btree_set<ActivationCondition>& OrderedConditions() const {
     return conditions_and_glyphs_.OrderedConditions();
   }
@@ -155,6 +160,15 @@ class GlyphGroupings {
     return it->second;
   }
 
+  std::optional<ActivationCondition> GlyphToConditionPrecombination(glyph_id_t gid) const {
+    auto it = conditions_and_glyphs_pre_combination_.GlyphToCondition().find(gid);
+    if (it == conditions_and_glyphs_pre_combination_.GlyphToCondition().end()) {
+      return std::nullopt;
+    }
+
+    return it->second;
+  }
+
  private:
   void CollectSegments(glyph_id_t gid, ift::common::SegmentSet& segments);
 
@@ -223,14 +237,17 @@ class GlyphGroupings {
     if (pre_combination) {
       TRYV(conditions_and_glyphs_pre_combination_.Add(condition, glyphs));
     }
-
     return absl::OkStatus();
   }
 
   absl::Status UnionConditionAndGlyphs(ActivationCondition condition,
-                                       ift::common::GlyphSet glyphs) {
+                                       ift::common::GlyphSet glyphs,
+                                       bool pre_combination = true) {
     TRYV(conditions_and_glyphs_.Union(condition, glyphs));
-    return conditions_and_glyphs_pre_combination_.Union(condition, glyphs);
+    if (pre_combination) {
+      TRYV(conditions_and_glyphs_pre_combination_.Union(condition, glyphs));
+    }
+    return absl::OkStatus();
   }
 
   void RemoveConditionAndGlyphs(ActivationCondition condition,

--- a/ift/encoder/glyph_groupings.h
+++ b/ift/encoder/glyph_groupings.h
@@ -23,7 +23,8 @@ namespace ift::encoder {
  */
 class GlyphGroupings {
  public:
-  GlyphGroupings(uint32_t glyph_count, bool simplify_combined = false) : combined_patches_(glyph_count), simplify_combined_(simplify_combined) {}
+  GlyphGroupings(uint32_t glyph_count, bool simplify_combined = false)
+      : combined_patches_(glyph_count), simplify_combined_(simplify_combined) {}
 
   bool operator==(const GlyphGroupings& other) {
     return or_glyph_groups_ == other.or_glyph_groups_ &&
@@ -160,8 +161,10 @@ class GlyphGroupings {
     return it->second;
   }
 
-  std::optional<ActivationCondition> GlyphToConditionPrecombination(glyph_id_t gid) const {
-    auto it = conditions_and_glyphs_pre_combination_.GlyphToCondition().find(gid);
+  std::optional<ActivationCondition> GlyphToConditionPrecombination(
+      glyph_id_t gid) const {
+    auto it =
+        conditions_and_glyphs_pre_combination_.GlyphToCondition().find(gid);
     if (it == conditions_and_glyphs_pre_combination_.GlyphToCondition().end()) {
       return std::nullopt;
     }

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -33,11 +33,11 @@ using ift::common::BazelDataFileResolver;
 using ift::common::CodepointSet;
 using ift::common::DataFileResolver;
 using ift::common::FontData;
+using ift::common::FontHelper;
 using ift::common::GlyphSet;
 using ift::common::hb_face_unique_ptr;
 using ift::common::make_hb_face;
 using ift::common::SegmentSet;
-using ift::common::FontHelper;
 
 void PrintTo(const flat_hash_map<ActivationCondition, GlyphSet>& conditions,
              std::ostream* os) {
@@ -64,7 +64,8 @@ class GlyphGroupingsTest : public ::testing::Test {
         }),
 
         glyph_groupings_(hb_face_get_glyph_count(roboto_.get())),
-        glyph_groupings_simplification_(hb_face_get_glyph_count(roboto_.get()), true),
+        glyph_groupings_simplification_(hb_face_get_glyph_count(roboto_.get()),
+                                        true),
         segments_complex_({
             Segment({0x54}, ProbabilityBound::Zero()),    // s0
             Segment({0x6C}, ProbabilityBound::Zero()),    // s1
@@ -302,12 +303,13 @@ TEST_F(GlyphGroupingsTest, CombinePatches) {
 }
 
 TEST_F(GlyphGroupingsTest, CombinePatches_WithSimpfliciation) {
-  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}), ToGlyphs({'b'}));
+  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}),
+                                                           ToGlyphs({'b'}));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
-                                    *glyph_conditions_, *closure_cache_,
-                                    std::nullopt, glyphs_to_group_, {});
+  sc = glyph_groupings_simplification_.GroupGlyphs(
+      *requested_segmentation_info_, *glyph_conditions_, *closure_cache_,
+      std::nullopt, glyphs_to_group_, {});
   ASSERT_TRUE(sc.ok()) << sc;
 
   // Starting Condition map:
@@ -323,7 +325,8 @@ TEST_F(GlyphGroupingsTest, CombinePatches_WithSimpfliciation) {
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k'})},
       {ActivationCondition::or_segments({3, 4}, 0), ToGlyphs({'g', 'h'})},
-      {ActivationCondition::or_segments({0, 2}, 0), ToGlyphs({'a', 'b', 'e', 'f'})},
+      {ActivationCondition::or_segments({0, 2}, 0),
+       ToGlyphs({'a', 'b', 'e', 'f'})},
       {ActivationCondition::or_segments({2, 3}, 0), ToGlyphs({'j'})},
   };
 
@@ -338,19 +341,21 @@ TEST_F(GlyphGroupingsTest, CombinePatches_SimplificationCollision) {
   glyph_conditions_->AddOrCondition(gid_l, 0);
   glyph_conditions_->AddOrCondition(gid_l, 2);
 
-  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}), ToGlyphs({'b'}));
+  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}),
+                                                           ToGlyphs({'b'}));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
-                                    *glyph_conditions_, *closure_cache_,
-                                    std::nullopt, glyphs_to_group_, {});
+  sc = glyph_groupings_simplification_.GroupGlyphs(
+      *requested_segmentation_info_, *glyph_conditions_, *closure_cache_,
+      std::nullopt, glyphs_to_group_, {});
   ASSERT_TRUE(sc.ok()) << sc;
 
   flat_hash_map<ActivationCondition, GlyphSet> expected = {
       {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
       {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k'})},
       {ActivationCondition::or_segments({3, 4}, 0), ToGlyphs({'g', 'h'})},
-      {ActivationCondition::or_segments({0, 2}, 0), ToGlyphs({'a', 'b', 'e', 'f', 'l'})},
+      {ActivationCondition::or_segments({0, 2}, 0),
+       ToGlyphs({'a', 'b', 'e', 'f', 'l'})},
       {ActivationCondition::or_segments({2, 3}, 0), ToGlyphs({'j'})},
   };
 
@@ -365,18 +370,19 @@ TEST_F(GlyphGroupingsTest, CombinePatches_SimplificationCollisionInvalidation) {
   glyph_conditions_->AddOrCondition(gid_l, 0);
   glyph_conditions_->AddOrCondition(gid_l, 2);
 
-  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}), ToGlyphs({'b'}));
+  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}),
+                                                           ToGlyphs({'b'}));
   ASSERT_TRUE(sc.ok()) << sc;
 
-  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
-                                    *glyph_conditions_, *closure_cache_,
-                                    std::nullopt, glyphs_to_group_, {});
+  sc = glyph_groupings_simplification_.GroupGlyphs(
+      *requested_segmentation_info_, *glyph_conditions_, *closure_cache_,
+      std::nullopt, glyphs_to_group_, {});
   ASSERT_TRUE(sc.ok()) << sc;
 
   // Invalidate 'l' by calling GroupGlyphs with 'l' in the glyphs set.
-  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
-                                    *glyph_conditions_, *closure_cache_,
-                                    std::nullopt, ToGlyphs({'l'}), {});
+  sc = glyph_groupings_simplification_.GroupGlyphs(
+      *requested_segmentation_info_, *glyph_conditions_, *closure_cache_,
+      std::nullopt, ToGlyphs({'l'}), {});
   ASSERT_TRUE(sc.ok()) << sc;
 }
 

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -6,6 +6,7 @@
 #include "gtest/gtest.h"
 #include "ift/common/bazel_data_file_resolver.h"
 #include "ift/common/font_data.h"
+#include "ift/common/font_helper.h"
 #include "ift/common/int_set.h"
 #include "ift/common/test_font_loader.h"
 #include "ift/encoder/activation_condition.h"
@@ -36,6 +37,7 @@ using ift::common::GlyphSet;
 using ift::common::hb_face_unique_ptr;
 using ift::common::make_hb_face;
 using ift::common::SegmentSet;
+using ift::common::FontHelper;
 
 void PrintTo(const flat_hash_map<ActivationCondition, GlyphSet>& conditions,
              std::ostream* os) {
@@ -326,6 +328,56 @@ TEST_F(GlyphGroupingsTest, CombinePatches_WithSimpfliciation) {
   };
 
   ASSERT_EQ(expected, glyph_groupings_simplification_.ConditionsAndGlyphs());
+}
+
+TEST_F(GlyphGroupingsTest, CombinePatches_SimplificationCollision) {
+  glyph_id_t gid_l = *FontHelper::GetNominalGlyph(roboto_.get(), 'l');
+  cp_to_gid_['l'] = gid_l;
+
+  glyphs_to_group_.insert(gid_l);
+  glyph_conditions_->AddOrCondition(gid_l, 0);
+  glyph_conditions_->AddOrCondition(gid_l, 2);
+
+  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}), ToGlyphs({'b'}));
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
+                                    *glyph_conditions_, *closure_cache_,
+                                    std::nullopt, glyphs_to_group_, {});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
+      {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
+      {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k'})},
+      {ActivationCondition::or_segments({3, 4}, 0), ToGlyphs({'g', 'h'})},
+      {ActivationCondition::or_segments({0, 2}, 0), ToGlyphs({'a', 'b', 'e', 'f', 'l'})},
+      {ActivationCondition::or_segments({2, 3}, 0), ToGlyphs({'j'})},
+  };
+
+  ASSERT_EQ(expected, glyph_groupings_simplification_.ConditionsAndGlyphs());
+}
+
+TEST_F(GlyphGroupingsTest, CombinePatches_SimplificationCollisionInvalidation) {
+  glyph_id_t gid_l = *FontHelper::GetNominalGlyph(roboto_.get(), 'l');
+  cp_to_gid_['l'] = gid_l;
+
+  glyphs_to_group_.insert(gid_l);
+  glyph_conditions_->AddOrCondition(gid_l, 0);
+  glyph_conditions_->AddOrCondition(gid_l, 2);
+
+  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}), ToGlyphs({'b'}));
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
+                                    *glyph_conditions_, *closure_cache_,
+                                    std::nullopt, glyphs_to_group_, {});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Invalidate 'l' by calling GroupGlyphs with 'l' in the glyphs set.
+  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
+                                    *glyph_conditions_, *closure_cache_,
+                                    std::nullopt, ToGlyphs({'l'}), {});
+  ASSERT_TRUE(sc.ok()) << sc;
 }
 
 TEST_F(GlyphGroupingsTest, CombinePatches_WithInertSpecialCase) {

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -912,4 +912,53 @@ TEST_F(GlyphGroupingsTest, IncrementalExclusiveConflict) {
                 {expected, {ToGlyph('a'), ToGlyph('b')}}}));
 }
 
+TEST_F(GlyphGroupingsTest,
+       CombinePatches_PreservesMatchingPrecombinationCondition) {
+  // Add a new glyph 'z' with pre-combination condition s0 OR s1
+  hb_font_t* font = hb_font_create(roboto_.get());
+  glyph_id_t gid_z;
+  hb_font_get_nominal_glyph(font, 'z', &gid_z);
+  hb_font_destroy(font);
+
+  glyphs_to_group_.insert(gid_z);
+  glyph_conditions_->AddOrCondition(gid_z, 0);
+  glyph_conditions_->AddOrCondition(gid_z, 1);
+
+  // Initial grouping
+  auto sc = glyph_groupings_.GroupGlyphs(*requested_segmentation_info_,
+                                         *glyph_conditions_, *closure_cache_,
+                                         std::nullopt, glyphs_to_group_, {});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Merge s0 and s1. This will create combined condition s0 OR s1.
+  sc = glyph_groupings_.CombinePatches(ToGlyphs({'a'}), ToGlyphs({'c'}));
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Apply the merge.
+  sc = glyph_groupings_.GroupGlyphs(*requested_segmentation_info_,
+                                    *glyph_conditions_, *closure_cache_,
+                                    std::nullopt, glyphs_to_group_, {});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Trigger another merge that does NOT involve s0 or s1, which will cause
+  // recomputation of combined patches.
+  sc = glyph_groupings_.CombinePatches(ToGlyphs({'g'}), ToGlyphs({'j'}));
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Apply the second merge. Only pass affected glyphs.
+  sc = glyph_groupings_.GroupGlyphs(
+      *requested_segmentation_info_, *glyph_conditions_, *closure_cache_,
+      std::nullopt, ToGlyphs({'g', 'h', 'j'}), {});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Check if 'z' is still in s0 OR s1.
+  auto condition = glyph_groupings_.GlyphToCondition(gid_z);
+  ASSERT_TRUE(condition.has_value());
+  EXPECT_EQ(*condition, ActivationCondition::or_segments({0, 1}, 0));
+
+  auto it = glyph_groupings_.ConditionsAndGlyphs().find(*condition);
+  ASSERT_TRUE(it != glyph_groupings_.ConditionsAndGlyphs().end());
+  EXPECT_TRUE(it->second.contains(gid_z));
+}
+
 }  // namespace ift::encoder

--- a/ift/encoder/glyph_groupings_test.cc
+++ b/ift/encoder/glyph_groupings_test.cc
@@ -62,6 +62,7 @@ class GlyphGroupingsTest : public ::testing::Test {
         }),
 
         glyph_groupings_(hb_face_get_glyph_count(roboto_.get())),
+        glyph_groupings_simplification_(hb_face_get_glyph_count(roboto_.get()), true),
         segments_complex_({
             Segment({0x54}, ProbabilityBound::Zero()),    // s0
             Segment({0x6C}, ProbabilityBound::Zero()),    // s1
@@ -175,6 +176,7 @@ class GlyphGroupingsTest : public ::testing::Test {
   std::vector<Segment> segments_;
   std::unique_ptr<GlyphConditionSet> glyph_conditions_;
   GlyphGroupings glyph_groupings_;
+  GlyphGroupings glyph_groupings_simplification_;
   GlyphSet glyphs_to_group_;
   flat_hash_map<hb_codepoint_t, glyph_id_t> cp_to_gid_;
 
@@ -295,6 +297,35 @@ TEST_F(GlyphGroupingsTest, CombinePatches) {
   };
 
   ASSERT_EQ(expected, glyph_groupings_.ConditionsAndGlyphs());
+}
+
+TEST_F(GlyphGroupingsTest, CombinePatches_WithSimpfliciation) {
+  auto sc = glyph_groupings_simplification_.CombinePatches(ToGlyphs({'e'}), ToGlyphs({'b'}));
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  sc = glyph_groupings_simplification_.GroupGlyphs(*requested_segmentation_info_,
+                                    *glyph_conditions_, *closure_cache_,
+                                    std::nullopt, glyphs_to_group_, {});
+  ASSERT_TRUE(sc.ok()) << sc;
+
+  // Starting Condition map:
+  // ...
+  // if (s0) -> {a, b}
+  // if (s2 AND s3) -> {e, f}
+  // ...
+  //
+  // When combined with simplification it forms the disjunctive superset:
+  //
+  // if ((s0 OR s2) AND (s0 OR s3)) =simplifies=> if (s0 OR s2)
+  flat_hash_map<ActivationCondition, GlyphSet> expected = {
+      {ActivationCondition::exclusive_segment(1, 0), ToGlyphs({'c', 'd'})},
+      {ActivationCondition::exclusive_segment(3, 0), ToGlyphs({'k'})},
+      {ActivationCondition::or_segments({3, 4}, 0), ToGlyphs({'g', 'h'})},
+      {ActivationCondition::or_segments({0, 2}, 0), ToGlyphs({'a', 'b', 'e', 'f'})},
+      {ActivationCondition::or_segments({2, 3}, 0), ToGlyphs({'j'})},
+  };
+
+  ASSERT_EQ(expected, glyph_groupings_simplification_.ConditionsAndGlyphs());
 }
 
 TEST_F(GlyphGroupingsTest, CombinePatches_WithInertSpecialCase) {

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -368,15 +368,15 @@ void SegmentationContext::TransferDependencyGraphGlyphConditions(
     if (condition.IsUnitary()) {
       condition = ActivationCondition::exclusive_segment(
           *condition.TriggeringSegments().begin(), 0);
-    } else if (condition_analysis_mode_ == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION &&
-      !condition.IsPurelyConjunctive() &&
-      !condition.IsPurelyDisjunctive()
-    ) {
-      // In DEP_GRAPH_ONLY_WITH_SIMPLIFICATION mode mixed conditions are simplified into
-      // a disjunctive superset.
-      // TODO(garretrieger): it may be better to do this conversion during dep graph
-      // construction, since it could it some cases reduce the cost of dep graph construction
-      // signficantly.
+    } else if (condition_analysis_mode_ ==
+                   config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION &&
+               !condition.IsPurelyConjunctive() &&
+               !condition.IsPurelyDisjunctive()) {
+      // In DEP_GRAPH_ONLY_WITH_SIMPLIFICATION mode mixed conditions are
+      // simplified into a disjunctive superset.
+      // TODO(garretrieger): it may be better to do this conversion during dep
+      // graph construction, since it could it some cases reduce the cost of dep
+      // graph construction signficantly.
       condition = condition.NonCompositeSuperset();
     }
     glyph_condition_set.SetCondition(g, condition);

--- a/ift/encoder/segmentation_context.cc
+++ b/ift/encoder/segmentation_context.cc
@@ -16,7 +16,6 @@
 using ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH;
 using ift::config::CLOSURE_ONLY;
 using ift::config::ConditionAnalysisMode;
-using ift::config::DEP_GRAPH_ONLY;
 using ift::config::UnmappedGlyphHandling;
 
 using absl::Status;
@@ -83,7 +82,7 @@ Status SegmentationContext::ValidateSegmentation(
 Status SegmentationContext::ReprocessChanged(InvalidationSet modified) {
   segment_index_t last_merged_segment_index = modified.base_segment;
 
-  if (condition_analysis_mode_ != DEP_GRAPH_ONLY) {
+  if (!IsPureDepGraphAnalysisMode()) {
     if (!InertSegments().contains(last_merged_segment_index)) {
       VLOG(1) << "Re-analyzing segment " << last_merged_segment_index
               << " due to merge.";
@@ -107,7 +106,7 @@ Status SegmentationContext::ReprocessChanged(InvalidationSet modified) {
 }
 
 Status SegmentationContext::ReprocessAll() {
-  if (condition_analysis_mode_ != DEP_GRAPH_ONLY) {
+  if (!IsPureDepGraphAnalysisMode()) {
     for (segment_index_t segment_index = 0;
          segment_index < SegmentationInfo().Segments().size();
          segment_index++) {
@@ -225,7 +224,7 @@ Status SegmentationContext::ReassignInitSubset(SubsetDefinition new_def) {
   inert_segments_.subtract(segments_to_reprocess);
 
   // Then reprocess segments:
-  if (condition_analysis_mode_ != DEP_GRAPH_ONLY) {
+  if (!IsPureDepGraphAnalysisMode()) {
     for (segment_index_t segment_index : segments_to_reprocess) {
       TRY(ReprocessSegment(segment_index));
     }
@@ -369,6 +368,16 @@ void SegmentationContext::TransferDependencyGraphGlyphConditions(
     if (condition.IsUnitary()) {
       condition = ActivationCondition::exclusive_segment(
           *condition.TriggeringSegments().begin(), 0);
+    } else if (condition_analysis_mode_ == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION &&
+      !condition.IsPurelyConjunctive() &&
+      !condition.IsPurelyDisjunctive()
+    ) {
+      // In DEP_GRAPH_ONLY_WITH_SIMPLIFICATION mode mixed conditions are simplified into
+      // a disjunctive superset.
+      // TODO(garretrieger): it may be better to do this conversion during dep graph
+      // construction, since it could it some cases reduce the cost of dep graph construction
+      // signficantly.
+      condition = condition.NonCompositeSuperset();
     }
     glyph_condition_set.SetCondition(g, condition);
   }

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -124,17 +124,14 @@ class SegmentationContext {
         segmentation_info_(std::move(segmentation_info)),
         dependency_closure_(std::nullopt),
         glyph_condition_set(hb_face_get_glyph_count(face)),
-        glyph_groupings(hb_face_get_glyph_count(face)),
+        glyph_groupings(hb_face_get_glyph_count(face), condition_analysis_mode == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION),
         brotli_quality_(brotli_quality),
         init_font_brotli_quality_(init_font_brotli_quality),
         condition_analysis_mode_(condition_analysis_mode),
         resolver_(std::move(resolver)) {}
 
   absl::Status InitDependencyClosure() {
-    if ((condition_analysis_mode_ == ift::config::CLOSURE_AND_DEP_GRAPH) ||
-        (condition_analysis_mode_ ==
-         ift::config::CLOSURE_AND_VALIDATE_DEP_GRAPH) ||
-        (condition_analysis_mode_ == ift::config::DEP_GRAPH_ONLY)) {
+    if (UsingDepGraph()) {
       dependency_closure_ = TRY(DependencyClosure::Create(
           segmentation_info_.get(), original_face.get(), *resolver_));
     }
@@ -199,6 +196,28 @@ class SegmentationContext {
 
   ift::config::ConditionAnalysisMode GetConditionAnalysisMode() const {
     return condition_analysis_mode_;
+  }
+
+  bool IsPureDepGraphAnalysisMode() const {
+    switch (condition_analysis_mode_) {
+    case config::DEP_GRAPH_ONLY:
+    case config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION:
+      return true;
+    default:
+      return false;
+    }
+  }
+
+  bool UsingDepGraph() const {
+    switch (condition_analysis_mode_) {
+    case config::CLOSURE_AND_DEP_GRAPH:
+    case config::CLOSURE_AND_VALIDATE_DEP_GRAPH:
+    case config::DEP_GRAPH_ONLY:
+    case config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION:
+      return true;
+    default:
+      return false;
+    }
   }
 
   // Assign a new merged segment to base and clear all of the segments that
@@ -274,7 +293,7 @@ class SegmentationContext {
     return glyph_groupings.GroupGlyphs(
         *segmentation_info_, glyph_condition_set, *glyph_closure_cache,
         maybe_dep_closure, glyphs, modified_segments,
-        condition_analysis_mode_ != config::DEP_GRAPH_ONLY);
+        !IsPureDepGraphAnalysisMode());
   }
 
   void TransferDependencyGraphGlyphConditions(const common::GlyphSet& gids);

--- a/ift/encoder/segmentation_context.h
+++ b/ift/encoder/segmentation_context.h
@@ -124,7 +124,9 @@ class SegmentationContext {
         segmentation_info_(std::move(segmentation_info)),
         dependency_closure_(std::nullopt),
         glyph_condition_set(hb_face_get_glyph_count(face)),
-        glyph_groupings(hb_face_get_glyph_count(face), condition_analysis_mode == config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION),
+        glyph_groupings(hb_face_get_glyph_count(face),
+                        condition_analysis_mode ==
+                            config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION),
         brotli_quality_(brotli_quality),
         init_font_brotli_quality_(init_font_brotli_quality),
         condition_analysis_mode_(condition_analysis_mode),
@@ -200,23 +202,23 @@ class SegmentationContext {
 
   bool IsPureDepGraphAnalysisMode() const {
     switch (condition_analysis_mode_) {
-    case config::DEP_GRAPH_ONLY:
-    case config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION:
-      return true;
-    default:
-      return false;
+      case config::DEP_GRAPH_ONLY:
+      case config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION:
+        return true;
+      default:
+        return false;
     }
   }
 
   bool UsingDepGraph() const {
     switch (condition_analysis_mode_) {
-    case config::CLOSURE_AND_DEP_GRAPH:
-    case config::CLOSURE_AND_VALIDATE_DEP_GRAPH:
-    case config::DEP_GRAPH_ONLY:
-    case config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION:
-      return true;
-    default:
-      return false;
+      case config::CLOSURE_AND_DEP_GRAPH:
+      case config::CLOSURE_AND_VALIDATE_DEP_GRAPH:
+      case config::DEP_GRAPH_ONLY:
+      case config::DEP_GRAPH_ONLY_WITH_SIMPLIFICATION:
+        return true;
+      default:
+        return false;
     }
   }
 
@@ -290,10 +292,10 @@ class SegmentationContext {
     if (dependency_closure_.has_value()) {
       maybe_dep_closure = (*dependency_closure_).get();
     }
-    return glyph_groupings.GroupGlyphs(
-        *segmentation_info_, glyph_condition_set, *glyph_closure_cache,
-        maybe_dep_closure, glyphs, modified_segments,
-        !IsPureDepGraphAnalysisMode());
+    return glyph_groupings.GroupGlyphs(*segmentation_info_, glyph_condition_set,
+                                       *glyph_closure_cache, maybe_dep_closure,
+                                       glyphs, modified_segments,
+                                       !IsPureDepGraphAnalysisMode());
   }
 
   void TransferDependencyGraphGlyphConditions(const common::GlyphSet& gids);


### PR DESCRIPTION
Same as DEP_GRAPH_ONLY but simplifies composite conditions into pure disjunctive/conjunctive expressions. This is useful for speeding up cases which are slow due to high complexity conditions. Used at quality level 1.

Additionally quality levels have been reworked:
- Always enable init font merging, batch testing shows it's always faster to have this enabled.
- Drop level 8, which performs worse than 7 in most cases (8 dropped preprocess merging)
- Adjust init font merging thresholds now that all levels feature init font merging.


