### PR TITLE
Optimizations to ActivationCondition::ReplaceSegments() and CandidateMerge::FindModifiedConditions()

### DIFF
--- a/ift/encoder/BUILD
+++ b/ift/encoder/BUILD
@@ -136,6 +136,7 @@ cc_library(
         ":common",
         "//ift/freq",
         "//ift/proto",
+        "@abseil-cpp//absl/hash",
     ],
     visibility = [
         "//visibility:public",

--- a/ift/encoder/activation_condition.cc
+++ b/ift/encoder/activation_condition.cc
@@ -1,6 +1,7 @@
 #include "ift/encoder/activation_condition.h"
 
 #include <algorithm>
+#include <optional>
 #include <vector>
 
 #include "absl/container/btree_set.h"
@@ -64,6 +65,7 @@ ActivationCondition ActivationCondition::and_segments(
   ActivationCondition conditions;
   conditions.activated_ = {activated};
 
+  conditions.conditions_.reserve(segments.size());
   for (auto id : segments) {
     conditions.conditions_.push_back(SegmentSet{id});
   }
@@ -101,6 +103,7 @@ ActivationCondition ActivationCondition::clear_exclusive(
     ActivationCondition&& condition) {
   ActivationCondition updated(std::move(condition));
   updated.is_exclusive_ = false;
+  updated.cached_hash_ = std::nullopt;
   return updated;
 }
 
@@ -118,6 +121,11 @@ static void Simplify(std::vector<SegmentSet>& conditions) {
               return a.size() < b.size();
             });
 
+  // TODO(garretrieger): a possibly faster approach is to keep a "minimal sets"
+  // list and check if each condition is a superset of anything in that list.
+  // This could utilize a set trie to speed up the check. We would be able to do
+  // the processing in a single pass and not require the cleanup loop. size() ==
+  // 1 sub groups can be special cased in this approach too.
   std::vector<uint8_t> redundant(conditions.size(), 0);
   for (size_t i = 0; i < conditions.size(); ++i) {
     if (redundant[i]) continue;
@@ -155,6 +163,7 @@ ActivationCondition ActivationCondition::And(const ActivationCondition& a,
                                b.conditions().begin(), b.conditions().end());
   Simplify(condition.conditions_);
   condition.is_exclusive_ = a_exclusive && b_exclusive && condition.IsUnitary();
+  condition.cached_hash_ = std::nullopt;
   return condition;
 }
 
@@ -241,6 +250,40 @@ bool ActivationCondition::Intersects(const common::SegmentSet& segments) const {
 
 ActivationCondition ActivationCondition::ReplaceSegments(
     segment_index_t base_segment, const SegmentSet& segments) const {
+  if (IsPurelyConjunctive()) {
+    // Fast path for doing replace on a purely conjunctive condition, skips
+    // simplify since we can easily gaurantee the new condition is already
+    // simplified.
+    ActivationCondition new_condition;
+    new_condition.conditions_.reserve(conditions_.size());
+    bool has_replace = false;
+    bool base_present = false;
+    for (const auto& sub_group : conditions_) {
+      if (sub_group.intersects(segments)) {
+        has_replace = true;
+        continue;
+      }
+      if (sub_group.contains(base_segment)) {
+        base_present = true;
+      }
+      new_condition.conditions_.push_back(sub_group);
+    }
+    if (has_replace && !base_present) {
+      SegmentSet base{base_segment};
+      // Insert to keep the vector sorted.
+      auto it = std::lower_bound(new_condition.conditions_.begin(),
+                                 new_condition.conditions_.end(), base);
+      new_condition.conditions_.insert(it, std::move(base));
+    }
+
+    new_condition.activated_ = activated_;
+    new_condition.is_fallback_ = is_fallback_;
+    new_condition.is_exclusive_ =
+        is_exclusive_ || new_condition.conditions_.size() == 1;
+    new_condition.encoding_ = encoding_;
+    return new_condition;
+  }
+
   ActivationCondition new_condition = *this;
   for (auto& condition_group : new_condition.conditions_) {
     if (condition_group.intersects(segments)) {
@@ -249,6 +292,7 @@ ActivationCondition ActivationCondition::ReplaceSegments(
     }
   }
   Simplify(new_condition.conditions_);
+  new_condition.cached_hash_ = std::nullopt;
   return new_condition;
 }
 

--- a/ift/encoder/activation_condition.h
+++ b/ift/encoder/activation_condition.h
@@ -2,7 +2,9 @@
 #define IFT_ENCODER_ACTIVATION_CONDITION_H_
 
 #include <cstdint>
+#include <optional>
 
+#include "absl/hash/hash.h"
 #include "ift/common/int_set.h"
 #include "ift/config/segmentation_plan.pb.h"
 #include "ift/encoder/segment.h"
@@ -219,15 +221,26 @@ class ActivationCondition {
 
   ift::config::ActivationConditionProto ToConfigProto() const;
 
+  size_t Hash() const {
+    if (!cached_hash_.has_value()) {
+      cached_hash_ = absl::HashOf(conditions_, activated_, is_fallback_,
+                                  is_exclusive_, encoding_);
+    }
+    return *cached_hash_;
+  }
+
   template <typename H>
   friend H AbslHashValue(H h, const ActivationCondition& c) {
-    return H::combine(std::move(h), c.conditions_, c.activated_, c.is_fallback_,
-                      c.is_exclusive_, c.encoding_);
+    return H::combine(std::move(h), c.Hash());
   }
 
   bool operator<(const ActivationCondition& other) const;
 
   bool operator==(const ActivationCondition& other) const {
+    if (cached_hash_.has_value() && other.cached_hash_.has_value() &&
+        cached_hash_ != other.cached_hash_) {
+      return false;
+    }
     return conditions_ == other.conditions_ && activated_ == other.activated_ &&
            is_fallback_ == other.is_fallback_ &&
            is_exclusive_ == other.is_exclusive_ && encoding_ == other.encoding_;
@@ -237,10 +250,14 @@ class ActivationCondition {
     return !(*this == other);
   }
 
-  void SetEncoding(proto::PatchEncoding encoding) { encoding_ = encoding; }
+  void SetEncoding(proto::PatchEncoding encoding) {
+    encoding_ = encoding;
+    cached_hash_ = std::nullopt;
+  }
 
   void AddPrefetches(absl::Span<const patch_id_t> activated) {
     activated_.insert(activated_.end(), activated.begin(), activated.end());
+    cached_hash_ = std::nullopt;
   }
 
  private:
@@ -254,6 +271,7 @@ class ActivationCondition {
   std::vector<ift::common::SegmentSet> conditions_;
   std::vector<patch_id_t> activated_;
   proto::PatchEncoding encoding_;
+  mutable std::optional<size_t> cached_hash_ = std::nullopt;
 };
 
 }  // namespace ift::encoder

--- a/ift/encoder/activation_condition_test.cc
+++ b/ift/encoder/activation_condition_test.cc
@@ -508,6 +508,13 @@ TEST(ActivationConditionTest, ReplaceSegments) {
   replaced = a.ReplaceSegments(300, {1, 3});
   EXPECT_EQ(replaced.ToString(),
             "if ((s2 OR s300) AND (s4 OR s300) AND s5) then p10");
+
+  auto b = ActivationCondition::and_segments({{1, 2, 3, 5}}, 10);
+  EXPECT_EQ(b.ReplaceSegments(2, {2, 5}).ToString(),
+            "if (s1 AND s2 AND s3) then p10");
+  EXPECT_EQ(b.ReplaceSegments(4, {2, 5}).ToString(),
+            "if (s1 AND s3 AND s4) then p10");
+  EXPECT_EQ(b.ReplaceSegments(3, {2, 5}).ToString(), "if (s1 AND s3) then p10");
 }
 
 TEST(ActivationConditionTest, ReplaceSegments_True) {
@@ -586,6 +593,22 @@ TEST(ActivationConditionTest, NonCompositeSuperset) {
                 {{3, 100}, {0, 1}, {3, 4, 5}}, 12)
                 .NonCompositeSuperset(),
             ActivationCondition::or_segments({3, 100}, 12));
+}
+
+TEST(ActivationConditionTest, HashCaching) {
+  auto cond = ActivationCondition::or_segments({1, 3}, 5);
+  size_t h1 = cond.Hash();
+  EXPECT_EQ(cond.Hash(), h1);
+
+  // Mutation resets hash
+  cond.SetEncoding(PatchEncoding::TABLE_KEYED_FULL);
+  size_t h2 = cond.Hash();
+  EXPECT_NE(h1, h2);
+
+  // Copy preserves hash
+  auto cond_copy = cond;
+  EXPECT_EQ(cond_copy.Hash(), h2);
+  EXPECT_EQ(cond, cond_copy);
 }
 
 }  // namespace ift::encoder

--- a/ift/encoder/candidate_merge.cc
+++ b/ift/encoder/candidate_merge.cc
@@ -200,7 +200,8 @@ static void MergeSegments(const Merger& merger, const SegmentSet& segments,
 
 static Status FindModifiedConditions(
     const Merger& merger, const SegmentSet& merged_segments,
-    flat_hash_map<ActivationCondition, const GlyphSet*>& modified_conditions) {
+    flat_hash_map<const ActivationCondition*, const GlyphSet*>&
+        modified_conditions) {
   const auto& groupings = merger.Context().glyph_groupings;
   const auto& conditions_and_glyphs = groupings.ConditionsAndGlyphs();
 
@@ -211,15 +212,12 @@ static Status FindModifiedConditions(
         continue;
       }
 
-      auto [it, inserted] = modified_conditions.try_emplace(c, nullptr);
-      if (inserted) {
-        auto glyph_it = conditions_and_glyphs.find(c);
-        if (glyph_it == conditions_and_glyphs.end()) {
-          return absl::InternalError(
-              "Condition which should be present wasn't found.");
-        }
-        it->second = &glyph_it->second;
+      auto glyph_it = conditions_and_glyphs.find(c);
+      if (glyph_it == conditions_and_glyphs.end()) {
+        return absl::InternalError(
+            "Condition which should be present wasn't found.");
       }
+      modified_conditions.try_emplace(&glyph_it->first, &glyph_it->second);
     }
   }
 
@@ -591,7 +589,8 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   // are conditions that intersect merged_segments.
   //
   // Map value is the glyphs associated with condition.
-  flat_hash_map<ActivationCondition, const GlyphSet*> modified_conditions;
+  flat_hash_map<const ActivationCondition*, const GlyphSet*>
+      modified_conditions;
 
   TRYV(FindModifiedConditions(merger, merged_segments, modified_conditions));
 
@@ -619,15 +618,15 @@ StatusOr<double> CandidateMerge::ComputeCostDelta(
   const uint32_t per_request_overhead = merger.Strategy().NetworkOverheadCost();
   for (const auto& [condition, glyphs] : modified_conditions) {
     uint32_t patch_size = TRY(patch_size_cache->GetPatchSize(*glyphs));
-    double p = TRY(condition.Probability(segments, *calculator));
+    double p = TRY(condition->Probability(segments, *calculator));
     double d = p * (patch_size + per_request_overhead);
     cost_delta -= d;
     VLOG(1) << "    - (" << p << " * " << (patch_size + per_request_overhead)
-            << ") -> " << d << " [removed patch " << condition.ToString()
+            << ") -> " << d << " [removed patch " << condition->ToString()
             << "]";
 
     ActivationCondition updated =
-        condition.ReplaceSegments(base, merged_segments);
+        condition->ReplaceSegments(base, merged_segments);
     if (updated.IsExclusive()) {
       // Clear is exclusive flag so that de-dup happens properly
       updated = ActivationCondition::clear_exclusive(std::move(updated));


### PR DESCRIPTION
Targeted at case with large condition complexity where these methods are slow. For Noto Color Emoji this results in a ~50% speedup.