### PR TITLE
Some more security fixes

### DIFF
--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -82,8 +82,8 @@ class DiffDriver {
               HasTable(base_face, derived_face, HHEA)) {
             differs.push_back(RangeAndDiffer(
                 base_face, derived_face, HMTX, stream,
-                new HmtxDiffer(TableRange::to_span(base_face, HHEA),
-                               TableRange::to_span(derived_face, HHEA))));
+                new HmtxDiffer(FontHelper::TableData(base_face, HHEA),
+                               FontHelper::TableData(derived_face, HHEA))));
           }
           break;
 
@@ -92,8 +92,8 @@ class DiffDriver {
               HasTable(base_face, derived_face, VHEA)) {
             differs.push_back(RangeAndDiffer(
                 base_face, derived_face, VMTX, stream,
-                new HmtxDiffer(TableRange::to_span(base_face, VHEA),
-                               TableRange::to_span(derived_face, VHEA))));
+                new HmtxDiffer(FontHelper::TableData(base_face, VHEA),
+                               FontHelper::TableData(derived_face, VHEA))));
           }
           break;
 
@@ -111,7 +111,7 @@ class DiffDriver {
               HasTable(base_face, derived_face, LOCA)) {
             differs.push_back(RangeAndDiffer(
                 base_face, derived_face, GLYF, stream,
-                new GlyfDiffer(TableRange::to_span(derived_face, LOCA),
+                new GlyfDiffer(FontHelper::TableData(derived_face, LOCA),
                                is_base_short_loca, is_derived_short_loca)));
           }
           break;
@@ -265,8 +265,8 @@ void BrotliFontDiff::SortForDiff(const IntSet& immutable_tables,
 Status BrotliFontDiff::Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
                             hb_subset_plan_t* derived_plan, hb_blob_t* derived,
                             FontData* patch) const {
-  Span<const uint8_t> base_span = TableRange::to_span(base);
-  Span<const uint8_t> derived_span = TableRange::to_span(derived);
+  FontData base_span(base);
+  FontData derived_span(derived);
 
   // get a 'real' (non facebuilder) face for the faces.
   hb_face_unique_ptr derived_face = make_hb_face(hb_face_create(derived, 0));
@@ -302,12 +302,10 @@ Status BrotliFontDiff::Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
             "base and derived must both have the same tables.");
       }
 
-      Span<const uint8_t> base_span =
-          TableRange::padded_table_span(TableRange::to_span(base_face.get(), tag));
-      Span<const uint8_t> derived_span =
-          TableRange::padded_table_span(TableRange::to_span(derived_face.get(), tag));
+      size_t base_padded_size = TableRange::padded_table_size(FontHelper::TableData(base_face.get(), tag).size());
+      size_t derived_padded_size = TableRange::padded_table_size(FontHelper::TableData(derived_face.get(), tag).size());
 
-      base_region_sizes[i] += base_span.size();
+      base_region_sizes[i] += base_padded_size;
 
       unsigned base_offset = TableRange::table_offset(base_face.get(), tag);
       unsigned derived_offset = TableRange::table_offset(derived_face.get(), tag);
@@ -330,15 +328,15 @@ Status BrotliFontDiff::Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
             "custom diff tables in base are not sequential.");
       }
 
-      derived_end_offset = derived_offset + derived_span.size();
-      base_end_offset = base_offset + base_span.size();
+      derived_end_offset = derived_offset + derived_padded_size;
+      base_end_offset = base_offset + base_padded_size;
     }
     i++;
   }
 
   Status s = out.insert_compressed_with_partial_dict(
-      derived_span.subspan(0, derived_start_offset),
-      base_span.subspan(0, base_start_offset));
+      derived_span.span().subspan(0, derived_start_offset),
+      base_span.span().subspan(0, base_start_offset));
   if (!s.ok()) {
     return s;
   }
