### PR TITLE
Add table diff cache to speed up font2ift compile phase.

### DIFF
--- a/ift/encoder/compiler.cc
+++ b/ift/encoder/compiler.cc
@@ -459,7 +459,7 @@ StatusOr<std::vector<std::pair<size_t, uint64_t>>> Compiler::EstimateEdgeSizes(
                               current.glyph_keyed_url_template);
 
         auto tentative_differ = TRY(GetTentativeDifferFor(
-            current.table_keyed_compat_id, replace_url_template));
+            context, current.table_keyed_compat_id, replace_url_template));
 
         FontData tentative_patch;
         TRYV(tentative_differ->Diff(current.font_data, next_res.font_data,
@@ -624,8 +624,8 @@ StatusOr<Compiler::CompileResult> Compiler::Compile(
           (next.glyph_keyed_url_template != current_glyph_keyed_url_template);
 
       FontData patch;
-      auto differ = TRY(
-          GetDifferFor(current_table_keyed_compat_id, replace_url_template));
+      auto differ = TRY(GetDifferFor(context, current_table_keyed_compat_id,
+                                     replace_url_template));
 
       TRYV((*differ).Diff(current_node_data, next.font_data, &patch));
 
@@ -644,15 +644,17 @@ StatusOr<Compiler::CompileResult> Compiler::Compile(
   return std::move(result);
 }
 
-TableKeyedDiff* Compiler::GetTableKeyedDifferFor(CompatId compat_id,
+TableKeyedDiff* Compiler::GetTableKeyedDifferFor(ProcessingContext& context,
+                                                 CompatId compat_id,
                                                  bool replace_url_template,
                                                  bool exclude_ift) const {
   if (!IsMixedMode()) {
     // If only table keyed patches are used we can diff the whole font.
     if (exclude_ift) {
-      return new TableKeyedDiff(compat_id, {"IFT ", "IFTX"});
+      return new TableKeyedDiff(compat_id, {"IFT ", "IFTX"},
+                                &context.table_diff_cache_);
     } else {
-      return new TableKeyedDiff(compat_id);
+      return new TableKeyedDiff(compat_id, &context.table_diff_cache_);
     }
   }
 
@@ -663,10 +665,11 @@ TableKeyedDiff* Compiler::GetTableKeyedDifferFor(CompatId compat_id,
     if (exclude_ift) {
       return new TableKeyedDiff(compat_id,
                                 {"IFT ", "IFTX", "glyf", "loca", "CFF "},
-                                {"gvar", "CFF2"});
+                                {"gvar", "CFF2"}, &context.table_diff_cache_);
     } else {
       return new TableKeyedDiff(compat_id, {"glyf", "loca", "CFF "},
-                                {"IFTX", "gvar", "CFF2"});
+                                {"IFTX", "gvar", "CFF2"},
+                                &context.table_diff_cache_);
     }
   }
 
@@ -674,23 +677,27 @@ TableKeyedDiff* Compiler::GetTableKeyedDifferFor(CompatId compat_id,
   // are handled by glyph keyed patches
   if (exclude_ift) {
     return new TableKeyedDiff(
-        compat_id, {"IFT ", "IFTX", "glyf", "loca", "gvar", "CFF ", "CFF2"});
+        compat_id, {"IFT ", "IFTX", "glyf", "loca", "gvar", "CFF ", "CFF2"}, {},
+        &context.table_diff_cache_);
   } else {
     return new TableKeyedDiff(compat_id,
-                              {"IFTX", "glyf", "loca", "gvar", "CFF ", "CFF2"});
+                              {"IFTX", "glyf", "loca", "gvar", "CFF ", "CFF2"},
+                              {}, &context.table_diff_cache_);
   }
 }
 
 StatusOr<std::unique_ptr<const BinaryDiff>> Compiler::GetTentativeDifferFor(
-    CompatId compat_id, bool replace_url_template) const {
+    ProcessingContext& context, CompatId compat_id,
+    bool replace_url_template) const {
   return std::unique_ptr<const BinaryDiff>(GetTableKeyedDifferFor(
-      compat_id, replace_url_template, /*exclude_ift=*/true));
+      context, compat_id, replace_url_template, /*exclude_ift=*/true));
 }
 
 StatusOr<std::unique_ptr<const BinaryDiff>> Compiler::GetDifferFor(
-    CompatId compat_id, bool replace_url_template) const {
+    ProcessingContext& context, CompatId compat_id,
+    bool replace_url_template) const {
   return std::unique_ptr<const BinaryDiff>(GetTableKeyedDifferFor(
-      compat_id, replace_url_template, /*exclude_ift=*/false));
+      context, compat_id, replace_url_template, /*exclude_ift=*/false));
 }
 
 StatusOr<hb_subset_plan_t*> Compiler::CreateSubsetPlan(

--- a/ift/encoder/compiler.h
+++ b/ift/encoder/compiler.h
@@ -358,13 +358,16 @@ class Compiler {
       const design_space_t& design_space) const;
 
   absl::StatusOr<std::unique_ptr<const ift::common::BinaryDiff>>
-  GetTentativeDifferFor(ift::common::CompatId compat_id,
+  GetTentativeDifferFor(ProcessingContext& context,
+                        ift::common::CompatId compat_id,
                         bool replace_url_template) const;
 
   absl::StatusOr<std::unique_ptr<const ift::common::BinaryDiff>> GetDifferFor(
-      ift::common::CompatId compat_id, bool replace_url_template) const;
+      ProcessingContext& context, ift::common::CompatId compat_id,
+      bool replace_url_template) const;
 
-  ift::TableKeyedDiff* GetTableKeyedDifferFor(ift::common::CompatId compat_id,
+  ift::TableKeyedDiff* GetTableKeyedDifferFor(ProcessingContext& context,
+                                              ift::common::CompatId compat_id,
                                               bool replace_url_template,
                                               bool exclude_ift) const;
 
@@ -410,6 +413,7 @@ class Compiler {
     absl::flat_hash_map<Jump, uint32_t> table_keyed_patch_id_map_;
     absl::flat_hash_map<Jump, uint64_t> estimated_patch_sizes_;
     ift::common::IntSet built_table_keyed_patches_;
+    ift::TableDiffCache table_diff_cache_;
 
     SubsetDefinition init_subset_;
 

--- a/ift/table_keyed_diff.cc
+++ b/ift/table_keyed_diff.cc
@@ -7,6 +7,7 @@
 #include "ift/common/font_data.h"
 #include "ift/common/font_helper.h"
 #include "ift/common/font_helper_macros.h"
+#include "ift/common/try.h"
 
 using absl::btree_set;
 using absl::flat_hash_map;
@@ -14,17 +15,18 @@ using absl::flat_hash_set;
 using absl::Status;
 using ift::common::FontData;
 using ift::common::FontHelper;
+using ift::common::hb_face_unique_ptr;
 
 namespace ift {
 
 Status TableKeyedDiff::Diff(const FontData& font_base,
                             const FontData& font_derived,
                             FontData* patch /* OUT */) const {
-  hb_face_t* face_base = font_base.reference_face();
-  hb_face_t* face_derived = font_derived.reference_face();
+  auto face_base = font_base.face();
+  auto face_derived = font_derived.face();
 
-  auto base_tags = FontHelper::GetTags(face_base);
-  auto derived_tags = FontHelper::GetTags(face_derived);
+  auto base_tags = FontHelper::GetTags(face_base.get());
+  auto derived_tags = FontHelper::GetTags(face_derived.get());
   auto diff_tags = TagsToDiff(base_tags, derived_tags);
 
   flat_hash_map<std::string, std::pair<uint32_t, FontData>> patches;
@@ -43,13 +45,13 @@ Status TableKeyedDiff::Diff(const FontData& font_base,
     FontData base_table;
     if (!replaced_tags_.contains(tag)) {
       if (in_base) {
-        base_table = FontHelper::TableData(face_base, t);
+        base_table = FontHelper::TableData(face_base.get(), t);
       } else {
         new_tables.insert(t);
       }
     }
 
-    FontData derived_table = FontHelper::TableData(face_derived, t);
+    FontData derived_table = FontHelper::TableData(face_derived.get(), t);
     if (base_table == derived_table) {
       // If table is unchanged then no diff is needed.
       unchanged_tables.insert(t);
@@ -57,18 +59,23 @@ Status TableKeyedDiff::Diff(const FontData& font_base,
     }
 
     FontData table_patch;
-    auto sc = binary_diff_.Diff(base_table, derived_table, &table_patch);
-    if (!sc.ok()) {
-      hb_face_destroy(face_base);
-      hb_face_destroy(face_derived);
-      return sc;
+    if (cache_ == nullptr) {
+      TRYV(binary_diff_.Diff(base_table, derived_table, &table_patch));
+    } else {
+      TableDiffKey key(base_table, derived_table);
+      std::optional<FontData>& cache_value = (*cache_)[key];
+      if (cache_value.has_value()) {
+        table_patch.shallow_copy(*cache_value);
+      } else {
+        TRYV(binary_diff_.Diff(base_table, derived_table, &table_patch));
+        FontData cached_patch;
+        cached_patch.shallow_copy(table_patch);
+        cache_value = std::move(cached_patch);
+      }
     }
 
     patches[tag] = std::pair(derived_table.size(), std::move(table_patch));
   }
-
-  hb_face_destroy(face_base);
-  hb_face_destroy(face_derived);
 
   for (hb_tag_t t : unchanged_tables) {
     std::string tag = FontHelper::ToString(t);

--- a/ift/table_keyed_diff.h
+++ b/ift/table_keyed_diff.h
@@ -4,6 +4,7 @@
 #include <initializer_list>
 
 #include "absl/container/btree_set.h"
+#include "absl/container/flat_hash_map.h"
 #include "absl/container/flat_hash_set.h"
 #include "absl/status/status.h"
 #include "ift/common/binary_diff.h"
@@ -13,32 +14,77 @@
 
 namespace ift {
 
+struct TableDiffKey {
+  ift::common::FontData base;
+  ift::common::FontData derived;
+
+  TableDiffKey() = default;
+
+  TableDiffKey(const ift::common::FontData& b, const ift::common::FontData& d) {
+    base.shallow_copy(b);
+    derived.shallow_copy(d);
+  }
+
+  TableDiffKey(const TableDiffKey& other) {
+    base.shallow_copy(other.base);
+    derived.shallow_copy(other.derived);
+  }
+
+  TableDiffKey& operator=(const TableDiffKey& other) {
+    if (this != &other) {
+      base.shallow_copy(other.base);
+      derived.shallow_copy(other.derived);
+    }
+    return *this;
+  }
+
+  TableDiffKey(TableDiffKey&&) = default;
+  TableDiffKey& operator=(TableDiffKey&&) = default;
+
+  bool operator==(const TableDiffKey& other) const {
+    return base == other.base && derived == other.derived;
+  }
+
+  template <typename H>
+  friend H AbslHashValue(H h, const TableDiffKey& key) {
+    return H::combine(std::move(h), key.base.str(), key.derived.str());
+  }
+};
+
+using TableDiffCache =
+    absl::flat_hash_map<TableDiffKey, std::optional<ift::common::FontData>>;
+
 /* Creates a per table brotli binary diff of two fonts. */
 class TableKeyedDiff : public ift::common::BinaryDiff {
  public:
-  TableKeyedDiff(ift::common::CompatId base_compat_id)
-      : binary_diff_(11), base_compat_id_(base_compat_id) {}
+  explicit TableKeyedDiff(ift::common::CompatId base_compat_id,
+                          TableDiffCache* cache = nullptr)
+      : binary_diff_(11), base_compat_id_(base_compat_id), cache_(cache) {}
 
   TableKeyedDiff(ift::common::CompatId base_compat_id,
-                 std::initializer_list<const char*> excluded_tags)
+                 std::initializer_list<const char*> excluded_tags,
+                 TableDiffCache* cache = nullptr)
       : binary_diff_(11),
         base_compat_id_(base_compat_id),
         excluded_tags_(),
-        replaced_tags_() {
+        replaced_tags_(),
+        cache_(cache) {
     std::copy(excluded_tags.begin(), excluded_tags.end(),
               std::inserter(excluded_tags_, excluded_tags_.begin()));
   }
 
   TableKeyedDiff(ift::common::CompatId base_compat_id,
                  absl::btree_set<std::string> excluded_tags,
-                 absl::btree_set<std::string> replaced_tags)
+                 absl::btree_set<std::string> replaced_tags,
+                 TableDiffCache* cache = nullptr)
       : binary_diff_(11),
         base_compat_id_(base_compat_id),
-        excluded_tags_(),
-        replaced_tags_() {
-    excluded_tags_ = excluded_tags;
-    replaced_tags_ = replaced_tags;
-  }
+        excluded_tags_(std::move(excluded_tags)),
+        replaced_tags_(std::move(replaced_tags)),
+        cache_(cache) {}
+
+  void SetCache(TableDiffCache* cache) { cache_ = cache; }
+  TableDiffCache* cache() const { return cache_; }
 
   absl::Status Diff(const ift::common::FontData& font_base,
                     const ift::common::FontData& font_derived,
@@ -55,6 +101,7 @@ class TableKeyedDiff : public ift::common::BinaryDiff {
   ift::common::CompatId base_compat_id_;
   absl::btree_set<std::string> excluded_tags_;
   absl::btree_set<std::string> replaced_tags_;
+  TableDiffCache* cache_ = nullptr;
 };
 
 }  // namespace ift

--- a/ift/table_keyed_diff_test.cc
+++ b/ift/table_keyed_diff_test.cc
@@ -229,6 +229,30 @@ TEST_F(TableKeyedDiffTest, AddTable) {
   ASSERT_EQ(patch.string(), expected);
 }
 
+TEST_F(TableKeyedDiffTest, CachedDiff) {
+  FontData before = FontHelper::BuildFont({
+      {tag1, "foo"},
+      {tag2, "bar"},
+  });
+
+  FontData after = FontHelper::BuildFont({
+      {tag1, "fooo"},
+      {tag2, "baar"},
+  });
+
+  TableDiffCache cache;
+  TableKeyedDiff differ(CompatId(1, 2, 3, 4), &cache);
+  FontData patch1;
+  auto sc1 = differ.Diff(before, after, &patch1);
+  ASSERT_TRUE(sc1.ok()) << sc1;
+  ASSERT_FALSE(cache.empty());
+
+  FontData patch2;
+  auto sc2 = differ.Diff(before, after, &patch2);
+  ASSERT_TRUE(sc2.ok()) << sc2;
+  ASSERT_EQ(patch1.string(), patch2.string());
+}
+
 /*
 TEST_F(TableKeyedDiffTest, FilteredDiff) {
   FontData before = FontHelper::BuildFont({


### PR DESCRIPTION
Many tables don't change as you move through the extension graph. The table diff cache avoids recomputing the same diffs repeatedly. Gives 3.5x speedup on example Roboto compilaton.