### PR TITLE
Rework quality 0 (auto pick).

### DIFF
--- a/ift/config/auto_segmenter_config.cc
+++ b/ift/config/auto_segmenter_config.cc
@@ -661,6 +661,38 @@ static void ApplyQualityLevelTo(Quality quality, SegmenterConfig& config) {
   }
 }
 
+static Quality AutoPickQuality(uint32_t codepoint_count) {
+  // TODO(garretrieger): more sophisticated scheme for auto picking quality
+  // level. roughly we want to estimate the expected cost of each quality level
+  // and pick based on that. Notably probably want some measure of condition
+  // complexity that feeds into the selection in addition to # of codepoints.
+
+  // These values were picked by looking at segmenter run times by quality level
+  // accross the font collection from https://github.com/google/fonts/.
+  // Roughly they aim to keep the number of segmentations that take >= 10 minutes
+  // for a particular count below 0.5%.
+  //
+  // Bin            Quality   % > 10 minutes
+  // [1,      300]  7         0.3
+  // (300,   1500]  6         0.3
+  // (1500,  3100]  4         0.0
+  // (3100, 30000]  2         0.0
+  // (30000,  inf]  1        28.6
+  if (codepoint_count <= 300) {
+    return SEVEN;
+  }
+  if (codepoint_count <= 1500) {
+    return SIX;
+  }
+  if (codepoint_count <= 3100) {
+    return FOUR;
+  }
+  if (codepoint_count <= 30000) {
+    return TWO;
+  }
+  return ONE;
+}
+
 StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
     hb_face_t* face, const ift::common::DataFileResolver& resolver,
     std::optional<std::string> primary_script,
@@ -676,20 +708,9 @@ StatusOr<SegmenterConfig> AutoSegmenterConfig::GenerateConfig(
   // Collect codepoints
   auto freq_list = TRY(BuiltInFrequenciesList(resolver));
   CodepointSet unicodes = FontHelper::ToCodepointsSet(face);
-  uint32_t cp_count = unicodes.size();
+  uint32_t codepoint_count = unicodes.size();
 
-  // TODO(garretrieger): more sophisticated scheme for auto picking quality
-  // level. roughly we want to estimate the expected cost of each quality level
-  // and pick based on that.
-
-  // TODO XXXXX redo this based on latest batch results, including using quality
-  // 1 for extreme cases (high condition complexity)
-  Quality quality = THREE;
-  if (cp_count <= 1000) {
-    quality = MAX;
-  } else if (cp_count <= 3000) {
-    quality = SIX;
-  }
+  Quality quality = AutoPickQuality(codepoint_count);
 
   if (quality_level.has_value() && quality_level.value() >= MIN &&
       quality_level.value() <= MAX) {

--- a/ift/config/auto_segmenter_config_test.cc
+++ b/ift/config/auto_segmenter_config_test.cc
@@ -97,7 +97,7 @@ TEST_F(AutoSegmenterConfigTest, Roboto_UnspecifiedPrimary) {
   ASSERT_EQ(config_string, R"(unmapped_glyph_handling: MOVE_TO_INIT_FONT
 generate_table_keyed_segments: true
 brotli_quality: 11
-brotli_quality_for_initial_font_merging: 11
+brotli_quality_for_initial_font_merging: 9
 base_heuristic_config {
   min_patch_size: 2500
 }
@@ -115,7 +115,7 @@ preprocess_merging_group_size_for_ungrouped: 12
 merge_groups {
   name: "Cyrillic"
   preprocess_merging_group_size: 4
-  preprocess_merging_probability_threshold: 0.0005
+  preprocess_merging_probability_threshold: 0.005
   cost_config {
     built_in_freq_data_name: "Script_cyrillic.riegeli"
   }
@@ -123,7 +123,7 @@ merge_groups {
 merge_groups {
   name: "Greek"
   preprocess_merging_group_size: 4
-  preprocess_merging_probability_threshold: 0.0005
+  preprocess_merging_probability_threshold: 0.005
   cost_config {
     built_in_freq_data_name: "Script_greek.riegeli"
   }
@@ -131,17 +131,17 @@ merge_groups {
 merge_groups {
   name: "Latin"
   preprocess_merging_group_size: 4
-  preprocess_merging_probability_threshold: 0.0005
+  preprocess_merging_probability_threshold: 0.005
   cost_config {
     built_in_freq_data_name: "Script_latin.riegeli"
     initial_font_merge_threshold: -160
-    initial_font_merge_probability_threshold: 0.25
+    initial_font_merge_probability_threshold: 0.3
   }
 }
 merge_groups {
   name: "Symbols"
   preprocess_merging_group_size: 4
-  preprocess_merging_probability_threshold: 0.0005
+  preprocess_merging_probability_threshold: 0.005
   cost_config {
     built_in_freq_data_name: "Script_symbols.riegeli"
   }
@@ -149,7 +149,7 @@ merge_groups {
 merge_groups {
   name: "Fallback"
   preprocess_merging_group_size: 4
-  preprocess_merging_probability_threshold: 0.0005
+  preprocess_merging_probability_threshold: 0.005
   cost_config {
     built_in_freq_data_name: "fallback.riegeli"
   }
@@ -306,7 +306,7 @@ TEST_F(AutoSegmenterConfigTest, QualityLevelForcing) {
   EXPECT_EQ(config_or->base_cost_config().optimization_cutoff_fraction(), 0.05);
 
   auto config_or_8 = AutoSegmenterConfig::GenerateConfig(face_.get(), *resolver,
-                                                         std::nullopt, 8);
+                                                         std::nullopt, 7);
   ASSERT_TRUE(config_or_8.ok()) << config_or_8.status();
   EXPECT_EQ(config_or_8->brotli_quality(), 11);
   EXPECT_EQ(config_or_8->unmapped_glyph_handling(), MOVE_TO_INIT_FONT);


### PR DESCRIPTION
Update the mapping from codepoint count to quality level using data from running the segmenter across all of the fonts in https://github.com/google/fonts/.

Stats for the new heuristic:

  | Old | Rework
-- | -- | --
Median Total Cost | 24,134 | 25,220
99th Total Time (s) | 1,666 | 601
Count > 600s | 77 | 21
Count <= 600s | 1,896 | 1,997