@@ -353,7 +351,7 @@ Status BrotliFontDiff::Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
   }
 
   if (derived_span.size() > derived_end_offset) {
-    s = out.insert_compressed(derived_span.subspan(derived_end_offset));
+    s = out.insert_compressed(derived_span.span().subspan(derived_end_offset));
     if (!s.ok()) {
       return s;
     }

--- a/brotli/brotli_font_diff.cc
+++ b/brotli/brotli_font_diff.cc
@@ -167,12 +167,9 @@ class DiffDriver {
 
         if (derived_gid > 0 && was_new_data != differ->IsNewData()) {
           if (was_new_data) {
-            Status s = range.CommitNew();
-            if (!s.ok()) {
-              return s;
-            }
+            TRYV(range.CommitNew());
           } else {
-            range.CommitExisting();
+            TRYV(range.CommitExisting());
           }
         }
 
@@ -195,12 +192,9 @@ class DiffDriver {
       differ->Finalize(&base_length, &derived_length);
       range.Extend(base_length, derived_length);
       if (differ->IsNewData()) {
-        Status s = range.CommitNew();
-        if (!s.ok()) {
-          return s;
-        }
+        TRYV(range.CommitNew());
       } else {
-        range.CommitExisting();
+        TRYV(range.CommitExisting());
       }
       range.stream().four_byte_align_uncompressed();
       out.append(range.stream());
@@ -334,27 +328,18 @@ Status BrotliFontDiff::Diff(hb_subset_plan_t* base_plan, hb_blob_t* base,
     i++;
   }
 
-  Status s = out.insert_compressed_with_partial_dict(
+  TRYV(out.insert_compressed_with_partial_dict(
       derived_span.span().subspan(0, derived_start_offset),
-      base_span.span().subspan(0, base_start_offset));
-  if (!s.ok()) {
-    return s;
-  }
+      base_span.span().subspan(0, base_start_offset)));
 
   if (!out.insert_from_dictionary(base_start_offset, base_region_sizes[0])) {
     return absl::InternalError("dict insert of immutable tables failed.");
   }
 
-  s = diff_driver.MakeDiff();
-  if (!s.ok()) {
-    return s;
-  }
+  TRYV(diff_driver.MakeDiff());
 
   if (derived_span.size() > derived_end_offset) {
-    s = out.insert_compressed(derived_span.span().subspan(derived_end_offset));
-    if (!s.ok()) {
-      return s;
-    }
+    TRYV(out.insert_compressed(derived_span.span().subspan(derived_end_offset)));
   }
 
   out.end_stream();

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -2,6 +2,7 @@
 #include "brotli/glyf_differ.h"
 
 #include "absl/strings/match.h"
+#include "absl/strings/string_view.h"
 #include "absl/types/span.h"
 #include "gtest/gtest.h"
 #include "hb-subset.h"
@@ -321,8 +322,9 @@ TEST_F(BrotliFontDiffTest, TruncatedHeadTable) {
 
 
 TEST(GlyfDifferTest, ShortLocaOOB) {
-  std::vector<uint8_t> loca = {0, 0, 0, 10};
-  GlyfDiffer differ(loca, true, true);
+  std::vector<char> loca_data = {0, 0, 0, 10};
+  FontData loca(absl::string_view(loca_data.data(), loca_data.size()));
+  GlyfDiffer differ(std::move(loca), true, true);
   unsigned base_delta = 0;
   unsigned derived_delta = 0;
   differ.Process(1, 1, 1, false, &base_delta, &derived_delta);
@@ -330,8 +332,9 @@ TEST(GlyfDifferTest, ShortLocaOOB) {
 }
 
 TEST(GlyfDifferTest, LongLocaOOB) {
-  std::vector<uint8_t> loca = {0, 0, 0, 0, 0, 0, 0, 10};
-  GlyfDiffer differ(loca, false, false);
+  std::vector<char> loca_data = {0, 0, 0, 0, 0, 0, 0, 10};
+  FontData loca(absl::string_view(loca_data.data(), loca_data.size()));
+  GlyfDiffer differ(std::move(loca), false, false);
   unsigned base_delta = 0;
   unsigned derived_delta = 0;
   differ.Process(1, 1, 1, false, &base_delta, &derived_delta);

--- a/brotli/brotli_font_diff_test.cc
+++ b/brotli/brotli_font_diff_test.cc
@@ -313,11 +313,49 @@ TEST_F(BrotliFontDiffTest, TruncatedHeadTable) {
   BrotliFontDiff differ(immutable_tables, custom_tables);
   FontData patch;
   Status status = differ.Diff(base_plan, bad_base_blob.get(), derived_plan, derived_blob.get(), &patch);
-  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
-  EXPECT_TRUE(absl::StrContains(status.message(), "head table is missing or truncated")) << status.message();
-
   hb_subset_plan_destroy(base_plan);
   hb_subset_plan_destroy(derived_plan);
+
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
+  EXPECT_TRUE(absl::StrContains(status.message(), "head table is missing or truncated")) << status.message();
+}
+
+TEST_F(BrotliFontDiffTest, TruncatedHmtxTable) {
+  hb_set_add_range(hb_subset_input_unicode_set(input), 0x41, 0x5A);
+  hb_subset_plan_t* base_plan = hb_subset_plan_create_or_fail(roboto, input);
+  hb_face_unique_ptr base_face = make_hb_face(hb_subset_plan_execute_or_fail(base_plan));
+  SortTables(roboto, base_face.get());
+  hb_blob_unique_ptr base_blob = make_hb_blob(hb_face_reference_blob(base_face.get()));
+
+  // Derived setup with bad (truncated) hmtx table
+  hb_set_add_range(hb_subset_input_unicode_set(input), 0x61, 0x7A);
+  hb_subset_plan_t* derived_plan = hb_subset_plan_create_or_fail(roboto, input);
+  hb_face_unique_ptr derived_face = make_hb_face(hb_subset_plan_execute_or_fail(derived_plan));
+  SortTables(roboto, derived_face.get());
+
+  auto ordered_tags = ift::common::FontHelper::GetOrderedTags(derived_face.get());
+  hb_face_unique_ptr builder = make_hb_face_builder();
+  std::string bad_hmtx_data = "short";
+
+  for (auto tag : ordered_tags) {
+    hb_blob_unique_ptr blob = FontHelper::TableData(derived_face.get(), tag).blob();
+    if (tag == HB_TAG('h', 'm', 't', 'x')) {
+      blob = make_hb_blob(hb_blob_create(bad_hmtx_data.data(), bad_hmtx_data.size(), HB_MEMORY_MODE_READONLY, nullptr, nullptr));
+    }
+    hb_face_builder_add_table(builder.get(), tag, blob.get());
+  }
+
+  SortTables(roboto, builder.get());
+  hb_blob_unique_ptr bad_derived_blob = make_hb_blob(hb_face_reference_blob(builder.get()));
+
+  BrotliFontDiff differ(immutable_tables, custom_tables);
+  FontData patch;
+  Status status = differ.Diff(base_plan, base_blob.get(), derived_plan, bad_derived_blob.get(), &patch);
+  hb_subset_plan_destroy(base_plan);
+  hb_subset_plan_destroy(derived_plan);
+
+  EXPECT_FALSE(status.ok());
+  EXPECT_EQ(status.code(), absl::StatusCode::kInvalidArgument);
 }
 
 

--- a/brotli/glyf_differ.h
+++ b/brotli/glyf_differ.h
@@ -3,6 +3,7 @@
 
 #include "absl/types/span.h"
 #include "brotli/table_differ.h"
+#include "ift/common/font_data.h"
 
 namespace brotli {
 
@@ -14,14 +15,14 @@ class GlyfDiffer : public TableDiffer {
     EXISTING_DATA,
   } mode = INIT;
 
-  absl::Span<const uint8_t> loca_;
+  ift::common::FontData loca_;
   bool is_base_short_loca_;
   bool is_derived_short_loca_;
 
  public:
-  GlyfDiffer(absl::Span<const uint8_t> loca, bool is_base_short_loca,
+  GlyfDiffer(ift::common::FontData loca, bool is_base_short_loca,
              bool is_derived_short_loca)
-      : loca_(loca),
+      : loca_(std::move(loca)),
         is_base_short_loca_(is_base_short_loca),
         is_derived_short_loca_(is_derived_short_loca) {}
 
@@ -64,7 +65,7 @@ class GlyfDiffer : public TableDiffer {
  private:
   // Length of glyph (in bytes) found in the derived subset.
   unsigned GlyphLength(unsigned gid) {
-    const uint8_t* derived_loca = loca_.data();
+    const uint8_t* derived_loca = loca_.span().data();
 
     if (is_derived_short_loca_) {
       size_t index = (size_t)gid * 2;

--- a/brotli/hmtx_differ.h
+++ b/brotli/hmtx_differ.h
@@ -1,8 +1,8 @@
 #ifndef BROTLI_HMTX_DIFFER_H_
 #define BROTLI_HMTX_DIFFER_H_
 
-#include "absl/types/span.h"
 #include "brotli/table_differ.h"
+#include "ift/common/font_data.h"
 
 namespace brotli {
 
@@ -18,8 +18,8 @@ class HmtxDiffer : public TableDiffer {
   unsigned derived_number_of_metrics;
 
  public:
-  HmtxDiffer(absl::Span<const uint8_t> base_hhea,
-             absl::Span<const uint8_t> derived_hhea)
+  HmtxDiffer(ift::common::FontData base_hhea,
+             ift::common::FontData derived_hhea)
       : base_number_of_metrics(GetNumberOfMetrics(base_hhea)),
         derived_number_of_metrics(GetNumberOfMetrics(derived_hhea)) {}
 
@@ -58,14 +58,15 @@ class HmtxDiffer : public TableDiffer {
   bool IsNewData() const override { return mode == NEW_DATA; }
 
  private:
-  static unsigned GetNumberOfMetrics(absl::Span<const uint8_t> hhea) {
+  static unsigned GetNumberOfMetrics(const ift::common::FontData& hhea) {
     constexpr unsigned field_offset = 34;
 
     if (hhea.size() < field_offset + 2) {
       return 0;
     }
 
-    const uint8_t* num_metrics = hhea.data() + field_offset;
+    const uint8_t* num_metrics =
+        hhea.span().data() + field_offset;
     return (num_metrics[0] << 8) | num_metrics[1];
   }
 };

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -3,7 +3,7 @@
 
 #include "absl/types/span.h"
 #include "brotli/brotli_stream.h"
-#include "hb-subset.h"
+#include "ift/common/font_helper.h"
 
 namespace brotli {
 
@@ -35,15 +35,8 @@ class TableRange {
   }
 
   static unsigned table_offset(hb_face_t* face, hb_tag_t tag) {
-    hb_blob_t* table = hb_face_reference_table(face, tag);
-    hb_blob_t* blob = hb_face_reference_blob(face);
-    unsigned offset =
-        hb_blob_get_data(table, nullptr) - hb_blob_get_data(blob, nullptr);
-
-    hb_blob_destroy(table);
-    hb_blob_destroy(blob);
-
-    return offset;
+    ift::common::CompareTableOffsets comparer(face);
+    return comparer.table_offset(tag);
   }
 
  public:

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -63,6 +63,10 @@ class TableRange {
   }
 
   absl::Status CommitNew() {
+    if (derived_offset_ > derived_.size() ||
+        derived_length_ > derived_.size() - derived_offset_) {
+      return absl::InvalidArgumentError("Table range out of bounds.");
+    }
     absl::Status s = out->insert_compressed(absl::Span<const uint8_t>(
         data() + derived_offset_, derived_length_));
     if (!s.ok()) {
@@ -78,7 +82,11 @@ class TableRange {
     return absl::OkStatus();
   }
 
-  void CommitExisting() {
+  absl::Status CommitExisting() {
+    if (derived_offset_ > derived_.size() ||
+        derived_length_ > derived_.size() - derived_offset_) {
+      return absl::InvalidArgumentError("Table range out of bounds.");
+    }
     if (!out->insert_from_dictionary(base_table_offset_ + base_offset_,
                                      derived_length_)) {
       // 1 byte backwards refs must be inserted as literals.
@@ -91,6 +99,8 @@ class TableRange {
 
     base_length_ = 0;
     derived_length_ = 0;
+
+    return absl::OkStatus();
   }
 };
 

--- a/brotli/table_range.h
+++ b/brotli/table_range.h
@@ -3,46 +3,31 @@
 
 #include "absl/types/span.h"
 #include "brotli/brotli_stream.h"
+#include "ift/common/font_data.h"
 #include "ift/common/font_helper.h"
 
 namespace brotli {
 
 class TableRange {
  public:
-  static absl::Span<const uint8_t> to_span(hb_face_t* face, hb_tag_t tag) {
-    hb_blob_t* table = hb_face_reference_table(face, tag);
-    absl::Span<const uint8_t> result = to_span(table);
-    hb_blob_destroy(table);
-
-    return result;
-  }
-
-  static absl::Span<const uint8_t> to_span(hb_blob_t* table) {
-    unsigned length;
-    const uint8_t* data =
-        reinterpret_cast<const uint8_t*>(hb_blob_get_data(table, &length));
-
-    return absl::Span<const uint8_t>(data, length);
-  }
-
-  static absl::Span<const uint8_t> padded_table_span(
-      absl::Span<const uint8_t> span) {
-    unsigned new_size = span.size();
-    while (new_size % 4) {
-      new_size++;
-    }
-    return absl::Span<const uint8_t>(span.data(), new_size);
-  }
 
   static unsigned table_offset(hb_face_t* face, hb_tag_t tag) {
     ift::common::CompareTableOffsets comparer(face);
     return comparer.table_offset(tag);
   }
 
+  static size_t padded_table_size(size_t size) {
+    while (size % 4) {
+      size++;
+    }
+    return size;
+  }
+
  public:
   TableRange(hb_face_t* base_face, hb_face_t* derived_face, hb_tag_t tag,
              const BrotliStream& base_stream) {
-    derived_ = to_span(derived_face, tag);
+
+    derived_ = ift::common::FontHelper::TableData(derived_face, tag);
 
     out.reset(new BrotliStream(base_stream.window_bits(),
                                base_stream.dictionary_size(),
@@ -53,7 +38,7 @@ class TableRange {
   }
 
  private:
-  absl::Span<const uint8_t> derived_;
+  ift::common::FontData derived_;
 
   unsigned base_table_offset_;
   unsigned base_offset_ = 0;
@@ -68,7 +53,7 @@ class TableRange {
 
   BrotliStream& stream() { return *out; }
 
-  const uint8_t* data() { return derived_.data(); }
+  const uint8_t* data() { return reinterpret_cast<const uint8_t*>(derived_.data()); }
 
   unsigned length() { return derived_.size(); }
 
@@ -79,7 +64,7 @@ class TableRange {
 
   absl::Status CommitNew() {
     absl::Status s = out->insert_compressed(absl::Span<const uint8_t>(
-        derived_.data() + derived_offset_, derived_length_));
+        data() + derived_offset_, derived_length_));
     if (!s.ok()) {
       return s;
     }
@@ -98,7 +83,7 @@ class TableRange {
                                      derived_length_)) {
       // 1 byte backwards refs must be inserted as literals.
       out->insert_uncompressed(absl::Span<const uint8_t>(
-          derived_.data() + derived_offset_, derived_length_));
+          data() + derived_offset_, derived_length_));
     }
 
     derived_offset_ += derived_length_;

--- a/ift/client/BUILD
+++ b/ift/client/BUILD
@@ -1,4 +1,5 @@
 load("@rules_cc//cc:cc_library.bzl", "cc_library")
+load("@rules_cc//cc:cc_test.bzl", "cc_test")
 
 package(features = ["layering_check"])
 
@@ -14,14 +15,22 @@ cc_library(
         "@fontations//:ift_extend",
         "@fontations//:ift_graph",
     ],
+    defines = [
+        "IFT_EXTEND_PATH=\\\"$(rlocationpath @fontations//:ift_extend)\\\"",
+        "IFT_GRAPH_PATH=\\\"$(rlocationpath @fontations//:ift_graph)\\\"",
+    ],
     visibility = [
         "//ift:__subpackages__",
     ],
     deps = [
         "//ift/common",
+        "//ift/common:try",
         "//ift/encoder",
         "@abseil-cpp//absl/container:btree",
         "@abseil-cpp//absl/container:flat_hash_map",
         "@abseil-cpp//absl/status",
+        "@abseil-cpp//absl/strings",
+        "@bazel_tools//tools/cpp/runfiles",
     ],
 )
+

--- a/ift/client/fontations_client.cc
+++ b/ift/client/fontations_client.cc
@@ -3,13 +3,21 @@
 #include <cstdint>
 #include <cstdio>
 #include <filesystem>
+#include <cstdlib>
 #include <sstream>
+#include <string>
+#include <sys/wait.h>
+#include <unistd.h>
+#include <vector>
 
 #include "absl/status/status.h"
+#include "absl/strings/str_cat.h"
+#include "tools/cpp/runfiles/runfiles.h"
 #include "ift/common/axis_range.h"
 #include "ift/common/font_data.h"
 #include "ift/common/int_set.h"
 #include "ift/encoder/compiler.h"
+#include "ift/common/try.h"
 
 using absl::btree_set;
 using absl::flat_hash_map;
@@ -21,8 +29,18 @@ using ift::common::IntSet;
 using ift::common::make_hb_blob;
 using ift::common::make_hb_face;
 using ift::encoder::Compiler;
+using bazel::tools::cpp::runfiles::Runfiles;
 
 namespace ift::client {
+
+StatusOr<std::string> ResolvePath(const std::string& runfile_path) {
+  std::string error;
+  std::unique_ptr<Runfiles> runfiles(std::move(Runfiles::CreateForTest(&error)));
+  if (!runfiles) {
+    return absl::InternalError("fontations_client.cc: Failed to init runfiles.");
+  }
+  return runfiles->Rlocation(runfile_path);
+}
 
 Status ToFile(const FontData& data, const char* path) {
   FILE* f = fopen(path, "wb");
@@ -95,20 +113,61 @@ StatusOr<std::string> WriteFontToDisk(const Compiler::Encoding& encoding) {
   return font_path;
 }
 
-StatusOr<std::string> Exec(const char* cmd) {
-  std::array<char, 128> buffer;
+StatusOr<std::string> Exec(const std::vector<std::string>& argv) {
+  if (argv.empty()) {
+    return absl::InvalidArgumentError("Empty argv");
+  }
+
+  int pipefd[2];
+  if (pipe(pipefd) == -1) {
+    return absl::InternalError("pipe failed");
+  }
+
+  pid_t pid = fork();
+  if (pid == -1) {
+    close(pipefd[0]);
+    close(pipefd[1]);
+    return absl::InternalError("fork failed");
+  }
+
+  if (pid == 0) {
+    // Child
+    close(pipefd[0]); // Close read end
+    if (dup2(pipefd[1], STDOUT_FILENO) == -1) {
+      _exit(127);
+    }
+    close(pipefd[1]);
+
+    std::vector<char*> c_argv;
+    for (const auto& arg : argv) {
+      c_argv.push_back(const_cast<char*>(arg.c_str()));
+    }
+    c_argv.push_back(nullptr);
+
+    execvp(c_argv[0], c_argv.data());
+    _exit(127); // exec failed
+  }
+
+  // Parent
+  close(pipefd[1]); // Close write end
+
   std::string result;
-  FILE* pipe = popen(cmd, "r");
-  if (!pipe) {
-    return absl::InternalError("Unable to start process.");
+  std::array<char, 128> buffer;
+  ssize_t bytes_read;
+  while ((bytes_read = read(pipefd[0], buffer.data(), buffer.size())) > 0) {
+    result.append(buffer.data(), bytes_read);
   }
-  while (fgets(buffer.data(), static_cast<int>(buffer.size()), pipe) !=
-         nullptr) {
-    result += buffer.data();
+  close(pipefd[0]);
+
+  int status;
+  if (waitpid(pid, &status, 0) == -1) {
+    return absl::InternalError("waitpid failed");
   }
-  if (pclose(pipe)) {
-    return absl::InternalError("exec command failed.");
+
+  if (!WIFEXITED(status) || WEXITSTATUS(status) != 0) {
+    return absl::InternalError("command failed");
   }
+
   return result;
 }
 
@@ -119,13 +178,14 @@ Status ToGraph(const Compiler::Encoding& encoding, graph& out,
     return font_path.status();
   }
 
-  std::string command = absl::StrCat(
-      "${TEST_SRCDIR}/+_repo_rules+fontations/ift_graph --font=", *font_path);
+  std::vector<std::string> argv = {
+      TRY(ResolvePath(IFT_GRAPH_PATH)),
+      absl::StrCat("--font=", *font_path)};
   if (include_patch_paths) {
-    command = absl::StrCat(command, " --include-patch-paths");
+    argv.push_back("--include-patch-paths");
   }
 
-  auto r = Exec(command.c_str());
+  auto r = Exec(argv);
   if (!r.ok()) {
     return r.status();
   }
@@ -187,13 +247,16 @@ StatusOr<FontData> ExtendWithDesignSpace(
   }
 
   // Run the extension
-  std::string command = absl::StrCat(
-      "${TEST_SRCDIR}/+_repo_rules+fontations/ift_extend --font=",
-      font_path.string(), " --unicodes=\"", unicodes, "\" --design-space=\"",
-      design_space_str, "\" --features=\"", features,
-      "\" --max-round-trips=", max_round_trips, " --max-fetches=", max_fetches,
-      " --output=", output.string());
-  auto r = Exec(command.c_str());
+  std::vector<std::string> argv = {
+      TRY(ResolvePath(IFT_EXTEND_PATH)),
+      absl::StrCat("--font=", font_path.string()),
+      absl::StrCat("--unicodes=", unicodes),
+      absl::StrCat("--design-space=", design_space_str),
+      absl::StrCat("--features=", features),
+      absl::StrCat("--max-round-trips=", max_round_trips),
+      absl::StrCat("--max-fetches=", max_fetches),
+      absl::StrCat("--output=", output.string())};
+  auto r = Exec(argv);
   if (!r.ok()) {
     return r.status();
   }

--- a/ift/common/font_helper.cc
+++ b/ift/common/font_helper.cc
@@ -26,6 +26,36 @@ using ift::common::FontData;
 
 namespace ift::common {
 
+static StatusOr<uint32_t> OffsetTo(const char* start, size_t length, const char* ptr) {
+  uintptr_t start_val = reinterpret_cast<uintptr_t>(start);
+  uintptr_t ptr_val = reinterpret_cast<uintptr_t>(ptr);
+  uintptr_t end_val = start_val + length;
+
+  if (ptr_val < start_val || ptr_val > end_val) {
+    return absl::InternalError("Pointer is not within the specified block.");
+  }
+  uintptr_t offset = ptr_val - start_val;
+  if (offset > UINT32_MAX) {
+    return absl::InternalError("Offset overflows uint32_t.");
+  }
+  return static_cast<uint32_t>(offset);
+}
+
+size_t CompareTableOffsets::table_offset(hb_tag_t tag) const {
+  if (!start || !length) {
+    return 0;
+  }
+
+  hb_blob_unique_ptr table = make_hb_blob(hb_face_reference_table(face.get(), tag));
+  const char* table_start = reinterpret_cast<const char*>(hb_blob_get_data(table.get(), nullptr));
+
+  auto offset = OffsetTo(reinterpret_cast<const char*>(start), length, table_start);
+  if (!offset.ok()) {
+    return 0;
+  }
+  return *offset;
+}
+
 StatusOr<bool> FontHelper::HasLongLoca(const hb_face_t* face) {
   FontData head = TableData(face, kHead);
   if (head.size() < 52) {
@@ -165,14 +195,7 @@ Status FontHelper::Cff2GetCharstrings(hb_face_t* face,
 
   const char* cff2_start = cff2_data.data();
   const char* charstrings_start = charstrings.data();
-  if (charstrings_start < cff2_start) {
-    return absl::InternalError("CharStrings is not after CFF2 start.");
-  }
-  uint64_t non_charstrings_length = (uint64_t)(charstrings_start - cff2_start);
-  if (non_charstrings_length > cff2_data.size()) {
-    return absl::InternalError("Non CharStrings data is too large.");
-  }
-
+  uint32_t non_charstrings_length = TRY(OffsetTo(cff2_start, cff2_data.size(), charstrings_start));
   hb_blob_unique_ptr non_charstrings_blob = make_hb_blob(
       hb_blob_create_sub_blob(cff2_data_blob.get(), 0, non_charstrings_length));
   non_charstrings.set(non_charstrings_blob.get());
@@ -193,16 +216,7 @@ static StatusOr<std::optional<uint32_t>> CharStringsOffset(
   const char* charstrings_start =
       hb_blob_get_data(charstrings_data, &charstrings_length);
 
-  if (charstrings_start < cff_start) {
-    return absl::InternalError("CharStrings is not after CFF2 start.");
-  }
-
-  uint64_t non_charstrings_length = (uint64_t)(charstrings_start - cff_start);
-  if (non_charstrings_length > all_data_length) {
-    return absl::InternalError("CharStrings offset is too large.");
-  }
-
-  return non_charstrings_length;
+  return TRY(OffsetTo(cff_start, all_data_length, charstrings_start));
 }
 
 StatusOr<std::optional<uint32_t>> FontHelper::CffCharStringsOffset(

--- a/ift/common/font_helper.h
+++ b/ift/common/font_helper.h
@@ -22,7 +22,7 @@ struct CompareTableOffsets {
   hb_blob_unique_ptr face_blob;
   hb_face_unique_ptr face;
   const uint8_t* start = nullptr;
-  const uint8_t* end = nullptr;
+  size_t length = 0;
 
   CompareTableOffsets(hb_face_t* f) :
     // f may be a face builder face and as a result not be located
@@ -35,32 +35,19 @@ struct CompareTableOffsets {
       return;
     }
 
-    unsigned length = 0;
-    start = reinterpret_cast<const uint8_t*>(hb_blob_get_data(face_blob.get(), &length));
-    end = start + length;
+    unsigned len = 0;
+    start = reinterpret_cast<const uint8_t*>(hb_blob_get_data(face_blob.get(), &len));
+    length = len;
   }
 
   CompareTableOffsets(const CompareTableOffsets& other) :
     face_blob(make_hb_blob(hb_blob_reference(other.face_blob.get()))),
     face(make_hb_face(hb_face_reference(other.face.get()))),
     start(other.start),
-    end(other.end)
+    length(other.length)
   {}
 
-  size_t table_offset(hb_tag_t tag) const {
-    if (!start || !end) {
-      return 0;
-    }
-
-    hb_blob_unique_ptr table = make_hb_blob(hb_face_reference_table(face.get(), tag));
-    const uint8_t* table_start = reinterpret_cast<const uint8_t*>(hb_blob_get_data(table.get(), nullptr));
-
-    if (table_start < start || table_start >= end) {
-      return 0;
-    }
-
-    return table_start - start;
-  }
+  size_t table_offset(hb_tag_t tag) const;
 
   bool operator()(hb_tag_t a, hb_tag_t b) const {
     return table_offset(a) < table_offset(b);


### PR DESCRIPTION
- More robust handling of command line arguments when calling rust cilent.
- Fix more cases of table offset calculation being done incorrectly for face builder hb_face_t's.
- Fix handling of truncated hmtx in BrotliFontDiff.